### PR TITLE
fix: Add fallback for contentBitrate and convert adBitrate from KBPS to BPS

### DIFF
--- a/NRExoPlayerTracker/src/main/java/com/newrelic/videoagent/exoplayer/tracker/NRTrackerExoPlayer.java
+++ b/NRExoPlayerTracker/src/main/java/com/newrelic/videoagent/exoplayer/tracker/NRTrackerExoPlayer.java
@@ -683,9 +683,10 @@ public class NRTrackerExoPlayer extends NRVideoTracker implements Player.Listene
         if (mediaLoadData.dataType == C.DATA_TYPE_MEDIA
                 && mediaLoadData.trackType == C.TRACK_TYPE_VIDEO
                 && loadEventInfo.loadDurationMs > 0) {
-            // Use actual video bitrate from player's video format instead of download speed
             if (player != null && player.getVideoFormat() != null && player.getVideoFormat().bitrate != C.INDEX_UNSET) {
                 this.actualBitrate = player.getVideoFormat().bitrate;
+            } else {
+                this.actualBitrate = (loadEventInfo.bytesLoaded * 8 * 1000) / loadEventInfo.loadDurationMs;
             }
         }
     }

--- a/NRIMATracker/src/main/java/com/newrelic/videoagent/ima/tracker/NRTrackerIMA.java
+++ b/NRIMATracker/src/main/java/com/newrelic/videoagent/ima/tracker/NRTrackerIMA.java
@@ -98,7 +98,7 @@ public class NRTrackerIMA extends NRVideoTracker implements AdErrorEvent.AdError
         }
         creativeId = ad.getCreativeId();
         title = ad.getTitle();
-        bitrate = (long)ad.getVastMediaBitrate();
+        bitrate = (long)ad.getVastMediaBitrate() * 1000;
         renditionHeight = (long)ad.getVastMediaHeight();
         renditionWidth = (long)ad.getVastMediaWidth();
         duration = Math.max((long)ad.getDuration(), 0L);


### PR DESCRIPTION
## Summary
- `contentBitrate` was always reported as 0 when manifest-declared bitrate was unavailable. Added a fallback to calculate bitrate from actual download data.
- `adBitrate` was incorrectly reported in KBPS instead of BPS. Applied conversion (×1000) to match the data model specification.

## Changes
- **NRTrackerExoPlayer.java** — Added fallback bitrate calculation using download speed when `player.getVideoFormat().bitrate` is unavailable
- **NRTrackerIMA.java** — Multiplied `getVastMediaBitrate()` by 1000 to convert KBPS to BPS

## Test Plan
- [ ] Play content video and verify `contentBitrate` reports a non-zero value in BPS
- [ ] Play content with HLS/DASH stream and verify manifest-declared bitrate is still preferred
- [ ] Play video with IMA ads and verify `adBitrate` reports in BPS (e.g., 500000 instead of 500)
- [ ] Verify cross-platform consistency with iOS bitrate values
