### PR TITLE
Add pause events for ad and add state conditions

### DIFF
--- a/NRExoPlayerTracker/src/main/java/com/newrelic/videoagent/exoplayer/tracker/NRTrackerExoPlayer.java
+++ b/NRExoPlayerTracker/src/main/java/com/newrelic/videoagent/exoplayer/tracker/NRTrackerExoPlayer.java
@@ -403,7 +403,7 @@ public class NRTrackerExoPlayer extends NRVideoTracker implements Player.Listene
             if (getState().isRequested && !getState().isStarted) {
                 sendStart();
             }
-            else if (getState().isPaused) {
+            else if (getState().isPaused && !player.isPlayingAd()) {
                 sendResume();
             }
             else if (!getState().isRequested && !getState().isStarted) {
@@ -420,7 +420,7 @@ public class NRTrackerExoPlayer extends NRVideoTracker implements Player.Listene
         else {
             NRLog.d("\tVideo Paused");
 
-            if (getState().isPlaying) {
+            if (getState().isPlaying && !player.isPlayingAd()) {
                 sendPause();
             }
         }

--- a/NRIMATracker/src/main/java/com/newrelic/videoagent/ima/tracker/NRTrackerIMA.java
+++ b/NRIMATracker/src/main/java/com/newrelic/videoagent/ima/tracker/NRTrackerIMA.java
@@ -68,6 +68,12 @@ public class NRTrackerIMA extends NRVideoTracker implements AdErrorEvent.AdError
                 quartile = 3L;
                 sendAdQuartile();
                 break;
+            case PAUSED:
+                sendPause();
+                break;
+            case RESUMED:
+                sendResume();
+                break;
         }
     }
 


### PR DESCRIPTION
## 📖 Description & Context

When pressing play/pause on ads, the ExoPlayer event listener was triggering pause and resume events on the content tracker (`NRTrackerExoPlayer`) instead of just triggering them on the ad tracker (`NRTrackerIMA`). 

## 👷 Fix

* Add `PAUSED` and `RESUMED` ad events.
* Modify player state change conditions to avoid triggering pause and resume events on ads.