### PR TITLE
Replace deprecated method and return null contentSrc

### DIFF
--- a/NRExoPlayerTracker/src/main/java/com/newrelic/videoagent/exoplayer/tracker/NRTrackerExoPlayer.java
+++ b/NRExoPlayerTracker/src/main/java/com/newrelic/videoagent/exoplayer/tracker/NRTrackerExoPlayer.java
@@ -197,17 +197,17 @@ public class NRTrackerExoPlayer extends NRVideoTracker implements Player.Listene
         if (player == null) return null;
 
         if (getPlaylist() != null) {
-            NRLog.d("Current window index = " + player.getCurrentWindowIndex());
+            NRLog.d("Current window index = " + player.getCurrentMediaItemIndex());
             try {
-                Uri src = getPlaylist().get(player.getCurrentWindowIndex());
+                Uri src = getPlaylist().get(player.getCurrentMediaItemIndex());
                 return src.toString();
             }
             catch (Exception e) {
-                return "";
+                return null;
             }
         }
         else {
-            return "";
+            return null;
         }
     }
 
@@ -452,9 +452,9 @@ public class NRTrackerExoPlayer extends NRVideoTracker implements Player.Listene
         NRLog.d("onTracksChanged analytics");
 
         // Next track in the playlist
-        if (player.getCurrentWindowIndex() != lastWindow) {
+        if (player.getCurrentMediaItemIndex() != lastWindow) {
             NRLog.d("Next video in the playlist starts");
-            lastWindow = player.getCurrentWindowIndex();
+            lastWindow = player.getCurrentMediaItemIndex();
             sendRequest();
         }
     }


### PR DESCRIPTION
## 📖 Description & Context
When no playlists are set, getSrc was returning an empty string for the contentSrc attribute, which may cause problems when sending analytics. Also, a deprecated method of the ExoPlayer was used.

## 👷 Fix

* Return null src url when playlist is null.
* Modify deprecated `getCurrentWindowIndex()` ExoPlayer method for `getCurrentMediaItemIndex()` ([documentation here](https://exoplayer.dev/doc/reference/com/google/android/exoplayer2/Player.html#getCurrentWindowIndex())).