### PR TITLE
NrTrackerExoPlayer updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,10 +7,13 @@
 /.idea/workspace.xml
 /.idea/navEditor.xml
 /.idea/assetWizardSettings.xml
-.DS_Store
 /build
 /captures
+.DS_Store
 .externalNativeBuild
 .cxx
+.idea
 local.properties
 docs
+binaries
+build

--- a/NRExoPlayerTracker/build.gradle
+++ b/NRExoPlayerTracker/build.gradle
@@ -9,8 +9,8 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 33
-        versionCode 4
-        versionName "1.0.4"
+        versionCode 5
+        versionName "1.0.5"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/NRExoPlayerTracker/src/main/java/com/newrelic/videoagent/exoplayer/tracker/NRTrackerExoPlayer.java
+++ b/NRExoPlayerTracker/src/main/java/com/newrelic/videoagent/exoplayer/tracker/NRTrackerExoPlayer.java
@@ -114,7 +114,7 @@ public class NRTrackerExoPlayer extends NRVideoTracker implements Player.Listene
      * @return The simple class name of this tracker.
      */
     public String getTrackerName() {
-        return this.getClass().getSimpleName();
+        return "ExoPlayer2Tracker";
     }
 
     /**

--- a/NRExoPlayerTracker/src/main/java/com/newrelic/videoagent/exoplayer/tracker/NRTrackerExoPlayer.java
+++ b/NRExoPlayerTracker/src/main/java/com/newrelic/videoagent/exoplayer/tracker/NRTrackerExoPlayer.java
@@ -2,6 +2,8 @@ package com.newrelic.videoagent.exoplayer.tracker;
 
 import android.net.Uri;
 
+import androidx.media3.common.MediaLibraryInfo;
+import androidx.media3.common.MediaMetadata;
 import androidx.media3.common.PlaybackException;
 import androidx.media3.common.Player;
 import androidx.media3.common.Tracks;
@@ -91,28 +93,28 @@ public class NRTrackerExoPlayer extends NRVideoTracker implements Player.Listene
     /**
      * Get player name.
      *
-     * @return Attribute.
+     * @return Player name from Media3 library.
      */
     public String getPlayerName() {
-        return "ExoPlayer2";
+        return MediaLibraryInfo.TAG;
     }
 
     /**
      * Get player version.
      *
-     * @return Attribute.
+     * @return Player version from Media3 library.
      */
     public String getPlayerVersion() {
-        return "2.x";
+        return MediaLibraryInfo.VERSION;
     }
 
     /**
      * Get tracker name.
      *
-     * @return Atribute.
+     * @return The simple class name of this tracker.
      */
     public String getTrackerName() {
-        return "ExoPlayer2Tracker";
+        return this.getClass().getSimpleName();
     }
 
     /**

--- a/NRExoPlayerTracker/src/main/java/com/newrelic/videoagent/exoplayer/tracker/NRTrackerExoPlayer.java
+++ b/NRExoPlayerTracker/src/main/java/com/newrelic/videoagent/exoplayer/tracker/NRTrackerExoPlayer.java
@@ -252,6 +252,24 @@ public class NRTrackerExoPlayer extends NRVideoTracker implements Player.Listene
         return (getPlayer().getVolume() == 0);
     }
 
+
+    /**
+     * Get the title from the currently played media
+     *
+     * @return String of the current title
+     */
+    public String getTitle() {
+        String contentTitle = "Unknown";
+        if (player != null && player.getCurrentMediaItem() != null && player.getCurrentMediaItem().mediaMetadata.title != null) {
+            MediaMetadata mm = player.getCurrentMediaItem().mediaMetadata;
+            contentTitle = mm.title.toString();
+            if (mm.subtitle != null) {
+                contentTitle += ": " + mm.subtitle; // Usually the episode title is available in subtitle
+            }
+        }
+        return contentTitle;
+    }
+
     /**
      * Get player instance.
      *

--- a/NRExoPlayerTracker/src/main/java/com/newrelic/videoagent/exoplayer/tracker/NRTrackerExoPlayer.java
+++ b/NRExoPlayerTracker/src/main/java/com/newrelic/videoagent/exoplayer/tracker/NRTrackerExoPlayer.java
@@ -29,12 +29,12 @@ public class NRTrackerExoPlayer extends NRVideoTracker implements Player.Listene
 
     protected ExoPlayer player;
 
-    private long bitrateEstimate;
-    private int lastHeight;
-    private int lastWidth;
-    private List<Uri> playlist;
-    private int lastWindow;
-    private String renditionChangeShift;
+    protected long bitrateEstimate;
+    protected int lastHeight;
+    protected int lastWidth;
+    protected List<Uri> playlist;
+    protected int lastWindow;
+    protected String renditionChangeShift;
 
     /**
      * Init a new ExoPlayer tracker.
@@ -255,7 +255,7 @@ public class NRTrackerExoPlayer extends NRVideoTracker implements Player.Listene
      *
      * @return Attribute.
      */
-    private ExoPlayer getPlayer() {
+    public ExoPlayer getPlayer() {
         return player;
     }
 

--- a/NRIMATracker/build.gradle
+++ b/NRIMATracker/build.gradle
@@ -9,8 +9,8 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 33
-        versionCode 4
-        versionName "1.0.4"
+        versionCode 5
+        versionName "1.0.5"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/NewRelicVideoCore/build.gradle
+++ b/NewRelicVideoCore/build.gradle
@@ -9,8 +9,8 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 33
-        versionCode 7
-        versionName "1.0.4"
+        versionCode 8
+        versionName "1.0.5"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"


### PR DESCRIPTION
- Using protected for members in NrTrackerExoPlayer. --> It helps in inheritance.
- Reading the player name and version dynamically. Using the classname as trackername. --> Provides the actual player info by default.
- Reading the contentTitle dynamically from the currently played media. --> Using the currently played media title, fallback to "Unknown" when it's not available.
- Small suggestions on gitignore
- Suggested version