### PR TITLE
Fix getAttributes UnsupportedOperationException error

### DIFF
--- a/NRExoPlayerTracker/build.gradle
+++ b/NRExoPlayerTracker/build.gradle
@@ -9,8 +9,8 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 33
-        versionCode 5
-        versionName "1.0.5"
+        versionCode 6
+        versionName "1.0.6"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/NRIMATracker/build.gradle
+++ b/NRIMATracker/build.gradle
@@ -9,8 +9,8 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 33
-        versionCode 5
-        versionName "1.0.5"
+        versionCode 6
+        versionName "1.0.6"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/NewRelicVideoCore/build.gradle
+++ b/NewRelicVideoCore/build.gradle
@@ -9,8 +9,8 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 33
-        versionCode 8
-        versionName "1.0.5"
+        versionCode 9
+        versionName "1.0.6"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/tracker/NRVideoTracker.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/tracker/NRVideoTracker.java
@@ -159,7 +159,7 @@ public class NRVideoTracker extends NRTracker {
         Map<String, Object> attr;
 
         if (attributes != null) {
-            attr = attributes;
+            attr = new HashMap<>(attributes);
         } else {
             attr = new HashMap<>();
         }


### PR DESCRIPTION
If we pass a Kotlin immutable Map to the `NRVideoTracker::sendEvent(String action, Map<String, Object> attributes)` function, we end up with a `UnsupportedOperationException` error. The function shouldn't force us to pass a mutable map, so it should always create a HashMap with what is received to ensure it can be modified internally.

![Capture d’écran, le 2025-01-22 à 13 36 18](https://github.com/user-attachments/assets/f0d051a5-5ad4-4171-b78a-7f05517acf37)
