### PR TITLE
feat: Add obfuscation rules support

### DIFF
--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/NRVideo.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/NRVideo.java
@@ -54,6 +54,14 @@ public final class NRVideo {
         return 60; // Default harvest cycle
     }
 
+    /**
+     * Get the HarvestManager instance for QOE provider registration
+     * @return HarvestManager instance, or null if not initialized
+     */
+    public HarvestManager getHarvestManager() {
+        return harvestManager;
+    }
+
     public static Integer addPlayer(NRVideoPlayerConfiguration config) {
         if (!isInitialized()) {
             NRLog.w("NRVideo not initialized - cannot add player");

--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/NRVideoConfiguration.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/NRVideoConfiguration.java
@@ -44,6 +44,7 @@ public final class NRVideoConfiguration {
     private final boolean debugLoggingEnabled;
     private final boolean isTV;
     private final String collectorAddress;
+    private final int qoeIntervalFactor;
 
     // Runtime configuration fields (mutable, thread-safe) - Using AtomicBoolean for better performance
     private final AtomicBoolean qoeAggregateEnabled = new AtomicBoolean(true);
@@ -86,6 +87,7 @@ public final class NRVideoConfiguration {
         this.debugLoggingEnabled = builder.debugLoggingEnabled;
         this.isTV = builder.isTV;
         this.collectorAddress = builder.collectorAddress;
+        this.qoeIntervalFactor = builder.qoeIntervalFactor;
 
         // Initialize runtime configuration
         this.qoeAggregateEnabled.set(builder.qoeAggregateEnabled);
@@ -104,6 +106,7 @@ public final class NRVideoConfiguration {
     public boolean isDebugLoggingEnabled() { return debugLoggingEnabled; }
     public boolean isTV() { return isTV; }
     public String getCollectorAddress() { return collectorAddress; }
+    public int getQoeIntervalFactor() { return qoeIntervalFactor; }
 
     // Runtime configuration getters and setters
     /**
@@ -231,7 +234,8 @@ public final class NRVideoConfiguration {
         private boolean debugLoggingEnabled = false;
         private boolean isTV = false;
         private String collectorAddress = null;
-        private boolean qoeAggregateEnabled = true; // Default enabled
+        private boolean qoeAggregateEnabled = false; // Default disabled
+        private int qoeIntervalFactor = 1; // Default 1 (send every harvest cycle)
 
         public Builder(String applicationToken) {
             this.applicationToken = applicationToken;
@@ -335,6 +339,24 @@ public final class NRVideoConfiguration {
          */
         public Builder enableQoeAggregate(boolean enabled) {
             this.qoeAggregateEnabled = enabled;
+            return this;
+        }
+
+        /**
+         * Set QOE interval factor to reduce frequency of QOE_AGGREGATE events.
+         * If standard harvest cycle is 30s and this is set to 3, QOE events send every 90s.
+         * First and last harvest cycles of a view always send QOE_AGGREGATE regardless of this setting.
+         * @param factor Interval factor (must be a positive integer >= 1).
+         *               Any value < 1 will default to 1. Decimal values are not supported.
+         * @return Builder instance for method chaining
+         */
+        public Builder withQoeIntervalFactor(int factor) {
+            if (factor < 1) {
+                NRLog.w("Invalid QOE interval factor: " + factor + ". Defaulting to 1.");
+                this.qoeIntervalFactor = 1;
+            } else {
+                this.qoeIntervalFactor = factor;
+            }
             return this;
         }
 

--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/NRVideoConfiguration.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/NRVideoConfiguration.java
@@ -47,7 +47,7 @@ public final class NRVideoConfiguration {
     private final int qoeIntervalFactor;
 
     // Runtime configuration fields (mutable, thread-safe) - Using AtomicBoolean for better performance
-    private final AtomicBoolean qoeAggregateEnabled = new AtomicBoolean(true);
+    private final AtomicBoolean qoeAggregateEnabled = new AtomicBoolean(false);
     private final AtomicBoolean runtimeConfigInitialized = new AtomicBoolean(false);
 
 

--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/NRVideoConfiguration.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/NRVideoConfiguration.java
@@ -6,7 +6,10 @@ import android.content.pm.PackageManager;
 import com.newrelic.videoagent.core.utils.NRLog;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -45,6 +48,9 @@ public final class NRVideoConfiguration {
     private final boolean isTV;
     private final String collectorAddress;
     private final int qoeAggregateIntervalMultiplier;
+    // React analogy: this is like a frozen array in JS — Collections.unmodifiableList()
+    // means nobody can accidentally push() to it after the config is built.
+    private final List<ObfuscationRule> obfuscationRules;
 
     // Runtime configuration fields (mutable, thread-safe) - Using AtomicBoolean for better performance
     private final AtomicBoolean qoeAggregateEnabled = new AtomicBoolean(false);
@@ -88,6 +94,11 @@ public final class NRVideoConfiguration {
         this.isTV = builder.isTV;
         this.collectorAddress = builder.collectorAddress;
         this.qoeAggregateIntervalMultiplier = builder.qoeAggregateIntervalMultiplier;
+        // Make a defensive copy and wrap it as unmodifiable.
+        // React analogy: like Object.freeze([...builder.obfuscationRules]) — same idea.
+        this.obfuscationRules = Collections.unmodifiableList(
+            new ArrayList<>(builder.obfuscationRules)
+        );
 
         // Initialize runtime configuration
         this.qoeAggregateEnabled.set(builder.qoeAggregateEnabled);
@@ -107,6 +118,7 @@ public final class NRVideoConfiguration {
     public boolean isTV() { return isTV; }
     public String getCollectorAddress() { return collectorAddress; }
     public int getQoeAggregateIntervalMultiplier() { return qoeAggregateIntervalMultiplier; }
+    public List<ObfuscationRule> getObfuscationRules() { return obfuscationRules; }
 
     // Runtime configuration getters and setters
     /**
@@ -236,6 +248,8 @@ public final class NRVideoConfiguration {
         private String collectorAddress = null;
         private boolean qoeAggregateEnabled = false; // Default disabled
         private int qoeAggregateIntervalMultiplier = 1; // Default 1 (send every harvest cycle)
+        // React analogy: this starts as an empty array [] — no rules by default.
+        private List<ObfuscationRule> obfuscationRules = new ArrayList<>();
 
         public Builder(String applicationToken) {
             this.applicationToken = applicationToken;
@@ -358,6 +372,22 @@ public final class NRVideoConfiguration {
                 this.qoeAggregateIntervalMultiplier = multiplier;
             }
             return this;
+        }
+
+        /**
+         * Set regex-based rules to mask sensitive data before events are transmitted.
+         * Rules are applied in order — each rule's output becomes the next rule's input.
+         *
+         * React analogy: this is like passing an array prop to a component:
+         *   <VideoAgent obfuscationRules={[{ pattern: "account-\\d+", replacement: "ACCOUNT_ID" }]} />
+         *
+         * @param rules List of ObfuscationRule objects. Pass an empty list to disable obfuscation.
+         */
+        public Builder withObfuscationRules(List<ObfuscationRule> rules) {
+            if (rules != null) {
+                this.obfuscationRules = rules;
+            }
+            return this; // returning 'this' is what makes the dot-chaining work
         }
 
         private void applyTVOptimizations() {

--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/NRVideoConfiguration.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/NRVideoConfiguration.java
@@ -44,7 +44,7 @@ public final class NRVideoConfiguration {
     private final boolean debugLoggingEnabled;
     private final boolean isTV;
     private final String collectorAddress;
-    private final int qoeIntervalFactor;
+    private final int qoeAggregateIntervalMultiplier;
 
     // Runtime configuration fields (mutable, thread-safe) - Using AtomicBoolean for better performance
     private final AtomicBoolean qoeAggregateEnabled = new AtomicBoolean(false);
@@ -87,7 +87,7 @@ public final class NRVideoConfiguration {
         this.debugLoggingEnabled = builder.debugLoggingEnabled;
         this.isTV = builder.isTV;
         this.collectorAddress = builder.collectorAddress;
-        this.qoeIntervalFactor = builder.qoeIntervalFactor;
+        this.qoeAggregateIntervalMultiplier = builder.qoeAggregateIntervalMultiplier;
 
         // Initialize runtime configuration
         this.qoeAggregateEnabled.set(builder.qoeAggregateEnabled);
@@ -106,7 +106,7 @@ public final class NRVideoConfiguration {
     public boolean isDebugLoggingEnabled() { return debugLoggingEnabled; }
     public boolean isTV() { return isTV; }
     public String getCollectorAddress() { return collectorAddress; }
-    public int getQoeIntervalFactor() { return qoeIntervalFactor; }
+    public int getQoeAggregateIntervalMultiplier() { return qoeAggregateIntervalMultiplier; }
 
     // Runtime configuration getters and setters
     /**
@@ -235,7 +235,7 @@ public final class NRVideoConfiguration {
         private boolean isTV = false;
         private String collectorAddress = null;
         private boolean qoeAggregateEnabled = false; // Default disabled
-        private int qoeIntervalFactor = 1; // Default 1 (send every harvest cycle)
+        private int qoeAggregateIntervalMultiplier = 1; // Default 1 (send every harvest cycle)
 
         public Builder(String applicationToken) {
             this.applicationToken = applicationToken;
@@ -343,19 +343,19 @@ public final class NRVideoConfiguration {
         }
 
         /**
-         * Set QOE interval factor to reduce frequency of QOE_AGGREGATE events.
+         * Set QOE aggregate interval multiplier to reduce frequency of QOE_AGGREGATE events.
          * If standard harvest cycle is 30s and this is set to 3, QOE events send every 90s.
          * First and last harvest cycles of a view always send QOE_AGGREGATE regardless of this setting.
-         * @param factor Interval factor (must be a positive integer >= 1).
-         *               Any value < 1 will default to 1. Decimal values are not supported.
+         * @param multiplier Interval multiplier (must be a positive integer >= 1).
+         *                   Any value < 1 will default to 1. Decimal values are not supported.
          * @return Builder instance for method chaining
          */
-        public Builder withQoeIntervalFactor(int factor) {
-            if (factor < 1) {
-                NRLog.w("Invalid QOE interval factor: " + factor + ". Defaulting to 1.");
-                this.qoeIntervalFactor = 1;
+        public Builder withQoeAggregateIntervalMultiplier(int multiplier) {
+            if (multiplier < 1) {
+                NRLog.w("Invalid QOE aggregate interval multiplier: " + multiplier + ". Defaulting to 1.");
+                this.qoeAggregateIntervalMultiplier = 1;
             } else {
-                this.qoeIntervalFactor = factor;
+                this.qoeAggregateIntervalMultiplier = multiplier;
             }
             return this;
         }

--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/ObfuscationEngine.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/ObfuscationEngine.java
@@ -1,0 +1,72 @@
+package com.newrelic.videoagent.core;
+
+import com.newrelic.videoagent.core.utils.NRLog;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+
+/**
+ * Applies a list of ObfuscationRules to a batch of events.
+ *
+ * Extracted into its own class so it can be unit-tested independently of
+ * OptimizedHttpClient (which requires Android context, HTTP connections, etc.).
+ */
+public class ObfuscationEngine {
+
+    // Static utility class — no instances needed.
+    private ObfuscationEngine() {}
+
+    /**
+     * Returns a new list of events with all obfuscation rules applied to every
+     * string-valued attribute. The original list and maps are never modified.
+     *
+     * @param events The raw event batch (may include QOE, regular, dead-letter events).
+     * @param rules  The rules from NRVideoConfiguration. Empty list is a no-op.
+     * @return A new list with obfuscated copies, or the original list if rules is empty.
+     */
+    public static List<Map<String, Object>> apply(
+            List<Map<String, Object>> events,
+            List<ObfuscationRule> rules) {
+
+        if (rules == null || rules.isEmpty()) {
+            return events; // fast path — zero overhead when not configured
+        }
+        if (events == null || events.isEmpty()) {
+            return events;
+        }
+
+        List<Map<String, Object>> result = new ArrayList<>(events.size());
+
+        for (Map<String, Object> event : events) {
+            // Shallow copy — safe because String is immutable (same in Java and JS).
+            Map<String, Object> copy = new HashMap<>(event);
+
+            for (Map.Entry<String, Object> entry : copy.entrySet()) {
+                if (entry.getValue() instanceof String) {
+                    String value = (String) entry.getValue();
+
+                    for (ObfuscationRule rule : rules) {
+                        try {
+                            // quoteReplacement treats '$' and '\' in the replacement as
+                            // plain characters, not regex back-references.
+                            value = rule.regex.matcher(value)
+                                              .replaceAll(Matcher.quoteReplacement(rule.replacement));
+                        } catch (Exception e) {
+                            NRLog.w("ObfuscationEngine: rule failed on key '"
+                                    + entry.getKey() + "': " + e.getMessage());
+                        }
+                    }
+
+                    entry.setValue(value);
+                }
+            }
+
+            result.add(copy);
+        }
+
+        return result;
+    }
+}

--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/ObfuscationRule.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/ObfuscationRule.java
@@ -1,0 +1,52 @@
+package com.newrelic.videoagent.core;
+
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+/**
+ * A single obfuscation rule — a regex pattern paired with a replacement string.
+ *
+ * React analogy: think of this as a TypeScript type:
+ *   type ObfuscationRule = { regex: RegExp; replacement: string }
+ *
+ * Usage:
+ *   new ObfuscationRule("account-\\d+", "ACCOUNT_ID")
+ *   new ObfuscationRule("/users/[^\"/]+", "/users/USER_ID")
+ *   new ObfuscationRule("token=[^&\"]+", "token=REDACTED")
+ */
+public class ObfuscationRule {
+
+    // 'final' in Java == 'const' in JS — these fields can never be reassigned after construction.
+    public final Pattern regex;
+    public final String replacement;
+
+    /**
+     * @param pattern     Regex pattern string, e.g. "account-\\d+"
+     *                    Note: Java strings need double-backslash for regex escapes,
+     *                    same as writing new RegExp("account-\\d+") in JS.
+     * @param replacement String to substitute for each match, e.g. "ACCOUNT_ID".
+     *                    Pass "" (empty string) to delete matched content entirely.
+     */
+    public ObfuscationRule(String pattern, String replacement) {
+        if (pattern == null || pattern.trim().isEmpty()) {
+            throw new IllegalArgumentException("ObfuscationRule: pattern cannot be null or empty");
+        }
+        if (replacement == null) {
+            // We allow "" (delete matches) but not null — null would NPE at apply time.
+            throw new IllegalArgumentException("ObfuscationRule: replacement cannot be null. Use \"\" to delete matches.");
+        }
+
+        this.replacement = replacement;
+
+        // Compile the regex eagerly here in the constructor.
+        // React analogy: like validating props in a constructor — fail fast at setup time,
+        // not silently during a harvest cycle when an event is about to be sent.
+        try {
+            this.regex = Pattern.compile(pattern);
+        } catch (PatternSyntaxException e) {
+            throw new IllegalArgumentException(
+                "ObfuscationRule: invalid regex pattern \"" + pattern + "\": " + e.getMessage(), e
+            );
+        }
+    }
+}

--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/harvest/HarvestManager.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/harvest/HarvestManager.java
@@ -27,7 +27,7 @@ public class HarvestManager implements EventBufferInterface.CapacityCallback {
 
     private final CrashSafeHarvestFactory factory;
     private final CopyOnWriteArrayList<QoeProvider> qoeProviders = new CopyOnWriteArrayList<>();
-    private final Map<QoeProvider, Integer> pendingQoeCycles = new ConcurrentHashMap<>();
+    private final Map<QoeProvider, Map<String, Object>> pendingQoeEvents = new ConcurrentHashMap<>();
     private int harvestCycleNumber = 0;
 
     public HarvestManager(NRVideoConfiguration configuration,
@@ -123,7 +123,7 @@ public class HarvestManager implements EventBufferInterface.CapacityCallback {
     public void unregisterQoeProvider(QoeProvider provider) {
         if (provider != null) {
             qoeProviders.remove(provider);
-            pendingQoeCycles.remove(provider);  // Clear any pending QOE
+            pendingQoeEvents.remove(provider);  // Clear any pending QOE
             NRLog.d("QOE provider unregistered. Remaining providers: " + qoeProviders.size());
         }
     }
@@ -174,7 +174,7 @@ public class HarvestManager implements EventBufferInterface.CapacityCallback {
      * Inject QOE_AGGREGATE events into harvest batch if conditions are met.
      * Implements "accumulate and send" pattern: QOE is only sent with batches
      * that contain VideoAction events. If QOE should be sent but batch is empty,
-     * it's marked as pending and sent with the next batch containing video events.
+     * it's stored as pending and sent with the next batch containing video events.
      *
      * EXCEPTION: Final QOE from CONTENT_END (marked with "isFinalQoe" flag) is
      * ALWAYS injected, even on empty batches, to ensure no data loss at session end.
@@ -214,25 +214,23 @@ public class HarvestManager implements EventBufferInterface.CapacityCallback {
 
                     // Unregister provider after injecting final QOE
                     qoeProviders.remove(provider);
-                    pendingQoeCycles.remove(provider);
+                    pendingQoeEvents.remove(provider);
                     continue; // Skip normal processing for this provider
                 }
 
                 // Check if there's a pending QOE from a previous empty batch
-                Integer pendingCycle = pendingQoeCycles.get(provider);
-                boolean hasPendingQoe = (pendingCycle != null);
+                Map<String, Object> pendingQoeEvent = pendingQoeEvents.get(provider);
+                boolean hasPendingQoe = (pendingQoeEvent != null);
 
                 if (hasVideoAction) {
                     // Batch has video events - send any pending and/or current QOE
 
                     if (hasPendingQoe) {
-                        // Generate QOE for the pending cycle
-                        Map<String, Object> pendingQoeEvent = provider.generateQoeIfNeeded(batch, pendingCycle);
-                        if (pendingQoeEvent != null) {
-                            batch.add(pendingQoeEvent);
-                            NRLog.d("QOE_AGGREGATE injected (pending from cycle " + pendingCycle + ") at cycle " + cycleNumber);
-                        }
-                        pendingQoeCycles.remove(provider);
+                        // Inject the stored pending QOE (don't regenerate)
+                        Object pendingCycleNum = pendingQoeEvent.remove("_cycleNumber"); // Remove internal field
+                        batch.add(pendingQoeEvent);
+                        NRLog.d("QOE_AGGREGATE injected (pending from cycle " + pendingCycleNum + ") at cycle " + cycleNumber);
+                        pendingQoeEvents.remove(provider);
                     }
 
                     if (shouldSendCurrentQoe) {
@@ -244,12 +242,17 @@ public class HarvestManager implements EventBufferInterface.CapacityCallback {
                     // Batch is empty (no video events)
 
                     if (shouldSendCurrentQoe) {
-                        // Mark current cycle as pending - will send with next video event batch
-                        pendingQoeCycles.put(provider, cycleNumber);
-                        NRLog.d("QOE_AGGREGATE pending for cycle " + cycleNumber + " - waiting for batch with video events");
+                        // Store the QOE event object as pending - will send with next video event batch
+                        // Don't overwrite if one already exists - keep the earlier QOE to avoid losing data
+                        if (!hasPendingQoe) {
+                            // Store cycle number in the event for logging (internal use only, removed before sending)
+                            currentQoeEvent.put("_cycleNumber", cycleNumber);
+                            pendingQoeEvents.put(provider, currentQoeEvent);
+                            NRLog.d("QOE_AGGREGATE pending for cycle " + cycleNumber + " - waiting for batch with video events");
+                        } else {
+                            NRLog.d("QOE_AGGREGATE for cycle " + cycleNumber + " skipped - pending QOE already exists");
+                        }
                     }
-                    // Note: Don't update pending if one already exists - keep the earlier cycle
-                    // to avoid losing QOE data
                 }
             } catch (Exception e) {
                 NRLog.e("Error generating QOE from provider: " + e.getMessage(), e);

--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/harvest/HarvestManager.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/harvest/HarvestManager.java
@@ -27,7 +27,6 @@ public class HarvestManager implements EventBufferInterface.CapacityCallback {
 
     private final CrashSafeHarvestFactory factory;
     private final CopyOnWriteArrayList<QoeProvider> qoeProviders = new CopyOnWriteArrayList<>();
-    private final Map<QoeProvider, Map<String, Object>> pendingQoeEvents = new ConcurrentHashMap<>();
     private int harvestCycleNumber = 0;
 
     public HarvestManager(NRVideoConfiguration configuration,
@@ -123,7 +122,6 @@ public class HarvestManager implements EventBufferInterface.CapacityCallback {
     public void unregisterQoeProvider(QoeProvider provider) {
         if (provider != null) {
             qoeProviders.remove(provider);
-            pendingQoeEvents.remove(provider);  // Clear any pending QOE
             NRLog.d("QOE provider unregistered. Remaining providers: " + qoeProviders.size());
         }
     }
@@ -172,13 +170,11 @@ public class HarvestManager implements EventBufferInterface.CapacityCallback {
 
     /**
      * Inject QOE_AGGREGATE events into harvest batch if conditions are met.
-     * Implements "accumulate and send" pattern: QOE is only sent with batches
-     * that contain VideoAction events. If QOE should be sent but batch is empty,
-     * it's stored as pending and sent with the next batch containing video events.
+     * Like iOS: QOE is sent independently on each qualified harvest cycle,
+     * regardless of whether the batch contains other VideoAction events.
      *
-     * EXCEPTION: Final QOE from CONTENT_END (marked with "isFinalQoe" flag) is
-     * ALWAYS injected, even on empty batches, to ensure no data loss at session end.
-     * Provider is automatically unregistered after final QOE is sent.
+     * Final QOE from CONTENT_END (marked with "isFinalQoe" flag) is always injected
+     * and triggers provider unregistration.
      *
      * @param batch The harvest batch to potentially inject QOE events into
      * @param cycleNumber The current harvest cycle number
@@ -188,71 +184,29 @@ public class HarvestManager implements EventBufferInterface.CapacityCallback {
             return;
         }
 
-        // Check if batch contains VideoAction events
-        boolean hasVideoAction = false;
-        for (Map<String, Object> event : batch) {
-            if ("VideoAction".equals(event.get("eventType"))) {
-                hasVideoAction = true;
-                break;
-            }
-        }
-
         // Process each registered QOE provider (use ArrayList copy to allow removal during iteration)
         List<QoeProvider> providersSnapshot = new ArrayList<>(qoeProviders);
         for (QoeProvider provider : providersSnapshot) {
             try {
                 // Check if current cycle should send QOE
                 Map<String, Object> currentQoeEvent = provider.generateQoeIfNeeded(batch, cycleNumber);
-                boolean shouldSendCurrentQoe = (currentQoeEvent != null);
 
-                // Check if this is the final QOE from CONTENT_END
-                if (currentQoeEvent != null && Boolean.TRUE.equals(currentQoeEvent.get("isFinalQoe"))) {
-                    // FINAL QOE - always send, even on empty batches
-                    currentQoeEvent.remove("isFinalQoe"); // Remove internal flag before sending
-                    batch.add(currentQoeEvent);
-                    NRLog.d("Final QOE_AGGREGATE from CONTENT_END injected - provider will be unregistered");
-
-                    // Unregister provider after injecting final QOE
-                    qoeProviders.remove(provider);
-                    pendingQoeEvents.remove(provider);
-                    continue; // Skip normal processing for this provider
-                }
-
-                // Check if there's a pending QOE from a previous empty batch
-                Map<String, Object> pendingQoeEvent = pendingQoeEvents.get(provider);
-                boolean hasPendingQoe = (pendingQoeEvent != null);
-
-                if (hasVideoAction) {
-                    // Batch has video events - send any pending and/or current QOE
-
-                    if (hasPendingQoe) {
-                        // Inject the stored pending QOE (don't regenerate)
-                        Object pendingCycleNum = pendingQoeEvent.remove("_cycleNumber"); // Remove internal field
-                        batch.add(pendingQoeEvent);
-                        NRLog.d("QOE_AGGREGATE injected (pending from cycle " + pendingCycleNum + ") at cycle " + cycleNumber);
-                        pendingQoeEvents.remove(provider);
-                    }
-
-                    if (shouldSendCurrentQoe) {
-                        // Send current cycle QOE
+                if (currentQoeEvent != null) {
+                    // Check if this is the final QOE from CONTENT_END
+                    if (Boolean.TRUE.equals(currentQoeEvent.get("isFinalQoe"))) {
+                        // FINAL QOE - remove internal flag before sending
+                        currentQoeEvent.remove("isFinalQoe");
                         batch.add(currentQoeEvent);
-                        NRLog.d("QOE_AGGREGATE injected into harvest batch (cycle " + cycleNumber + ")");
-                    }
-                } else {
-                    // Batch is empty (no video events)
+                        NRLog.d("Final QOE_AGGREGATE from CONTENT_END injected - provider will be unregistered");
 
-                    if (shouldSendCurrentQoe) {
-                        // Store the QOE event object as pending - will send with next video event batch
-                        // Don't overwrite if one already exists - keep the earlier QOE to avoid losing data
-                        if (!hasPendingQoe) {
-                            // Store cycle number in the event for logging (internal use only, removed before sending)
-                            currentQoeEvent.put("_cycleNumber", cycleNumber);
-                            pendingQoeEvents.put(provider, currentQoeEvent);
-                            NRLog.d("QOE_AGGREGATE pending for cycle " + cycleNumber + " - waiting for batch with video events");
-                        } else {
-                            NRLog.d("QOE_AGGREGATE for cycle " + cycleNumber + " skipped - pending QOE already exists");
-                        }
+                        // Unregister provider after injecting final QOE
+                        qoeProviders.remove(provider);
+                        continue;
                     }
+
+                    // Regular QOE - send independently (like iOS)
+                    batch.add(currentQoeEvent);
+                    NRLog.d("QOE_AGGREGATE injected into harvest batch (cycle " + cycleNumber + ")");
                 }
             } catch (Exception e) {
                 NRLog.e("Error generating QOE from provider: " + e.getMessage(), e);

--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/harvest/HarvestManager.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/harvest/HarvestManager.java
@@ -4,6 +4,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.HashMap;
 import java.util.Locale;
+import java.util.ArrayList;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ConcurrentHashMap;
 
 import android.content.Context;
 import com.newrelic.videoagent.core.NRVideoConfiguration;
@@ -18,10 +21,14 @@ import com.newrelic.videoagent.core.utils.NRLog;
  * - Zero performance impact during normal operation
  * - Proper 60% capacity threshold scheduler startup
  * - OPTIMIZED: Always uses CrashSafeHarvestFactory for consistent behavior
+ * - QOE Provider support for harvest-time QOE_AGGREGATE injection
  */
 public class HarvestManager implements EventBufferInterface.CapacityCallback {
 
     private final CrashSafeHarvestFactory factory;
+    private final CopyOnWriteArrayList<QoeProvider> qoeProviders = new CopyOnWriteArrayList<>();
+    private final Map<QoeProvider, Integer> pendingQoeCycles = new ConcurrentHashMap<>();
+    private int harvestCycleNumber = 0;
 
     public HarvestManager(NRVideoConfiguration configuration,
                           Context context) {
@@ -94,6 +101,34 @@ public class HarvestManager implements EventBufferInterface.CapacityCallback {
     }
 
     /**
+     * Register a QOE provider to be called during harvest cycles.
+     * Called by NRVideoTracker at CONTENT_START.
+     *
+     * @param provider The QOE provider to register
+     */
+    public void registerQoeProvider(QoeProvider provider) {
+        if (provider != null && !qoeProviders.contains(provider)) {
+            qoeProviders.add(provider);
+            NRLog.d("QOE provider registered. Total providers: " + qoeProviders.size());
+        }
+    }
+
+    /**
+     * Unregister a QOE provider.
+     * Called by NRVideoTracker at CONTENT_END or tracker disposal.
+     * Also clears any pending QOE for this provider.
+     *
+     * @param provider The QOE provider to unregister
+     */
+    public void unregisterQoeProvider(QoeProvider provider) {
+        if (provider != null) {
+            qoeProviders.remove(provider);
+            pendingQoeCycles.remove(provider);  // Clear any pending QOE
+            NRLog.d("QOE provider unregistered. Remaining providers: " + qoeProviders.size());
+        }
+    }
+
+    /**
      * Generic harvest method for both regular and live events
      * OPTIMIZED: Updated for 2KB events with device-specific batch sizes
      * @param batchSizeBytes Maximum batch size in bytes (optimized for 2KB events)
@@ -102,12 +137,19 @@ public class HarvestManager implements EventBufferInterface.CapacityCallback {
      */
     private void harvest(int batchSizeBytes, String priorityFilter, String harvestType) {
         try {
+            // Increment harvest cycle number
+            harvestCycleNumber++;
+
             SizeEstimator sizeEstimator = new DefaultSizeEstimator();
             List<Map<String, Object>> events = factory.getEventBuffer().pollBatchByPriority(
                 batchSizeBytes,
                 sizeEstimator,
                 priorityFilter
             );
+
+            // Inject QOE events BEFORE checking if batch is empty
+            // QOE should be generated based on cycle number, even if there are no other events
+            injectQoeEventsIfNeeded(events, harvestCycleNumber);
 
             if (!events.isEmpty()) {
                 boolean success = factory.getHttpClient().sendEvents(events, harvestType);
@@ -125,6 +167,93 @@ public class HarvestManager implements EventBufferInterface.CapacityCallback {
 
         } catch (Exception e) {
             NRLog.e(harvestType + " harvest failed: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Inject QOE_AGGREGATE events into harvest batch if conditions are met.
+     * Implements "accumulate and send" pattern: QOE is only sent with batches
+     * that contain VideoAction events. If QOE should be sent but batch is empty,
+     * it's marked as pending and sent with the next batch containing video events.
+     *
+     * EXCEPTION: Final QOE from CONTENT_END (marked with "isFinalQoe" flag) is
+     * ALWAYS injected, even on empty batches, to ensure no data loss at session end.
+     * Provider is automatically unregistered after final QOE is sent.
+     *
+     * @param batch The harvest batch to potentially inject QOE events into
+     * @param cycleNumber The current harvest cycle number
+     */
+    private void injectQoeEventsIfNeeded(List<Map<String, Object>> batch, int cycleNumber) {
+        if (batch == null || qoeProviders.isEmpty()) {
+            return;
+        }
+
+        // Check if batch contains VideoAction events
+        boolean hasVideoAction = false;
+        for (Map<String, Object> event : batch) {
+            if ("VideoAction".equals(event.get("eventType"))) {
+                hasVideoAction = true;
+                break;
+            }
+        }
+
+        // Process each registered QOE provider (use ArrayList copy to allow removal during iteration)
+        List<QoeProvider> providersSnapshot = new ArrayList<>(qoeProviders);
+        for (QoeProvider provider : providersSnapshot) {
+            try {
+                // Check if current cycle should send QOE
+                Map<String, Object> currentQoeEvent = provider.generateQoeIfNeeded(batch, cycleNumber);
+                boolean shouldSendCurrentQoe = (currentQoeEvent != null);
+
+                // Check if this is the final QOE from CONTENT_END
+                if (currentQoeEvent != null && Boolean.TRUE.equals(currentQoeEvent.get("isFinalQoe"))) {
+                    // FINAL QOE - always send, even on empty batches
+                    currentQoeEvent.remove("isFinalQoe"); // Remove internal flag before sending
+                    batch.add(currentQoeEvent);
+                    NRLog.d("Final QOE_AGGREGATE from CONTENT_END injected - provider will be unregistered");
+
+                    // Unregister provider after injecting final QOE
+                    qoeProviders.remove(provider);
+                    pendingQoeCycles.remove(provider);
+                    continue; // Skip normal processing for this provider
+                }
+
+                // Check if there's a pending QOE from a previous empty batch
+                Integer pendingCycle = pendingQoeCycles.get(provider);
+                boolean hasPendingQoe = (pendingCycle != null);
+
+                if (hasVideoAction) {
+                    // Batch has video events - send any pending and/or current QOE
+
+                    if (hasPendingQoe) {
+                        // Generate QOE for the pending cycle
+                        Map<String, Object> pendingQoeEvent = provider.generateQoeIfNeeded(batch, pendingCycle);
+                        if (pendingQoeEvent != null) {
+                            batch.add(pendingQoeEvent);
+                            NRLog.d("QOE_AGGREGATE injected (pending from cycle " + pendingCycle + ") at cycle " + cycleNumber);
+                        }
+                        pendingQoeCycles.remove(provider);
+                    }
+
+                    if (shouldSendCurrentQoe) {
+                        // Send current cycle QOE
+                        batch.add(currentQoeEvent);
+                        NRLog.d("QOE_AGGREGATE injected into harvest batch (cycle " + cycleNumber + ")");
+                    }
+                } else {
+                    // Batch is empty (no video events)
+
+                    if (shouldSendCurrentQoe) {
+                        // Mark current cycle as pending - will send with next video event batch
+                        pendingQoeCycles.put(provider, cycleNumber);
+                        NRLog.d("QOE_AGGREGATE pending for cycle " + cycleNumber + " - waiting for batch with video events");
+                    }
+                    // Note: Don't update pending if one already exists - keep the earlier cycle
+                    // to avoid losing QOE data
+                }
+            } catch (Exception e) {
+                NRLog.e("Error generating QOE from provider: " + e.getMessage(), e);
+            }
         }
     }
 

--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/harvest/HarvestManager.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/harvest/HarvestManager.java
@@ -7,6 +7,7 @@ import java.util.Locale;
 import java.util.ArrayList;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import android.content.Context;
 import com.newrelic.videoagent.core.NRVideoConfiguration;
@@ -27,7 +28,7 @@ public class HarvestManager implements EventBufferInterface.CapacityCallback {
 
     private final CrashSafeHarvestFactory factory;
     private final CopyOnWriteArrayList<QoeProvider> qoeProviders = new CopyOnWriteArrayList<>();
-    private int harvestCycleNumber = 0;
+    private final AtomicInteger harvestCycleNumber = new AtomicInteger(0);
 
     public HarvestManager(NRVideoConfiguration configuration,
                           Context context) {
@@ -135,8 +136,8 @@ public class HarvestManager implements EventBufferInterface.CapacityCallback {
      */
     private void harvest(int batchSizeBytes, String priorityFilter, String harvestType) {
         try {
-            // Increment harvest cycle number
-            harvestCycleNumber++;
+            // Increment harvest cycle number (thread-safe atomic operation)
+            int currentCycle = harvestCycleNumber.incrementAndGet();
 
             SizeEstimator sizeEstimator = new DefaultSizeEstimator();
             List<Map<String, Object>> events = factory.getEventBuffer().pollBatchByPriority(
@@ -147,7 +148,7 @@ public class HarvestManager implements EventBufferInterface.CapacityCallback {
 
             // Inject QOE events BEFORE checking if batch is empty
             // QOE should be generated based on cycle number, even if there are no other events
-            injectQoeEventsIfNeeded(events, harvestCycleNumber);
+            injectQoeEventsIfNeeded(events, currentCycle);
 
             if (!events.isEmpty()) {
                 boolean success = factory.getHttpClient().sendEvents(events, harvestType);

--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/harvest/OptimizedHttpClient.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/harvest/OptimizedHttpClient.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import java.util.HashMap;
 import java.util.Arrays;
 import java.util.zip.GZIPOutputStream;
+import com.newrelic.videoagent.core.ObfuscationEngine;
 
 /**
  * Optimized HTTP client for mobile/TV environments
@@ -89,8 +90,19 @@ public class OptimizedHttpClient implements HttpClientInterface {
             return true;
         }
 
-        // Attempt to send with immediate retries
-        return sendEventsWithRetry(events);
+        // Apply obfuscation rules to a COPY of the events before sending.
+        //
+        // React analogy: like doing const safeEvents = events.map(e => mask(e)) before
+        // calling fetch() — the original array stays untouched.
+        //
+        // Why a copy and not mutating in place?
+        // If sendEventsWithRetry() fails, HarvestManager passes the same list to the
+        // dead letter handler for retry. If we had mutated in place, the retry would
+        // run obfuscation again on already-obfuscated values — double masking.
+        // By working on a copy, the original list stays clean for any retry path.
+        List<Map<String, Object>> safeEvents = ObfuscationEngine.apply(events, configuration.getObfuscationRules());
+
+        return sendEventsWithRetry(safeEvents);
     }
 
     private boolean sendEventsWithRetry(List<Map<String, Object>> events) {
@@ -159,6 +171,13 @@ public class OptimizedHttpClient implements HttpClientInterface {
 
             List<Object> payload = new ArrayList<>();
             payload.add(appToken);
+
+            // Build device metadata map
+            HashMap<String, Object> deviceMetadata = new HashMap<>();
+            deviceMetadata.put("size", deviceInfo.getSize());
+            deviceMetadata.put("platform", deviceInfo.getApplicationFramework());
+            deviceMetadata.put("platformVersion", deviceInfo.getApplicationFrameworkVersion());
+
             payload.add(Arrays.asList(
                     deviceInfo.getOsName(),
                     deviceInfo.getOsVersion(),
@@ -169,11 +188,7 @@ public class OptimizedHttpClient implements HttpClientInterface {
                     "",
                     "",
                     deviceInfo.getManufacturer(),
-                    new HashMap<String, Object>() {{
-                        put("size", deviceInfo.getSize());
-                        put("platform", deviceInfo.getApplicationFramework());
-                        put("platformVersion", deviceInfo.getApplicationFrameworkVersion());
-                    }}
+                    deviceMetadata
             ));
             payload.add(0);
             payload.add(new ArrayList<>()); // []

--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/harvest/QoeProvider.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/harvest/QoeProvider.java
@@ -1,0 +1,25 @@
+package com.newrelic.videoagent.core.harvest;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Provider interface for QOE_AGGREGATE event generation at harvest time.
+ * Registered by video trackers and invoked by HarvestManager during harvest cycles.
+ */
+public interface QoeProvider {
+
+    /**
+     * Called by HarvestManager during harvest to check if QOE should be generated.
+     *
+     * @param batch The current harvest batch containing VideoAction events
+     * @param harvestCycleNumber The current harvest cycle number (1-based)
+     * @return QOE_AGGREGATE event map if it should be generated, null otherwise
+     */
+    Map<String, Object> generateQoeIfNeeded(List<Map<String, Object>> batch, int harvestCycleNumber);
+
+    /**
+     * Called when the provider should be unregistered (e.g., video ended).
+     */
+    void unregister();
+}

--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/tracker/NRTracker.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/tracker/NRTracker.java
@@ -24,7 +24,7 @@ public class NRTracker {
 
     protected final NRVideoConfiguration configuration;
     private final NREventAttributes eventAttributes;
-    private NRTimeSinceTable timeSinceTable;
+    protected NRTimeSinceTable timeSinceTable;
 
     /**
      * Create a new NRTracker with configuration.

--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/tracker/NRVideoTracker.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/tracker/NRVideoTracker.java
@@ -70,6 +70,7 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
     // QOE_AGGREGATE provider fields
     private boolean qoeProviderRegistered = false;
     private Map<String, Object> pendingQoeForNextHarvest = null; // For CONTENT_END
+    private Map<String, Object> lastSentQoeKpis = null; // Snapshot of last sent QoE KPIs for dirty check
 
     /**
      * Create a new NRVideoTracker.
@@ -344,6 +345,16 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
             if (state.isAd) {
                 sendVideoAdEvent(AD_REQUEST);
             } else {
+                // Register QOE provider at CONTENT_REQUEST (like iOS) so QoE is captured
+                // even if CONTENT_START never happens (e.g., startup error)
+                if (!qoeProviderRegistered && configuration != null && configuration.isQoeAggregateEnabled()) {
+                    if (NRVideo.getInstance() != null && NRVideo.getInstance().getHarvestManager() != null) {
+                        NRVideo.getInstance().getHarvestManager().registerQoeProvider(this);
+                        qoeProviderRegistered = true;
+                        NRLog.d("QOE provider registered at CONTENT_REQUEST");
+                    }
+                }
+
                 sendVideoEvent(CONTENT_REQUEST);
             }
         }
@@ -381,15 +392,6 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
 
                 // Resume bitrate timer when content starts playing
                 resumeBitrateTimer();
-
-                // Register QOE provider with HarvestManager (harvest-time generation)
-                if (!qoeProviderRegistered && configuration != null && configuration.isQoeAggregateEnabled()) {
-                    if (NRVideo.getInstance() != null && NRVideo.getInstance().getHarvestManager() != null) {
-                        NRVideo.getInstance().getHarvestManager().registerQoeProvider(this);
-                        qoeProviderRegistered = true;
-                        NRLog.d("QOE provider registered at CONTENT_START");
-                    }
-                }
             }
             playtimeSinceLastEventTimestamp = System.currentTimeMillis();
         }
@@ -645,11 +647,22 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
             boolean shouldSend = (harvestCycleNumber - 1) % intervalMultiplier == 0;
 
             if (shouldSend) {
-                // Build QOE event with standard attributes (reuse existing attribute generation)
-                Map<String, Object> qoeEvent = buildQoeEventWithStandardAttributes();
+                // Calculate current QoE KPIs
+                Map<String, Object> currentKpis = calculateQOEKpiAttributes();
 
-                NRLog.d("QOE_AGGREGATE generated for harvest cycle " + harvestCycleNumber);
-                return qoeEvent;
+                // Dirty check: Only send if KPI values have changed since last send
+                if (haveQoeKpisChanged(currentKpis)) {
+                    // Build QOE event with standard attributes
+                    Map<String, Object> qoeEvent = buildQoeEventWithStandardAttributes();
+
+                    // Update snapshot for next dirty check
+                    lastSentQoeKpis = new HashMap<>(currentKpis);
+
+                    NRLog.d("QOE_AGGREGATE generated for harvest cycle " + harvestCycleNumber + " (KPIs changed)");
+                    return qoeEvent;
+                } else {
+                    NRLog.d("QOE_AGGREGATE skipped for harvest cycle " + harvestCycleNumber + " (no KPI changes)");
+                }
             }
         }
 
@@ -700,6 +713,48 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
         }
 
         return qoeEvent;
+    }
+
+    /**
+     * Check if QoE KPI attributes have changed since the last sent QoE event.
+     * Implements dirty check pattern like iOS to prevent sending duplicate QoE with identical values.
+     *
+     * @param currentKpis Current QoE KPI attributes
+     * @return true if KPIs have changed or this is the first QoE, false if identical to last send
+     */
+    private boolean haveQoeKpisChanged(Map<String, Object> currentKpis) {
+        // First QoE always sends
+        if (lastSentQoeKpis == null) {
+            return true;
+        }
+
+        // Compare each KPI attribute
+        // KPI attributes: startupTime, peakBitrate, averageBitrate, totalPlaytime,
+        // totalRebufferingTime, rebufferingRatio, hadStartupFailure, hadPlaybackFailure
+        for (String key : currentKpis.keySet()) {
+            Object currentValue = currentKpis.get(key);
+            Object lastValue = lastSentQoeKpis.get(key);
+
+            // If key is missing in last snapshot, consider it changed
+            if (lastValue == null && currentValue != null) {
+                return true;
+            }
+
+            // Compare values (handles Long, Double, Boolean, String)
+            if (currentValue != null && !currentValue.equals(lastValue)) {
+                return true;
+            }
+        }
+
+        // Check if any keys were removed
+        for (String key : lastSentQoeKpis.keySet()) {
+            if (!currentKpis.containsKey(key)) {
+                return true;
+            }
+        }
+
+        // No changes detected
+        return false;
     }
 
     /**
@@ -1081,6 +1136,7 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
 
         // Reset QOE provider fields for new view session
         pendingQoeForNextHarvest = null;
+        lastSentQoeKpis = null; // Reset dirty check snapshot for new view session
     }
 
 

--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/tracker/NRVideoTracker.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/tracker/NRVideoTracker.java
@@ -71,6 +71,7 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
     private boolean qoeProviderRegistered = false;
     private Map<String, Object> pendingQoeForNextHarvest = null; // For CONTENT_END
     private Map<String, Object> lastSentQoeKpis = null; // Snapshot of last sent QoE KPIs for dirty check
+    private volatile Map<String, Object> cachedStandardAttributes = null; // Cached attributes for thread-safe access
 
     /**
      * Create a new NRVideoTracker.
@@ -321,6 +322,14 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
         // QoE: Track bitrate after all attributes are processed (including contentBitrate)
         if (!state.isAd && !QOE_AGGREGATE.equals(action)) {
             trackBitrateFromProcessedAttributes(action, attr);
+        }
+
+        // Cache attributes for non-QOE events (for thread-safe QOE generation)
+        // QOE generation runs on harvest background thread but ExoPlayer requires main thread access.
+        // By caching attributes here (called on main thread during video events), QOE can safely
+        // use these attributes without accessing the player directly.
+        if (attr != null && !QOE_AGGREGATE.equals(action)) {
+            cachedStandardAttributes = new HashMap<>(attr);
         }
 
         return attr;
@@ -679,7 +688,8 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
 
     /**
      * Build QOE event with all standard video tracking attributes.
-     * Reuses the existing attribute generation pipeline to ensure consistency.
+     * Thread-safe: Uses cached attributes from last video event instead of
+     * accessing player directly (which requires main thread).
      *
      * @return Complete QOE event map with standard attributes
      */
@@ -687,16 +697,22 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
         // Start with QOE KPI attributes
         Map<String, Object> qoeEvent = calculateQOEKpiAttributes();
 
-        // Add standard video tracking attributes (reuse getAttributes pipeline)
-        qoeEvent = getAttributes(QOE_AGGREGATE, qoeEvent);
+        // Add cached standard video tracking attributes (thread-safe)
+        // Note: Cache is populated by video events (CONTENT_START, HEARTBEAT, etc.) on main thread
+        // This avoids thread safety issues with ExoPlayer which requires main thread access
+        if (cachedStandardAttributes != null) {
+            qoeEvent.putAll(cachedStandardAttributes);
+        } else {
+            NRLog.w("QOE: No cached attributes available yet (this is normal for very first QOE before any video events)");
+        }
 
-        // Add instrumentation attributes (same as NRTracker.sendEvent())
+        // Add/override instrumentation attributes (same as NRTracker.sendEvent())
         qoeEvent.put("agentSession", getAgentSession());
         qoeEvent.put("instrumentation.provider", "newrelic");
         qoeEvent.put("instrumentation.name", getInstrumentationName());
         qoeEvent.put("instrumentation.version", getCoreVersion());
 
-        // Add core attributes
+        // Add/override core attributes
         qoeEvent.put("eventType", "VideoAction");
         qoeEvent.put("actionName", QOE_AGGREGATE);
         qoeEvent.put("timestamp", System.currentTimeMillis());

--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/tracker/NRVideoTracker.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/tracker/NRVideoTracker.java
@@ -66,6 +66,7 @@ public class NRVideoTracker extends NRTracker {
     private boolean hasVideoActionInCurrentCycle = false;
     private boolean qoeAggregateAlreadySent = false;
     private Long lastHarvestCycleTimestamp = null;
+    private int harvestCycleCount = 0; // Track number of harvest cycles for qoeIntervalFactor
 
     /**
      * Create a new NRVideoTracker.
@@ -451,9 +452,11 @@ public class NRVideoTracker extends NRTracker {
                 }
                 totalAdPlaytime = totalAdPlaytime + totalPlaytime;
             } else {
+                // For last harvest cycle: force send QOE_AGGREGATE if not already sent and QOE is enabled
+                if (!qoeAggregateAlreadySent && configuration != null && configuration.isQoeAggregateEnabled()) {
+                    sendQoeAggregate();
+                }
                 sendVideoEvent(CONTENT_END);
-                // Send single and latest QOE with this VideoAction event
-                markVideoActionInCycle();
             }
 
             stopHeartbeat();
@@ -608,6 +611,7 @@ public class NRVideoTracker extends NRTracker {
     /**
      * Check if we need to send QOE_AGGREGATE for the current harvest cycle.
      * Only sends once per harvest cycle and only if there was a video action.
+     * Respects qoeIntervalFactor to reduce frequency (first and last cycles always send).
      */
     private void checkAndSendQoeAggregateIfNeeded() {
         long currentTime = System.currentTimeMillis();
@@ -618,11 +622,28 @@ public class NRVideoTracker extends NRTracker {
                 (currentTime - lastHarvestCycleTimestamp) >= harvestCycleMs) {
             resetHarvestCycleFlags();
             lastHarvestCycleTimestamp = currentTime;
+            harvestCycleCount++; // Increment cycle count for qoeIntervalFactor
         }
         // Send QOE_AGGREGATE if we haven't sent it yet and we have video actions
-        if (hasVideoActionInCurrentCycle && !qoeAggregateAlreadySent) {
+        // Check if this cycle should send based on qoeIntervalFactor
+        if (hasVideoActionInCurrentCycle && !qoeAggregateAlreadySent && shouldSendQoeInCurrentCycle()) {
             sendQoeAggregate();
         }
+    }
+
+    /**
+     * Determine if QOE_AGGREGATE should be sent in the current harvest cycle.
+     * First cycle (cycle 1) always sends. Then sends every Nth cycle where N = qoeIntervalFactor.
+     * @return true if QOE should be sent, false otherwise
+     */
+    private boolean shouldSendQoeInCurrentCycle() {
+        if (configuration == null) {
+            return true; // Default behavior if no config
+        }
+        int intervalFactor = configuration.getQoeIntervalFactor();
+        // First cycle always sends (harvestCycleCount == 1)
+        // Then send every intervalFactor cycles (e.g., if factor=3, send on cycles 1, 3, 6, 9, ...)
+        return harvestCycleCount == 1 || (harvestCycleCount % intervalFactor == 0);
     }
 
     /**
@@ -908,6 +929,7 @@ public class NRVideoTracker extends NRTracker {
         // Reset QOE_AGGREGATE harvest cycle tracking fields
         resetHarvestCycleFlags();
         lastHarvestCycleTimestamp = null;
+        harvestCycleCount = 0; // Reset cycle count for new view session
     }
 
 

--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/tracker/NRVideoTracker.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/tracker/NRVideoTracker.java
@@ -480,23 +480,24 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
                 }
                 totalAdPlaytime = totalAdPlaytime + totalPlaytime;
             } else {
-                // Build QOE eagerly for CONTENT_END and enqueue for next harvest
-                if (configuration != null && configuration.isQoeAggregateEnabled()) {
-                    // Build QOE with standard attributes (reuse the new helper method)
+                // Send final QOE immediately with CONTENT_END
+                if (configuration != null && configuration.isQoeAggregateEnabled() && qoeProviderRegistered) {
+                    // Build final QOE with standard attributes
                     Map<String, Object> qoeEvent = buildQoeEventWithStandardAttributes();
 
-                    // Mark as final QOE so HarvestManager always sends it (even on empty batches)
-                    qoeEvent.put("isFinalQoe", true);
+                    // Send QOE immediately (not through harvest cycle)
+                    sendEvent(QOE_AGGREGATE, qoeEvent);
+                    NRLog.d("Final QOE_AGGREGATE sent immediately with CONTENT_END");
 
-                    // Enqueue for next harvest to avoid race conditions
-                    pendingQoeForNextHarvest = qoeEvent;
-                    NRLog.d("QOE_AGGREGATE built eagerly at CONTENT_END, enqueued for next harvest");
+                    // Unregister QOE provider after sending final QOE
+                    if (NRVideo.getInstance() != null && NRVideo.getInstance().getHarvestManager() != null) {
+                        NRVideo.getInstance().getHarvestManager().unregisterQoeProvider(this);
+                        qoeProviderRegistered = false;
+                        NRLog.d("QOE provider unregistered after final QOE");
+                    }
                 }
 
                 sendVideoEvent(CONTENT_END);
-
-                // NOTE: Provider unregistration is delayed until after final QOE is sent
-                // This happens automatically in HarvestManager when it detects "isFinalQoe" flag
             }
 
             stopHeartbeat();
@@ -643,7 +644,7 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
      */
     @Override
     public Map<String, Object> generateQoeIfNeeded(List<Map<String, Object>> batch, int harvestCycleNumber) {
-        // Check if QOE is enabled
+        // Check if QOE is enabled and generate regular harvest QOE
         if (!state.isAd && configuration != null && configuration.isQoeAggregateEnabled()) {
             // Check if this harvest cycle should send based on interval multiplier
             int intervalMultiplier = configuration.getQoeAggregateIntervalMultiplier();
@@ -673,14 +674,6 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
                     NRLog.d("QOE_AGGREGATE skipped for harvest cycle " + harvestCycleNumber + " (no KPI changes)");
                 }
             }
-        }
-
-        // Check if there's a pending QOE from CONTENT_END
-        if (pendingQoeForNextHarvest != null) {
-            Map<String, Object> qoe = pendingQoeForNextHarvest;
-            pendingQoeForNextHarvest = null; // Clear after use
-            NRLog.d("Pending QOE_AGGREGATE from CONTENT_END injected into harvest");
-            return qoe;
         }
 
         return null; // Don't generate QOE for this cycle

--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/tracker/NRVideoTracker.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/tracker/NRVideoTracker.java
@@ -69,7 +69,7 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
 
     // QOE_AGGREGATE provider fields
     private boolean qoeProviderRegistered = false;
-    private Map<String, Object> pendingQoeForNextHarvest = null; // For CONTENT_END
+    private volatile Map<String, Object> pendingQoeForNextHarvest = null; // For CONTENT_END (volatile for thread safety)
     private Map<String, Object> lastSentQoeKpis = null; // Snapshot of last sent QoE KPIs for dirty check
     private volatile Map<String, Object> cachedStandardAttributes = null; // Cached attributes for thread-safe access
 
@@ -177,6 +177,8 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
     public void dispose() {
         super.dispose();
         stopHeartbeat();
+        // Clean up pending QOE to prevent memory leaks
+        pendingQoeForNextHarvest = null;
     }
 
     /**
@@ -480,21 +482,18 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
                 }
                 totalAdPlaytime = totalAdPlaytime + totalPlaytime;
             } else {
-                // Send final QOE immediately with CONTENT_END
+                // Build final QOE at CONTENT_END and mark for next harvest cycle
                 if (configuration != null && configuration.isQoeAggregateEnabled() && qoeProviderRegistered) {
-                    // Build final QOE with standard attributes
-                    Map<String, Object> qoeEvent = buildQoeEventWithStandardAttributes();
+                    // Build final QOE with complete metrics
+                    Map<String, Object> finalQoe = buildQoeEventWithStandardAttributes();
 
-                    // Send QOE immediately (not through harvest cycle)
-                    sendEvent(QOE_AGGREGATE, qoeEvent);
-                    NRLog.d("Final QOE_AGGREGATE sent immediately with CONTENT_END");
+                    // Mark as final QOE so HarvestManager knows to unregister provider
+                    finalQoe.put("isFinalQoe", true);
 
-                    // Unregister QOE provider after sending final QOE
-                    if (NRVideo.getInstance() != null && NRVideo.getInstance().getHarvestManager() != null) {
-                        NRVideo.getInstance().getHarvestManager().unregisterQoeProvider(this);
-                        qoeProviderRegistered = false;
-                        NRLog.d("QOE provider unregistered after final QOE");
-                    }
+                    // Store for next harvest cycle (will be sent with priority)
+                    pendingQoeForNextHarvest = finalQoe;
+
+                    NRLog.d("Final QOE_AGGREGATE prepared at CONTENT_END, will send on next harvest cycle");
                 }
 
                 sendVideoEvent(CONTENT_END);
@@ -644,7 +643,15 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
      */
     @Override
     public Map<String, Object> generateQoeIfNeeded(List<Map<String, Object>> batch, int harvestCycleNumber) {
-        // Check if QOE is enabled and generate regular harvest QOE
+        // Priority 1: Check if there's a pending final QOE from CONTENT_END
+        if (pendingQoeForNextHarvest != null) {
+            Map<String, Object> finalQoe = pendingQoeForNextHarvest;
+            pendingQoeForNextHarvest = null; // Clear after retrieving
+            NRLog.d("Sending pending final QOE_AGGREGATE from CONTENT_END");
+            return finalQoe; // HarvestManager will see "isFinalQoe" flag and unregister provider
+        }
+
+        // Priority 2: Generate regular harvest QOE if conditions are met
         if (!state.isAd && configuration != null && configuration.isQoeAggregateEnabled()) {
             // Check if this harvest cycle should send based on interval multiplier
             int intervalMultiplier = configuration.getQoeAggregateIntervalMultiplier();
@@ -1153,7 +1160,8 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
         qoeBitrateTimerPaused = false;
 
         // Reset QOE provider fields for new view session
-        pendingQoeForNextHarvest = null;
+        // NOTE: Don't reset pendingQoeForNextHarvest here - it needs to persist until next harvest
+        // pendingQoeForNextHarvest = null;  // DON'T CLEAR - final QOE needs to be sent on next harvest
         lastSentQoeKpis = null; // Reset dirty check snapshot for new view session
     }
 

--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/tracker/NRVideoTracker.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/tracker/NRVideoTracker.java
@@ -697,13 +697,56 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
         // Start with QOE KPI attributes
         Map<String, Object> qoeEvent = calculateQOEKpiAttributes();
 
-        // Add cached standard video tracking attributes (thread-safe)
+        // Add filtered cached attributes (match iOS behavior)
         // Note: Cache is populated by video events (CONTENT_START, HEARTBEAT, etc.) on main thread
         // This avoids thread safety issues with ExoPlayer which requires main thread access
         if (cachedStandardAttributes != null) {
-            qoeEvent.putAll(cachedStandardAttributes);
+            // Filter attributes to match iOS implementation:
+            // - Keep timeSinceRequested and timeSinceStarted (session context)
+            // - Filter out all other timeSince* attributes (event-specific)
+            // - Filter out bufferType (event-specific)
+            for (Map.Entry<String, Object> entry : cachedStandardAttributes.entrySet()) {
+                String key = entry.getKey();
+
+                // Filter out event-specific timeSince* attributes
+                // Keep only timeSinceRequested and timeSinceStarted for session context
+                if (key.startsWith("timeSince")
+                    && !key.equals("timeSinceRequested")
+                    && !key.equals("timeSinceStarted")) {
+                    continue;  // Skip event-specific timeSince
+                }
+
+                // Filter out buffer-specific attribute
+                if (key.equals("bufferType")) {
+                    continue;  // Skip buffer-specific attribute
+                }
+
+                // Include all other attributes
+                qoeEvent.put(key, entry.getValue());
+            }
         } else {
             NRLog.w("QOE: No cached attributes available yet (this is normal for very first QOE before any video events)");
+        }
+
+        // Explicitly ensure session context attributes are present by applying timeSince values
+        // This guarantees timeSinceRequested and timeSinceStarted are always included
+        Map<String, Object> freshTimeSinceAttributes = new HashMap<>();
+        timeSinceTable.applyAttributes(QOE_AGGREGATE, freshTimeSinceAttributes);
+
+        // Extract and add the session context timeSince attributes
+        if (freshTimeSinceAttributes.containsKey("timeSinceRequested")) {
+            qoeEvent.put("timeSinceRequested", freshTimeSinceAttributes.get("timeSinceRequested"));
+        }
+        if (freshTimeSinceAttributes.containsKey("timeSinceStarted")) {
+            qoeEvent.put("timeSinceStarted", freshTimeSinceAttributes.get("timeSinceStarted"));
+        }
+
+        // Log to verify these critical attributes are present
+        if (qoeEvent.containsKey("timeSinceRequested") || qoeEvent.containsKey("timeSinceStarted")) {
+            NRLog.d("QOE session context: timeSinceRequested=" + qoeEvent.get("timeSinceRequested") +
+                    ", timeSinceStarted=" + qoeEvent.get("timeSinceStarted"));
+        } else {
+            NRLog.w("QOE: Session context attributes (timeSinceRequested/timeSinceStarted) not available yet");
         }
 
         // Add/override instrumentation attributes (same as NRTracker.sendEvent())

--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/tracker/NRVideoTracker.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/tracker/NRVideoTracker.java
@@ -11,6 +11,7 @@ import com.newrelic.videoagent.core.harvest.QoeProvider;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -64,6 +65,7 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
     private Long qoeLastRenditionChangeTime;
     private Long qoeTotalBitrateWeightedTime;
     private Long qoeTotalActiveTime;
+    private boolean qoeBitrateTimerPaused;
 
     // QOE_AGGREGATE provider fields
     private boolean qoeProviderRegistered = false;
@@ -162,6 +164,7 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
         qoeLastRenditionChangeTime = null;
         qoeTotalBitrateWeightedTime = 0L;
         qoeTotalActiveTime = 0L;
+        qoeBitrateTimerPaused = false;
     }
 
     /**
@@ -373,6 +376,12 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
 
                 sendVideoEvent(CONTENT_START);
 
+                // Calculate and cache startup time at CONTENT_START (for QOE reporting)
+                calculateAndCacheStartupTime();
+
+                // Resume bitrate timer when content starts playing
+                resumeBitrateTimer();
+
                 // Register QOE provider with HarvestManager (harvest-time generation)
                 if (!qoeProviderRegistered && configuration != null && configuration.isQoeAggregateEnabled()) {
                     if (NRVideo.getInstance() != null && NRVideo.getInstance().getHarvestManager() != null) {
@@ -400,6 +409,8 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
                 sendVideoAdEvent(AD_PAUSE);
             } else {
                 sendVideoEvent(CONTENT_PAUSE);
+                // Pause bitrate timer during pause to exclude paused time from average
+                pauseBitrateTimer();
             }
             playtimeSinceLastEventTimestamp = 0L;
         }
@@ -434,6 +445,10 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
                 sendVideoAdEvent(AD_RESUME);
             } else {
                 sendVideoEvent(CONTENT_RESUME);
+                // Resume bitrate timer when playback resumes (only if not buffering or seeking)
+                if (!state.isBuffering && !state.isSeeking) {
+                    resumeBitrateTimer();
+                }
             }
             if (!state.isBuffering && !state.isSeeking) {
                 playtimeSinceLastEventTimestamp = System.currentTimeMillis();
@@ -456,16 +471,8 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
             } else {
                 // Build QOE eagerly for CONTENT_END and enqueue for next harvest
                 if (configuration != null && configuration.isQoeAggregateEnabled()) {
-                    Map<String, Object> qoeEvent = new HashMap<>();
-                    qoeEvent.put("eventType", "VideoAction");
-                    qoeEvent.put("actionName", QOE_AGGREGATE);
-                    qoeEvent.put("timestamp", System.currentTimeMillis());
-                    qoeEvent.put("sessionId", getAgentSession());
-                    qoeEvent.put("viewId", getViewId());
-
-                    // Add QOE KPI attributes while tracker state is still valid
-                    Map<String, Object> kpiAttributes = calculateQOEKpiAttributes();
-                    qoeEvent.putAll(kpiAttributes);
+                    // Build QOE with standard attributes (reuse the new helper method)
+                    Map<String, Object> qoeEvent = buildQoeEventWithStandardAttributes();
 
                     // Mark as final QOE so HarvestManager always sends it (even on empty batches)
                     qoeEvent.put("isFinalQoe", true);
@@ -502,6 +509,8 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
                 sendVideoAdEvent(AD_SEEK_START);
             } else {
                 sendVideoEvent(CONTENT_SEEK_START);
+                // Pause bitrate timer during seeking to exclude seek time from average
+                pauseBitrateTimer();
             }
             playtimeSinceLastEventTimestamp = 0L;
         }
@@ -516,6 +525,10 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
                 sendVideoAdEvent(AD_SEEK_END);
             } else {
                 sendVideoEvent(CONTENT_SEEK_END);
+                // Resume bitrate timer when seeking ends (only if not buffering or paused)
+                if (!state.isBuffering && !state.isPaused) {
+                    resumeBitrateTimer();
+                }
             }
             if (!state.isBuffering && !state.isPaused) {
                 playtimeSinceLastEventTimestamp = System.currentTimeMillis();
@@ -536,6 +549,8 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
                 sendVideoAdEvent(AD_BUFFER_START);
             } else {
                 sendVideoEvent(CONTENT_BUFFER_START);
+                // Pause bitrate timer during buffering to exclude buffering time from average
+                pauseBitrateTimer();
             }
             playtimeSinceLastEventTimestamp = 0L;
         }
@@ -556,6 +571,10 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
                 sendVideoAdEvent(AD_BUFFER_END);
             } else {
                 sendVideoEvent(CONTENT_BUFFER_END);
+                // Resume bitrate timer when buffering ends (only if not seeking or paused)
+                if (!state.isSeeking && !state.isPaused) {
+                    resumeBitrateTimer();
+                }
             }
             if (!state.isSeeking && !state.isPaused) {
                 playtimeSinceLastEventTimestamp = System.currentTimeMillis();
@@ -618,21 +637,16 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
             // Check if this harvest cycle should send based on interval multiplier
             int intervalMultiplier = configuration.getQoeAggregateIntervalMultiplier();
 
-            // First cycle always sends, then every Nth cycle
-            boolean shouldSend = harvestCycleNumber == 1 || (harvestCycleNumber % intervalMultiplier == 0);
+            // Formula matches iOS: (harvestCycleNumber - 1) % multiplier == 0
+            // Examples:
+            //   multiplier=1: cycles 1,2,3,4... (every harvest)
+            //   multiplier=2: cycles 1,3,5,7... (every other)
+            //   multiplier=3: cycles 1,4,7,10... (every third)
+            boolean shouldSend = (harvestCycleNumber - 1) % intervalMultiplier == 0;
 
             if (shouldSend) {
-                // Build QOE event
-                Map<String, Object> qoeEvent = new HashMap<>();
-                qoeEvent.put("eventType", "VideoAction");
-                qoeEvent.put("actionName", QOE_AGGREGATE);
-                qoeEvent.put("timestamp", System.currentTimeMillis());
-                qoeEvent.put("sessionId", getAgentSession());
-                qoeEvent.put("viewId", getViewId());
-
-                // Add QOE KPI attributes
-                Map<String, Object> kpiAttributes = calculateQOEKpiAttributes();
-                qoeEvent.putAll(kpiAttributes);
+                // Build QOE event with standard attributes (reuse existing attribute generation)
+                Map<String, Object> qoeEvent = buildQoeEventWithStandardAttributes();
 
                 NRLog.d("QOE_AGGREGATE generated for harvest cycle " + harvestCycleNumber);
                 return qoeEvent;
@@ -648,6 +662,44 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
         }
 
         return null; // Don't generate QOE for this cycle
+    }
+
+    /**
+     * Build QOE event with all standard video tracking attributes.
+     * Reuses the existing attribute generation pipeline to ensure consistency.
+     *
+     * @return Complete QOE event map with standard attributes
+     */
+    private Map<String, Object> buildQoeEventWithStandardAttributes() {
+        // Start with QOE KPI attributes
+        Map<String, Object> qoeEvent = calculateQOEKpiAttributes();
+
+        // Add standard video tracking attributes (reuse getAttributes pipeline)
+        qoeEvent = getAttributes(QOE_AGGREGATE, qoeEvent);
+
+        // Add instrumentation attributes (same as NRTracker.sendEvent())
+        qoeEvent.put("agentSession", getAgentSession());
+        qoeEvent.put("instrumentation.provider", "newrelic");
+        qoeEvent.put("instrumentation.name", getInstrumentationName());
+        qoeEvent.put("instrumentation.version", getCoreVersion());
+
+        // Add core attributes
+        qoeEvent.put("eventType", "VideoAction");
+        qoeEvent.put("actionName", QOE_AGGREGATE);
+        qoeEvent.put("timestamp", System.currentTimeMillis());
+        qoeEvent.put("sessionId", getAgentSession());
+        qoeEvent.put("viewId", getViewId());
+
+        // Remove null and empty values (same as NRTracker.sendEvent())
+        Iterator<Object> it = qoeEvent.values().iterator();
+        while (it.hasNext()) {
+            Object v = it.next();
+            if (v == null || "".equals(v)) {
+                it.remove();
+            }
+        }
+
+        return qoeEvent;
     }
 
     /**
@@ -714,6 +766,19 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
         // qoeAggregateVersion - Version identifier for QOE calculation algorithm
         kpiAttributes.put("qoeAggregateVersion", "1.0.0");
 
+        // startupTime - Cached value calculated at CONTENT_START
+        if (qoeStartupTime != null && qoeStartupTime >= 0) {
+            kpiAttributes.put("startupTime", qoeStartupTime);
+        } else {
+            kpiAttributes.put("startupTime", 0L);
+        }
+
+        // hadStartupFailure - Boolean indicating if error occurred before CONTENT_START
+        if (qoeHadStartupFailure == null) {
+            qoeHadStartupFailure = false;
+        }
+        kpiAttributes.put("hadStartupFailure", qoeHadStartupFailure);
+
         return kpiAttributes;
     }
 
@@ -746,14 +811,56 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
     }
 
     /**
+     * Calculate and cache startup time at CONTENT_START.
+     * This method calculates startup time once and caches it for all subsequent QOE reports.
+     * Called immediately after CONTENT_START event is sent.
+     */
+    private void calculateAndCacheStartupTime() {
+        if (qoeStartupTime != null) {
+            return; // Already calculated
+        }
+
+        // Get the CONTENT_START attributes to extract timing values
+        Map<String, Object> startAttributes = getAttributes(CONTENT_START, null);
+        timeSinceTable.applyAttributes(CONTENT_START, startAttributes);
+
+        Long timeSinceRequested = (Long) startAttributes.get("timeSinceRequested");
+
+        if (timeSinceRequested != null && timeSinceRequested >= 0) {
+            Long totalExclusionTime = 0L;
+
+            // Exclude ad time that occurred during startup period
+            if (startupPeriodAdTime != null && startupPeriodAdTime > 0) {
+                totalExclusionTime += startupPeriodAdTime;
+            }
+
+            // Exclude pause time that occurred during startup period
+            if (startupPeriodPauseTime != null && startupPeriodPauseTime > 0) {
+                totalExclusionTime += startupPeriodPauseTime;
+            }
+
+            // Calculate: startupTime = timeSinceRequested - adTime - pauseTime
+            // Ensure result is non-negative
+            qoeStartupTime = Math.max(timeSinceRequested - totalExclusionTime, 0L);
+
+            NRLog.d("Startup time calculated and cached: " + qoeStartupTime + "ms");
+        } else {
+            qoeStartupTime = 0L;
+        }
+    }
+
+    /**
      * Calculate and add startup time to QOE_AGGREGATE attributes.
      * Called from NRTracker.sendEvent() where timing attributes are already available.
+     * @deprecated This method is kept for backward compatibility but is no longer used
+     * in the harvest-time QOE generation architecture. Use calculateAndCacheStartupTime() instead.
      *
      * @param attributes The QOE_AGGREGATE attributes map to add startup time to
      * @param timeSinceRequested Time since CONTENT_REQUEST event
      * @param timeSinceStarted Time since CONTENT_START event
      * @param timeSinceLastError Time since CONTENT_ERROR event
      */
+    @Deprecated
     public void calculateAndAddStartupTime(Map<String, Object> attributes,
                                            Long timeSinceRequested,
                                            Long timeSinceStarted,
@@ -843,14 +950,65 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
     }
 
     /**
+     * Pause the bitrate timer during non-play states (pause, buffering, seeking).
+     * This ensures that time spent in non-play states is not counted in the
+     * time-weighted average bitrate calculation.
+     */
+    private void pauseBitrateTimer() {
+        if (qoeBitrateTimerPaused) {
+            return; // Already paused, nothing to do
+        }
+
+        // Save the current segment before pausing
+        if (qoeCurrentBitrate != null && qoeLastRenditionChangeTime != null && qoeCurrentBitrate > 0) {
+            long currentTime = System.currentTimeMillis();
+
+            // Ensure valid timestamps
+            if (qoeLastRenditionChangeTime > 0 && currentTime >= qoeLastRenditionChangeTime) {
+                long segmentDuration = currentTime - qoeLastRenditionChangeTime;
+
+                if (segmentDuration > 0) {
+                    // Prevent overflow in multiplication
+                    if (qoeCurrentBitrate <= Long.MAX_VALUE / segmentDuration) {
+                        try {
+                            qoeTotalBitrateWeightedTime = safeAdd(qoeTotalBitrateWeightedTime, qoeCurrentBitrate * segmentDuration);
+                            qoeTotalActiveTime = safeAdd(qoeTotalActiveTime, segmentDuration);
+                        } catch (ArithmeticException e) {
+                            NRLog.w("QoE bitrate accumulation overflow during pause - resetting");
+                            qoeTotalBitrateWeightedTime = 0L;
+                            qoeTotalActiveTime = 0L;
+                        }
+                    }
+                }
+            }
+        }
+
+        qoeBitrateTimerPaused = true;
+    }
+
+    /**
+     * Resume the bitrate timer after exiting non-play states.
+     * Restarts timing from the current moment so paused time is excluded.
+     */
+    private void resumeBitrateTimer() {
+        if (!qoeBitrateTimerPaused) {
+            return; // Already running, nothing to do
+        }
+
+        // Restart the timer from now (exclude the paused time)
+        qoeLastRenditionChangeTime = System.currentTimeMillis();
+        qoeBitrateTimerPaused = false;
+    }
+
+    /**
      * Finalize time-weighted bitrate calculation by including the current segment.
      * Called during QoE calculation to include the time since the last rendition change.
      *
      * @return Time-weighted average bitrate, or null if no data available
      */
     private Long calculateTimeWeightedAverageBitrate() {
-        // Include current segment in calculation
-        if (qoeCurrentBitrate != null && qoeLastRenditionChangeTime != null && qoeCurrentBitrate > 0) {
+        // Include current segment in calculation (only if timer is not paused)
+        if (!qoeBitrateTimerPaused && qoeCurrentBitrate != null && qoeLastRenditionChangeTime != null && qoeCurrentBitrate > 0) {
             long currentTime = System.currentTimeMillis();
 
             // Safety check: ensure valid timestamp
@@ -919,6 +1077,7 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
         qoeLastRenditionChangeTime = null;
         qoeTotalBitrateWeightedTime = 0L;
         qoeTotalActiveTime = 0L;
+        qoeBitrateTimerPaused = false;
 
         // Reset QOE provider fields for new view session
         pendingQoeForNextHarvest = null;

--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/tracker/NRVideoTracker.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/tracker/NRVideoTracker.java
@@ -7,9 +7,11 @@ import com.newrelic.videoagent.core.NRVideoConfiguration;
 import com.newrelic.videoagent.core.model.NRTimeSince;
 import com.newrelic.videoagent.core.model.NRTrackerState;
 import com.newrelic.videoagent.core.utils.NRLog;
+import com.newrelic.videoagent.core.harvest.QoeProvider;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Random;
 
@@ -18,8 +20,9 @@ import com.newrelic.videoagent.core.exception.ErrorExceptionHandler;
 
 /**
  * `NRVideoTracker` defines the basic behaviour of a video tracker.
+ * Implements QoeProvider for harvest-time QOE_AGGREGATE generation.
  */
-public class NRVideoTracker extends NRTracker {
+public class NRVideoTracker extends NRTracker implements QoeProvider {
 
 
     private static final int CONTENT_HEARTBEAT_INTERVAL_SEC = 30;
@@ -62,11 +65,9 @@ public class NRVideoTracker extends NRTracker {
     private Long qoeTotalBitrateWeightedTime;
     private Long qoeTotalActiveTime;
 
-    // QOE_AGGREGATE harvest cycle tracking fields
-    private boolean hasVideoActionInCurrentCycle = false;
-    private boolean qoeAggregateAlreadySent = false;
-    private Long lastHarvestCycleTimestamp = null;
-    private int harvestCycleCount = 0; // Track number of harvest cycles for qoeIntervalFactor
+    // QOE_AGGREGATE provider fields
+    private boolean qoeProviderRegistered = false;
+    private Map<String, Object> pendingQoeForNextHarvest = null; // For CONTENT_END
 
     /**
      * Create a new NRVideoTracker.
@@ -341,8 +342,6 @@ public class NRVideoTracker extends NRTracker {
                 sendVideoAdEvent(AD_REQUEST);
             } else {
                 sendVideoEvent(CONTENT_REQUEST);
-                // Mark video action for QOE_AGGREGATE once per harvest cycle
-                markVideoActionInCycle();
             }
         }
     }
@@ -373,8 +372,15 @@ public class NRVideoTracker extends NRTracker {
                 hasContentStarted = true;
 
                 sendVideoEvent(CONTENT_START);
-                // Mark video action for QOE_AGGREGATE once per harvest cycle
-                markVideoActionInCycle();
+
+                // Register QOE provider with HarvestManager (harvest-time generation)
+                if (!qoeProviderRegistered && configuration != null && configuration.isQoeAggregateEnabled()) {
+                    if (NRVideo.getInstance() != null && NRVideo.getInstance().getHarvestManager() != null) {
+                        NRVideo.getInstance().getHarvestManager().registerQoeProvider(this);
+                        qoeProviderRegistered = true;
+                        NRLog.d("QOE provider registered at CONTENT_START");
+                    }
+                }
             }
             playtimeSinceLastEventTimestamp = System.currentTimeMillis();
         }
@@ -394,8 +400,6 @@ public class NRVideoTracker extends NRTracker {
                 sendVideoAdEvent(AD_PAUSE);
             } else {
                 sendVideoEvent(CONTENT_PAUSE);
-                // Send single and latest QOE with this VideoAction event
-                markVideoActionInCycle();
             }
             playtimeSinceLastEventTimestamp = 0L;
         }
@@ -430,8 +434,6 @@ public class NRVideoTracker extends NRTracker {
                 sendVideoAdEvent(AD_RESUME);
             } else {
                 sendVideoEvent(CONTENT_RESUME);
-                // Send single and latest QOE with this VideoAction event
-                markVideoActionInCycle();
             }
             if (!state.isBuffering && !state.isSeeking) {
                 playtimeSinceLastEventTimestamp = System.currentTimeMillis();
@@ -452,11 +454,31 @@ public class NRVideoTracker extends NRTracker {
                 }
                 totalAdPlaytime = totalAdPlaytime + totalPlaytime;
             } else {
-                // For last harvest cycle: force send QOE_AGGREGATE if not already sent and QOE is enabled
-                if (!qoeAggregateAlreadySent && configuration != null && configuration.isQoeAggregateEnabled()) {
-                    sendQoeAggregate();
+                // Build QOE eagerly for CONTENT_END and enqueue for next harvest
+                if (configuration != null && configuration.isQoeAggregateEnabled()) {
+                    Map<String, Object> qoeEvent = new HashMap<>();
+                    qoeEvent.put("eventType", "VideoAction");
+                    qoeEvent.put("actionName", QOE_AGGREGATE);
+                    qoeEvent.put("timestamp", System.currentTimeMillis());
+                    qoeEvent.put("sessionId", getAgentSession());
+                    qoeEvent.put("viewId", getViewId());
+
+                    // Add QOE KPI attributes while tracker state is still valid
+                    Map<String, Object> kpiAttributes = calculateQOEKpiAttributes();
+                    qoeEvent.putAll(kpiAttributes);
+
+                    // Mark as final QOE so HarvestManager always sends it (even on empty batches)
+                    qoeEvent.put("isFinalQoe", true);
+
+                    // Enqueue for next harvest to avoid race conditions
+                    pendingQoeForNextHarvest = qoeEvent;
+                    NRLog.d("QOE_AGGREGATE built eagerly at CONTENT_END, enqueued for next harvest");
                 }
+
                 sendVideoEvent(CONTENT_END);
+
+                // NOTE: Provider unregistration is delayed until after final QOE is sent
+                // This happens automatically in HarvestManager when it detects "isFinalQoe" flag
             }
 
             stopHeartbeat();
@@ -480,8 +502,6 @@ public class NRVideoTracker extends NRTracker {
                 sendVideoAdEvent(AD_SEEK_START);
             } else {
                 sendVideoEvent(CONTENT_SEEK_START);
-                // Send single and latest QOE with this VideoAction event
-                markVideoActionInCycle();
             }
             playtimeSinceLastEventTimestamp = 0L;
         }
@@ -496,8 +516,6 @@ public class NRVideoTracker extends NRTracker {
                 sendVideoAdEvent(AD_SEEK_END);
             } else {
                 sendVideoEvent(CONTENT_SEEK_END);
-                // Send single and latest QOE with this VideoAction event
-                markVideoActionInCycle();
             }
             if (!state.isBuffering && !state.isPaused) {
                 playtimeSinceLastEventTimestamp = System.currentTimeMillis();
@@ -518,8 +536,6 @@ public class NRVideoTracker extends NRTracker {
                 sendVideoAdEvent(AD_BUFFER_START);
             } else {
                 sendVideoEvent(CONTENT_BUFFER_START);
-                // Send single and latest QOE with this VideoAction event
-                markVideoActionInCycle();
             }
             playtimeSinceLastEventTimestamp = 0L;
         }
@@ -540,8 +556,6 @@ public class NRVideoTracker extends NRTracker {
                 sendVideoAdEvent(AD_BUFFER_END);
             } else {
                 sendVideoEvent(CONTENT_BUFFER_END);
-                // Send single and latest QOE with this VideoAction event
-                markVideoActionInCycle();
             }
             if (!state.isSeeking && !state.isPaused) {
                 playtimeSinceLastEventTimestamp = System.currentTimeMillis();
@@ -566,8 +580,6 @@ public class NRVideoTracker extends NRTracker {
                 sendVideoAdEvent(AD_HEARTBEAT,eventData);
             } else {
                 sendVideoEvent(CONTENT_HEARTBEAT, eventData);
-                // Send single and latest QOE with this VideoAction event
-                markVideoActionInCycle();
             }
         }
         state.chrono.start();
@@ -582,8 +594,6 @@ public class NRVideoTracker extends NRTracker {
             sendVideoAdEvent(AD_RENDITION_CHANGE);
         } else {
             sendVideoEvent(CONTENT_RENDITION_CHANGE);
-            // Send single and latest QOE with this VideoAction event
-            sendQoeAggregate();
         }
     }
 
@@ -594,76 +604,60 @@ public class NRVideoTracker extends NRTracker {
      * This design choice focuses QoE measurement on the primary content viewing experience.
      */
     /**
-     * Mark that a video action occurred in the current harvest cycle.
-     * This will trigger QOE_AGGREGATE to be sent once per cycle.
+     * Implementation of QoeProvider interface.
+     * Called by HarvestManager during harvest to generate QOE_AGGREGATE events.
+     *
+     * @param batch The current harvest batch containing VideoAction events
+     * @param harvestCycleNumber The current harvest cycle number (1-based)
+     * @return QOE_AGGREGATE event map if it should be generated, null otherwise
      */
-    public void markVideoActionInCycle() {
-        if (!state.isAd) { // Only for content, not ads
-            checkAndSendQoeAggregateIfNeeded(); // Check for new cycle first (may reset flags)
-            hasVideoActionInCurrentCycle = true; // Now mark action in current cycle
-            // Check again now that we've marked the action
-            if (hasVideoActionInCurrentCycle && !qoeAggregateAlreadySent) {
-                sendQoeAggregate();
+    @Override
+    public Map<String, Object> generateQoeIfNeeded(List<Map<String, Object>> batch, int harvestCycleNumber) {
+        // Check if QOE is enabled
+        if (!state.isAd && configuration != null && configuration.isQoeAggregateEnabled()) {
+            // Check if this harvest cycle should send based on interval multiplier
+            int intervalMultiplier = configuration.getQoeAggregateIntervalMultiplier();
+
+            // First cycle always sends, then every Nth cycle
+            boolean shouldSend = harvestCycleNumber == 1 || (harvestCycleNumber % intervalMultiplier == 0);
+
+            if (shouldSend) {
+                // Build QOE event
+                Map<String, Object> qoeEvent = new HashMap<>();
+                qoeEvent.put("eventType", "VideoAction");
+                qoeEvent.put("actionName", QOE_AGGREGATE);
+                qoeEvent.put("timestamp", System.currentTimeMillis());
+                qoeEvent.put("sessionId", getAgentSession());
+                qoeEvent.put("viewId", getViewId());
+
+                // Add QOE KPI attributes
+                Map<String, Object> kpiAttributes = calculateQOEKpiAttributes();
+                qoeEvent.putAll(kpiAttributes);
+
+                NRLog.d("QOE_AGGREGATE generated for harvest cycle " + harvestCycleNumber);
+                return qoeEvent;
             }
         }
+
+        // Check if there's a pending QOE from CONTENT_END
+        if (pendingQoeForNextHarvest != null) {
+            Map<String, Object> qoe = pendingQoeForNextHarvest;
+            pendingQoeForNextHarvest = null; // Clear after use
+            NRLog.d("Pending QOE_AGGREGATE from CONTENT_END injected into harvest");
+            return qoe;
+        }
+
+        return null; // Don't generate QOE for this cycle
     }
 
     /**
-     * Check if we need to send QOE_AGGREGATE for the current harvest cycle.
-     * Only sends once per harvest cycle and only if there was a video action.
-     * Respects qoeIntervalFactor to reduce frequency (first and last cycles always send).
+     * Implementation of QoeProvider interface.
+     * Called when provider should be unregistered.
      */
-    private void checkAndSendQoeAggregateIfNeeded() {
-        long currentTime = System.currentTimeMillis();
-        // Use user-configured harvest cycle
-        long harvestCycleMs = NRVideo.getHarvestCycleSeconds() * 1000L;
-        // Check if we're in a new harvest cycle
-        if (lastHarvestCycleTimestamp == null ||
-                (currentTime - lastHarvestCycleTimestamp) >= harvestCycleMs) {
-            resetHarvestCycleFlags();
-            lastHarvestCycleTimestamp = currentTime;
-            harvestCycleCount++; // Increment cycle count for qoeIntervalFactor
-        }
-        // Send QOE_AGGREGATE if we haven't sent it yet and we have video actions
-        // Check if this cycle should send based on qoeIntervalFactor
-        if (hasVideoActionInCurrentCycle && !qoeAggregateAlreadySent && shouldSendQoeInCurrentCycle()) {
-            sendQoeAggregate();
-        }
-    }
-
-    /**
-     * Determine if QOE_AGGREGATE should be sent in the current harvest cycle.
-     * First cycle (cycle 1) always sends. Then sends every Nth cycle where N = qoeIntervalFactor.
-     * @return true if QOE should be sent, false otherwise
-     */
-    private boolean shouldSendQoeInCurrentCycle() {
-        if (configuration == null) {
-            return true; // Default behavior if no config
-        }
-        int intervalFactor = configuration.getQoeIntervalFactor();
-        // First cycle always sends (harvestCycleCount == 1)
-        // Then send every intervalFactor cycles (e.g., if factor=3, send on cycles 1, 3, 6, 9, ...)
-        return harvestCycleCount == 1 || (harvestCycleCount % intervalFactor == 0);
-    }
-
-    /**
-     * Reset harvest cycle tracking flags for new cycle
-     */
-    private void resetHarvestCycleFlags() {
-        hasVideoActionInCurrentCycle = false;
-        qoeAggregateAlreadySent = false;
-    }
-
-    /**
-     * Send QOE_AGGREGATE event (internal method - called once per cycle)
-     */
-    private void sendQoeAggregate() {
-        if (!state.isAd && configuration != null && configuration.isQoeAggregateEnabled()) {
-            // Only send for content, not ads, and only if QOE aggregate is enabled
-            Map<String, Object> kpiAttributes = calculateQOEKpiAttributes();
-            sendVideoEvent(QOE_AGGREGATE, kpiAttributes);
-            qoeAggregateAlreadySent = true;
-        }
+    @Override
+    public void unregister() {
+        qoeProviderRegistered = false;
+        NRLog.d("QOE provider unregistered for tracker");
     }
 
     /**
@@ -926,10 +920,8 @@ public class NRVideoTracker extends NRTracker {
         qoeTotalBitrateWeightedTime = 0L;
         qoeTotalActiveTime = 0L;
 
-        // Reset QOE_AGGREGATE harvest cycle tracking fields
-        resetHarvestCycleFlags();
-        lastHarvestCycleTimestamp = null;
-        harvestCycleCount = 0; // Reset cycle count for new view session
+        // Reset QOE provider fields for new view session
+        pendingQoeForNextHarvest = null;
     }
 
 

--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/tracker/NRVideoTracker.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/tracker/NRVideoTracker.java
@@ -807,10 +807,19 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
         }
         kpiAttributes.put("totalRebufferingTime", qoeTotalRebufferingTime);
 
-        // Use elapsedTime (accumulatedVideoWatchTime) instead of totalPlaytime for QOE
-        Long elapsedTime = state.accumulatedVideoWatchTime;
+        // Calculate real-time totalPlaytime (cumulative, not reset like accumulatedVideoWatchTime)
+        // totalPlaytime is updated during video events, but we add time since last event for real-time value
+        Long elapsedTime = totalPlaytime;
         if (elapsedTime == null) {
             elapsedTime = 0L;
+        }
+
+        // If video is playing, add time since last video event update
+        if (state.isPlaying && playtimeSinceLastEventTimestamp > 0) {
+            long timeSinceLastUpdate = System.currentTimeMillis() - playtimeSinceLastEventTimestamp;
+            if (timeSinceLastUpdate > 0) {
+                elapsedTime += timeSinceLastUpdate;
+            }
         }
 
         // rebufferingRatio - Rebuffering time as a percentage of elapsed watch time
@@ -821,7 +830,7 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
             kpiAttributes.put("rebufferingRatio", 0.0);
         }
 
-        // totalPlaytime - Use elapsedTime (accumulated video watch time) instead of totalPlaytime
+        // totalPlaytime - Real-time cumulative playtime
         kpiAttributes.put("totalPlaytime", elapsedTime);
 
         // averageBitrate - Time-weighted average bitrate across all content playback

--- a/NewRelicVideoCore/src/test/java/com/newrelic/videoagent/core/ObfuscationEngineTest.java
+++ b/NewRelicVideoCore/src/test/java/com/newrelic/videoagent/core/ObfuscationEngineTest.java
@@ -1,0 +1,473 @@
+package com.newrelic.videoagent.core;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for ObfuscationEngine.apply() — the core logic that masks event attributes.
+ *
+ * Grouped into sections:
+ *   1. No-op / fast-path cases
+ *   2. Basic replacement
+ *   3. Multiple rules
+ *   4. Non-string value handling
+ *   5. Immutability — originals must never be mutated
+ *   6. Corner cases (special chars in replacement, empty strings, null values, etc.)
+ *   7. Realistic end-to-end scenarios
+ */
+public class ObfuscationEngineTest {
+
+    // =========================================================================
+    // 1. No-op / fast-path cases
+    // =========================================================================
+
+    @Test
+    public void noRules_returnsOriginalListUnchanged() {
+        List<Map<String, Object>> events = singleEvent("contentSrc", "https://cdn.com/users/john/video.mp4");
+
+        List<Map<String, Object>> result = ObfuscationEngine.apply(events, Collections.emptyList());
+
+        // With no rules the exact same list reference is returned — zero overhead.
+        assertSame(events, result);
+    }
+
+    @Test
+    public void nullRules_returnsOriginalListUnchanged() {
+        List<Map<String, Object>> events = singleEvent("contentSrc", "https://cdn.com/secret");
+
+        List<Map<String, Object>> result = ObfuscationEngine.apply(events, null);
+
+        assertSame(events, result);
+    }
+
+    @Test
+    public void emptyEventList_returnsOriginalEmptyList() {
+        List<Map<String, Object>> events = new ArrayList<>();
+        List<ObfuscationRule> rules = rules("account-\\d+", "ACCOUNT_ID");
+
+        List<Map<String, Object>> result = ObfuscationEngine.apply(events, rules);
+
+        assertSame(events, result);
+    }
+
+    @Test
+    public void nullEventList_returnsNull() {
+        List<ObfuscationRule> rules = rules("account-\\d+", "ACCOUNT_ID");
+
+        List<Map<String, Object>> result = ObfuscationEngine.apply(null, rules);
+
+        assertNull(result);
+    }
+
+    // =========================================================================
+    // 2. Basic replacement
+    // =========================================================================
+
+    @Test
+    public void singleRule_matchingValue_isReplaced() {
+        List<Map<String, Object>> events = singleEvent("contentSrc", "https://cdn.com/account-83729/video.mp4");
+        List<ObfuscationRule> rules = rules("account-\\d+", "ACCOUNT_ID");
+
+        List<Map<String, Object>> result = ObfuscationEngine.apply(events, rules);
+
+        assertEquals("https://cdn.com/ACCOUNT_ID/video.mp4", result.get(0).get("contentSrc"));
+    }
+
+    @Test
+    public void singleRule_noMatch_valueUnchanged() {
+        List<Map<String, Object>> events = singleEvent("contentSrc", "https://cdn.com/video.mp4");
+        List<ObfuscationRule> rules = rules("account-\\d+", "ACCOUNT_ID");
+
+        List<Map<String, Object>> result = ObfuscationEngine.apply(events, rules);
+
+        assertEquals("https://cdn.com/video.mp4", result.get(0).get("contentSrc"));
+    }
+
+    @Test
+    public void singleRule_multipleMatchesInSameValue_allReplaced() {
+        // regex replaceAll — every occurrence is replaced, not just the first.
+        List<Map<String, Object>> events = singleEvent("contentSrc", "account-111/sub/account-222");
+        List<ObfuscationRule> rules = rules("account-\\d+", "ACCOUNT_ID");
+
+        List<Map<String, Object>> result = ObfuscationEngine.apply(events, rules);
+
+        assertEquals("ACCOUNT_ID/sub/ACCOUNT_ID", result.get(0).get("contentSrc"));
+    }
+
+    @Test
+    public void singleRule_entireValueMatches_wholeValueReplaced() {
+        List<Map<String, Object>> events = singleEvent("userId", "john_doe_123");
+        List<ObfuscationRule> rules = rules("john_doe_\\d+", "USER_ID");
+
+        List<Map<String, Object>> result = ObfuscationEngine.apply(events, rules);
+
+        assertEquals("USER_ID", result.get(0).get("userId"));
+    }
+
+    @Test
+    public void singleRule_appliedAcrossAllEventsInBatch() {
+        Map<String, Object> e1 = event("contentSrc", "cdn.com/account-1/v.mp4");
+        Map<String, Object> e2 = event("contentSrc", "cdn.com/account-2/v.mp4");
+        Map<String, Object> e3 = event("contentSrc", "cdn.com/no-match/v.mp4");
+        List<Map<String, Object>> events = Arrays.asList(e1, e2, e3);
+        List<ObfuscationRule> rules = rules("account-\\d+", "ACCOUNT_ID");
+
+        List<Map<String, Object>> result = ObfuscationEngine.apply(events, rules);
+
+        assertEquals("cdn.com/ACCOUNT_ID/v.mp4",  result.get(0).get("contentSrc"));
+        assertEquals("cdn.com/ACCOUNT_ID/v.mp4",  result.get(1).get("contentSrc"));
+        assertEquals("cdn.com/no-match/v.mp4",     result.get(2).get("contentSrc")); // unchanged
+    }
+
+    @Test
+    public void singleRule_allStringAttributesInEventAreObfuscated() {
+        // The rule should run on every string value in the map, not just "contentSrc".
+        Map<String, Object> ev = new HashMap<>();
+        ev.put("contentSrc",   "https://cdn.com/account-99/video");
+        ev.put("contentTitle", "Show for account-99 subscribers");
+        ev.put("eventType",    "CONTENT_START");
+        List<ObfuscationRule> rules = rules("account-\\d+", "ACCOUNT_ID");
+
+        List<Map<String, Object>> result = ObfuscationEngine.apply(Collections.singletonList(ev), rules);
+        Map<String, Object> out = result.get(0);
+
+        assertEquals("https://cdn.com/ACCOUNT_ID/video", out.get("contentSrc"));
+        assertEquals("Show for ACCOUNT_ID subscribers",  out.get("contentTitle"));
+        assertEquals("CONTENT_START",                    out.get("eventType")); // no match — unchanged
+    }
+
+    // =========================================================================
+    // 3. Multiple rules
+    // =========================================================================
+
+    @Test
+    public void multipleRules_allAppliedInOrder() {
+        Map<String, Object> ev = event("url", "https://cdn.com/account-42/token=secret99");
+        List<ObfuscationRule> rules = Arrays.asList(
+            new ObfuscationRule("account-\\d+", "ACCOUNT_ID"),
+            new ObfuscationRule("token=[^&\"]+", "token=REDACTED")
+        );
+
+        List<Map<String, Object>> result = ObfuscationEngine.apply(Collections.singletonList(ev), rules);
+
+        assertEquals("https://cdn.com/ACCOUNT_ID/token=REDACTED", result.get(0).get("url"));
+    }
+
+    @Test
+    public void multipleRules_orderMatters_secondRuleSeesOutputOfFirst() {
+        // Rule 1 turns "john" → "USER", then Rule 2 turns "USER_profile" → "PROFILE".
+        // If applied to the original (not chained), Rule 2 would never match "USER_profile".
+        Map<String, Object> ev = event("path", "/john_profile");
+        List<ObfuscationRule> rules = Arrays.asList(
+            new ObfuscationRule("john", "USER"),       // /john_profile → /USER_profile
+            new ObfuscationRule("USER_profile", "PROFILE") // /USER_profile → /PROFILE
+        );
+
+        List<Map<String, Object>> result = ObfuscationEngine.apply(Collections.singletonList(ev), rules);
+
+        assertEquals("/PROFILE", result.get(0).get("path"));
+    }
+
+    // =========================================================================
+    // 4. Non-string value handling
+    // =========================================================================
+
+    @Test
+    public void integerValues_areNotObfuscated() {
+        Map<String, Object> ev = event("bitrate", 5000000); // Integer, not String
+        List<ObfuscationRule> rules = rules("\\d+", "REDACTED");
+
+        List<Map<String, Object>> result = ObfuscationEngine.apply(Collections.singletonList(ev), rules);
+
+        assertEquals(5000000, result.get(0).get("bitrate")); // unchanged
+    }
+
+    @Test
+    public void longValues_areNotObfuscated() {
+        Map<String, Object> ev = event("timestamp", 1712345678000L);
+        List<ObfuscationRule> rules = rules("\\d+", "REDACTED");
+
+        List<Map<String, Object>> result = ObfuscationEngine.apply(Collections.singletonList(ev), rules);
+
+        assertEquals(1712345678000L, result.get(0).get("timestamp"));
+    }
+
+    @Test
+    public void doubleValues_areNotObfuscated() {
+        Map<String, Object> ev = event("bufferLength", 2.5);
+        List<ObfuscationRule> rules = rules("\\d+", "REDACTED");
+
+        List<Map<String, Object>> result = ObfuscationEngine.apply(Collections.singletonList(ev), rules);
+
+        assertEquals(2.5, result.get(0).get("bufferLength"));
+    }
+
+    @Test
+    public void booleanValues_areNotObfuscated() {
+        Map<String, Object> ev = event("contentIsLive", true);
+        List<ObfuscationRule> rules = rules("true", "REDACTED");
+
+        List<Map<String, Object>> result = ObfuscationEngine.apply(Collections.singletonList(ev), rules);
+
+        assertEquals(true, result.get(0).get("contentIsLive")); // still Boolean, not a String
+    }
+
+    @Test
+    public void nullValue_isSkipped_noNullPointerException() {
+        // A map entry with a null value must not throw — instanceof String returns false for null.
+        Map<String, Object> ev = new HashMap<>();
+        ev.put("contentId", null);
+        ev.put("contentSrc", "https://cdn.com/account-5/v.mp4");
+        List<ObfuscationRule> rules = rules("account-\\d+", "ACCOUNT_ID");
+
+        List<Map<String, Object>> result = ObfuscationEngine.apply(Collections.singletonList(ev), rules);
+
+        assertNull(result.get(0).get("contentId"));                              // null preserved
+        assertEquals("https://cdn.com/ACCOUNT_ID/v.mp4", result.get(0).get("contentSrc")); // string replaced
+    }
+
+    // =========================================================================
+    // 5. Immutability — originals must never be mutated
+    // =========================================================================
+
+    @Test
+    public void originalList_isNotMutated() {
+        List<Map<String, Object>> events = singleEvent("contentSrc", "cdn.com/account-1/v.mp4");
+        List<ObfuscationRule> rules = rules("account-\\d+", "ACCOUNT_ID");
+
+        ObfuscationEngine.apply(events, rules);
+
+        // The original list must still hold the unobfuscated value.
+        assertEquals("cdn.com/account-1/v.mp4", events.get(0).get("contentSrc"));
+    }
+
+    @Test
+    public void originalMaps_areNotMutated() {
+        Map<String, Object> original = event("contentSrc", "cdn.com/account-1/v.mp4");
+        List<ObfuscationRule> rules = rules("account-\\d+", "ACCOUNT_ID");
+
+        ObfuscationEngine.apply(Collections.singletonList(original), rules);
+
+        // The original map object must be untouched.
+        assertEquals("cdn.com/account-1/v.mp4", original.get("contentSrc"));
+    }
+
+    @Test
+    public void returnedList_isDifferentInstance() {
+        List<Map<String, Object>> events = singleEvent("contentSrc", "cdn.com/account-1/v.mp4");
+        List<ObfuscationRule> rules = rules("account-\\d+", "ACCOUNT_ID");
+
+        List<Map<String, Object>> result = ObfuscationEngine.apply(events, rules);
+
+        assertNotSame(events, result);           // different list
+        assertNotSame(events.get(0), result.get(0)); // different map
+    }
+
+    @Test
+    public void immutability_critical_deadLetterRetryGetsCleanOriginal() {
+        // Simulates what HarvestManager does: pass the same events list to sendEvents()
+        // and, on failure, to the dead-letter handler. The dead-letter handler must see
+        // unobfuscated values so the next retry obfuscates them correctly.
+        Map<String, Object> original = event("contentSrc", "cdn.com/account-99/v.mp4");
+        List<Map<String, Object>> events = Collections.singletonList(original);
+        List<ObfuscationRule> rules = rules("account-\\d+", "ACCOUNT_ID");
+
+        // Simulate first send attempt (obfuscate + send)
+        List<Map<String, Object>> firstAttempt = ObfuscationEngine.apply(events, rules);
+        assertEquals("cdn.com/ACCOUNT_ID/v.mp4", firstAttempt.get(0).get("contentSrc"));
+
+        // Simulate dead-letter retry: apply again on the ORIGINAL list
+        List<Map<String, Object>> retryAttempt = ObfuscationEngine.apply(events, rules);
+        assertEquals("cdn.com/ACCOUNT_ID/v.mp4", retryAttempt.get(0).get("contentSrc")); // still correct
+        assertEquals("cdn.com/account-99/v.mp4", events.get(0).get("contentSrc"));       // original clean
+    }
+
+    // =========================================================================
+    // 6. Corner cases
+    // =========================================================================
+
+    @Test
+    public void emptyStringValue_ruleDoesNotMatch_valueUnchanged() {
+        List<Map<String, Object>> events = singleEvent("contentTitle", "");
+        List<ObfuscationRule> rules = rules("account-\\d+", "ACCOUNT_ID");
+
+        List<Map<String, Object>> result = ObfuscationEngine.apply(events, rules);
+
+        assertEquals("", result.get(0).get("contentTitle"));
+    }
+
+    @Test
+    public void emptyReplacement_deletesMatchedContent() {
+        List<Map<String, Object>> events = singleEvent("url", "https://cdn.com/account-42/video");
+        List<ObfuscationRule> rules = rules("account-\\d+", "");
+
+        List<Map<String, Object>> result = ObfuscationEngine.apply(events, rules);
+
+        assertEquals("https://cdn.com//video", result.get(0).get("url"));
+    }
+
+    @Test
+    public void replacementWithDollarSign_treatedAsLiteral() {
+        // Without Matcher.quoteReplacement(), "$ID" would be treated as a back-reference
+        // and throw IllegalArgumentException or produce wrong output.
+        List<Map<String, Object>> events = singleEvent("contentSrc", "cdn.com/account-7/v.mp4");
+        List<ObfuscationRule> rules = rules("account-\\d+", "$ACCOUNT_ID");
+
+        List<Map<String, Object>> result = ObfuscationEngine.apply(events, rules);
+
+        // '$' must appear literally in the output, not cause an exception.
+        assertEquals("cdn.com/$ACCOUNT_ID/v.mp4", result.get(0).get("contentSrc"));
+    }
+
+    @Test
+    public void replacementWithBackslash_treatedAsLiteral() {
+        List<Map<String, Object>> events = singleEvent("contentSrc", "cdn.com/account-7/v.mp4");
+        List<ObfuscationRule> rules = rules("account-\\d+", "\\REDACTED");
+
+        List<Map<String, Object>> result = ObfuscationEngine.apply(events, rules);
+
+        assertEquals("cdn.com/\\REDACTED/v.mp4", result.get(0).get("contentSrc"));
+    }
+
+    @Test
+    public void eventWithOnlyNonStringValues_copiedAsIs() {
+        Map<String, Object> ev = new HashMap<>();
+        ev.put("bitrate",    5000000);
+        ev.put("timestamp",  1712345678000L);
+        ev.put("isLive",     false);
+        List<ObfuscationRule> rules = rules("\\d+", "REDACTED");
+
+        List<Map<String, Object>> result = ObfuscationEngine.apply(Collections.singletonList(ev), rules);
+
+        assertEquals(5000000,          result.get(0).get("bitrate"));
+        assertEquals(1712345678000L,   result.get(0).get("timestamp"));
+        assertEquals(false,            result.get(0).get("isLive"));
+    }
+
+    @Test
+    public void mixedBatch_regularAndQoeEvents_allObfuscated() {
+        // Simulates the real harvest batch: regular events + QOE event injected afterwards.
+        Map<String, Object> contentStart = new HashMap<>();
+        contentStart.put("eventType", "CONTENT_START");
+        contentStart.put("contentSrc", "https://cdn.com/account-10/video.mp4");
+
+        Map<String, Object> qoeEvent = new HashMap<>();
+        qoeEvent.put("eventType", "QOE_AGGREGATE");
+        qoeEvent.put("contentSrc", "https://cdn.com/account-10/video.mp4");
+        qoeEvent.put("totalPlaytime", 30000L); // Long — must not be touched
+
+        List<Map<String, Object>> batch = Arrays.asList(contentStart, qoeEvent);
+        List<ObfuscationRule> rules = rules("account-\\d+", "ACCOUNT_ID");
+
+        List<Map<String, Object>> result = ObfuscationEngine.apply(batch, rules);
+
+        assertEquals("https://cdn.com/ACCOUNT_ID/video.mp4", result.get(0).get("contentSrc"));
+        assertEquals("https://cdn.com/ACCOUNT_ID/video.mp4", result.get(1).get("contentSrc"));
+        assertEquals(30000L, result.get(1).get("totalPlaytime")); // Long untouched
+    }
+
+    @Test
+    public void resultListHasSameSizeAsInput() {
+        List<Map<String, Object>> events = Arrays.asList(
+            event("contentSrc", "cdn.com/account-1/v.mp4"),
+            event("contentSrc", "cdn.com/account-2/v.mp4"),
+            event("contentSrc", "cdn.com/account-3/v.mp4")
+        );
+        List<ObfuscationRule> rules = rules("account-\\d+", "ACCOUNT_ID");
+
+        List<Map<String, Object>> result = ObfuscationEngine.apply(events, rules);
+
+        assertEquals(3, result.size());
+    }
+
+    // =========================================================================
+    // 7. Realistic end-to-end scenarios
+    // =========================================================================
+
+    @Test
+    public void scenario_maskUserIdInUrl() {
+        List<Map<String, Object>> events = singleEvent(
+            "contentSrc", "https://stream.example.com/users/john_doe_123/live.m3u8"
+        );
+        List<ObfuscationRule> rules = rules("/users/[^\"/]+", "/users/USER_ID");
+
+        List<Map<String, Object>> result = ObfuscationEngine.apply(events, rules);
+
+        assertEquals(
+            "https://stream.example.com/users/USER_ID/live.m3u8",
+            result.get(0).get("contentSrc")
+        );
+    }
+
+    @Test
+    public void scenario_maskAuthToken() {
+        List<Map<String, Object>> events = singleEvent(
+            "contentSrc", "https://cdn.com/video.mp4?token=eyJhbGciOiJIUzI1NiJ9&quality=HD"
+        );
+        List<ObfuscationRule> rules = rules("token=[^&\"]+", "token=REDACTED");
+
+        List<Map<String, Object>> result = ObfuscationEngine.apply(events, rules);
+
+        assertEquals(
+            "https://cdn.com/video.mp4?token=REDACTED&quality=HD",
+            result.get(0).get("contentSrc")
+        );
+    }
+
+    @Test
+    public void scenario_threeRulesOnRealWorldEvent() {
+        Map<String, Object> ev = new HashMap<>();
+        ev.put("eventType",    "CONTENT_START");
+        ev.put("contentSrc",   "https://cdn.com/account-42/users/jane/token=secret99&q=HD");
+        ev.put("contentTitle", "Premium content for account-42");
+        ev.put("bitrate",      4500000); // non-string, must be untouched
+        ev.put("timestamp",    1712345678000L);
+
+        List<ObfuscationRule> rules = Arrays.asList(
+            new ObfuscationRule("account-\\d+",  "ACCOUNT_ID"),
+            new ObfuscationRule("/users/[^/\"?&]+", "/users/USER_ID"),
+            new ObfuscationRule("token=[^&\"]+", "token=REDACTED")
+        );
+
+        List<Map<String, Object>> result = ObfuscationEngine.apply(Collections.singletonList(ev), rules);
+        Map<String, Object> out = result.get(0);
+
+        assertEquals("CONTENT_START", out.get("eventType")); // no match
+        assertEquals(
+            "https://cdn.com/ACCOUNT_ID/users/USER_ID/token=REDACTED&q=HD",
+            out.get("contentSrc")
+        );
+        assertEquals("Premium content for ACCOUNT_ID",  out.get("contentTitle"));
+        assertEquals(4500000,          out.get("bitrate"));    // Integer untouched
+        assertEquals(1712345678000L,   out.get("timestamp"));  // Long untouched
+    }
+
+    // =========================================================================
+    // Helpers — keep test bodies readable
+    // =========================================================================
+
+    /** Creates a single-entry event list with one key-value pair. */
+    private List<Map<String, Object>> singleEvent(String key, Object value) {
+        return Collections.singletonList(event(key, value));
+    }
+
+    /** Creates a single event map with one key-value pair. */
+    private Map<String, Object> event(String key, Object value) {
+        Map<String, Object> map = new HashMap<>();
+        map.put(key, value);
+        return map;
+    }
+
+    /** Creates a single-rule list from a pattern and replacement string. */
+    private List<ObfuscationRule> rules(String pattern, String replacement) {
+        return Collections.singletonList(new ObfuscationRule(pattern, replacement));
+    }
+}

--- a/NewRelicVideoCore/src/test/java/com/newrelic/videoagent/core/ObfuscationRuleTest.java
+++ b/NewRelicVideoCore/src/test/java/com/newrelic/videoagent/core/ObfuscationRuleTest.java
@@ -1,0 +1,146 @@
+package com.newrelic.videoagent.core;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for ObfuscationRule construction and validation.
+ *
+ * These are pure JUnit 4 tests — no Android context needed because ObfuscationRule
+ * only uses java.util.regex.Pattern, which is plain Java.
+ */
+public class ObfuscationRuleTest {
+
+    // -------------------------------------------------------------------------
+    // Happy path
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void validRule_compilesSuccessfully() {
+        ObfuscationRule rule = new ObfuscationRule("account-\\d+", "ACCOUNT_ID");
+
+        assertNotNull(rule.regex);
+        assertEquals("ACCOUNT_ID", rule.replacement);
+    }
+
+    @Test
+    public void validRule_emptyReplacement_isAllowed() {
+        // Empty string means "delete matches" — a legitimate use case.
+        ObfuscationRule rule = new ObfuscationRule("secret-\\w+", "");
+
+        assertNotNull(rule.regex);
+        assertEquals("", rule.replacement);
+    }
+
+    @Test
+    public void validRule_replacementWithDollarSign_isAllowed() {
+        // '$' is special in Java regex replacements, but ObfuscationEngine guards against
+        // that with Matcher.quoteReplacement(). The rule itself should accept any string.
+        ObfuscationRule rule = new ObfuscationRule("price-\\d+", "$PRICE");
+
+        assertEquals("$PRICE", rule.replacement);
+    }
+
+    @Test
+    public void validRule_replacementWithBackslash_isAllowed() {
+        // Same as above — '\' is special in replacements but quoteReplacement handles it.
+        ObfuscationRule rule = new ObfuscationRule("path-\\w+", "\\REDACTED");
+
+        assertEquals("\\REDACTED", rule.replacement);
+    }
+
+    @Test
+    public void validRule_complexPattern_compilesSuccessfully() {
+        // A realistic URL masking pattern
+        ObfuscationRule rule = new ObfuscationRule("/users/[^\"/]+", "/users/USER_ID");
+
+        assertNotNull(rule.regex);
+        // Verify the compiled regex actually matches what we expect
+        assertTrue(rule.regex.matcher("/users/john_doe/profile").find());
+        assertFalse(rule.regex.matcher("/products/shoes").find());
+    }
+
+    @Test
+    public void validRule_patternWithFlags_compilesSuccessfully() {
+        // Patterns with inline flags like (?i) for case-insensitive
+        ObfuscationRule rule = new ObfuscationRule("(?i)token=[^&]+", "token=REDACTED");
+
+        assertNotNull(rule.regex);
+        assertTrue(rule.regex.matcher("TOKEN=abc123").find());
+        assertTrue(rule.regex.matcher("token=abc123").find());
+    }
+
+    // -------------------------------------------------------------------------
+    // Null / empty pattern
+    // -------------------------------------------------------------------------
+
+    @Test(expected = IllegalArgumentException.class)
+    public void nullPattern_throwsIllegalArgumentException() {
+        new ObfuscationRule(null, "REPLACEMENT");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void emptyPattern_throwsIllegalArgumentException() {
+        new ObfuscationRule("", "REPLACEMENT");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void blankPattern_whitespaceOnly_throwsIllegalArgumentException() {
+        // "   " is technically non-empty but trim() makes it empty — should still reject.
+        new ObfuscationRule("   ", "REPLACEMENT");
+    }
+
+    // -------------------------------------------------------------------------
+    // Null replacement
+    // -------------------------------------------------------------------------
+
+    @Test(expected = IllegalArgumentException.class)
+    public void nullReplacement_throwsIllegalArgumentException() {
+        // null replacement would NPE silently at apply time — reject it eagerly.
+        new ObfuscationRule("account-\\d+", null);
+    }
+
+    // -------------------------------------------------------------------------
+    // Invalid regex
+    // -------------------------------------------------------------------------
+
+    @Test(expected = IllegalArgumentException.class)
+    public void invalidRegex_unclosedGroup_throwsIllegalArgumentException() {
+        // "(unclosed" is a malformed regex — should fail at construction, not at harvest.
+        new ObfuscationRule("(unclosed", "REPLACEMENT");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void invalidRegex_danglingQuantifier_throwsIllegalArgumentException() {
+        // "*" with nothing to quantify is invalid
+        new ObfuscationRule("*invalid", "REPLACEMENT");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void invalidRegex_unclosedBracket_throwsIllegalArgumentException() {
+        new ObfuscationRule("[unclosed", "REPLACEMENT");
+    }
+
+    // -------------------------------------------------------------------------
+    // Pattern correctness (verify the compiled regex behaves as expected)
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void compiledPattern_matchesExpectedInput() {
+        ObfuscationRule rule = new ObfuscationRule("account-\\d+", "ACCOUNT_ID");
+
+        assertTrue(rule.regex.matcher("account-83729").matches());
+        assertTrue(rule.regex.matcher("account-1").matches());
+        assertFalse(rule.regex.matcher("account-abc").matches()); // letters, not digits
+        assertFalse(rule.regex.matcher("account-").matches());    // no digits at all
+    }
+
+    @Test
+    public void compiledPattern_tokenMasking_matchesExpectedInput() {
+        ObfuscationRule rule = new ObfuscationRule("token=[^&\"]+", "token=REDACTED");
+
+        assertTrue(rule.regex.matcher("token=abc123xyz").find());
+        assertFalse(rule.regex.matcher("token=").find()); // empty value — no match
+    }
+}

--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ To start the video agent with ExoPlayer tracker only:
 NRVideoConfiguration config = new NRVideoConfiguration.Builder("application-token")
         .autoDetectPlatform(getApplicationContext())
         .withHarvestCycle(5*60) //This is in seconds, for ondemand video, please use minimum 5 minutes
+        .enableQoeAggregate(true) // Optional: Enable QoE metrics (disabled by default)
+        .withQoeAggregateIntervalMultiplier(2) // Optional: Send QoE every 2nd harvest cycle (default: 1)
         .build();
 NRVideo.newBuilder(getApplicationContext()).withConfiguration(config).build();
 
@@ -167,8 +169,18 @@ builder.setAdEventListener(adTracker.getAdEventListener());
 - **`harvestCycleSeconds`**  
   Interval \(in seconds\) between regular data harvests\. Controls how often data is sent to the New Relic\. Typical values range from 300 to 600 seconds\.
 
-- **`liveHarvestCycleSeconds`**  
+- **`liveHarvestCycleSeconds`**
   Interval \(in seconds\) for live stream data harvests\. Used for real\-time or near\-real\-time data transmission\. Valid range is 30 to 60 seconds\.
+
+- **`enableQoeAggregate`**
+  Enables Quality of Experience \(QoE\) aggregate metrics collection and reporting\. When enabled, the agent generates `QOE_AGGREGATE` events containing KPIs such as startup time, average bitrate, rebuffering metrics, and playback failures\. **Default: `false`** \(QoE is disabled by default and must be explicitly enabled\)\.
+
+- **`qoeAggregateIntervalMultiplier`**
+  Controls the frequency of QoE aggregate event generation as a multiplier of the harvest cycle\. For example:
+  - `1` = QoE generated every harvest cycle \(cycles 1, 2, 3, 4\.\.\.\)
+  - `2` = QoE generated every other harvest cycle \(cycles 1, 3, 5, 7\.\.\.\)
+  - `3` = QoE generated every third harvest cycle \(cycles 1, 4, 7, 10\.\.\.\)
+  **Default: `1`** \(QoE generated every harvest cycle when enabled\)\. Only applies when `enableQoeAggregate` is `true`\.
 
 **`NRVideoPlayerConfiguration.java`**
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The New Relic Video Agent for Android contains multiple modules necessary to ins
 - **Quality of Experience (QoE) Metrics** - Optional aggregate KPIs including startup time, bitrate, and rebuffering ratio
 - **Configurable Harvest Cycles** - Control data transmission frequency for regular and live streaming content
 - **Crash-Safe Buffering** - Events are persisted and retried on network failures
+- **Obfuscation Rules** - Regex-based masking of sensitive data (user IDs, tokens, account numbers) before events leave the device
 
 ## Modules
 
@@ -173,6 +174,42 @@ NRVideo.newBuilder(getApplicationContext()).withConfiguration(config).build();
 </p>
 </details>
 
+To mask sensitive data using obfuscation rules:
+
+<details>
+<summary>Java</summary>
+<p>
+
+```java
+import com.newrelic.videoagent.core.ObfuscationRule;
+import java.util.Arrays;
+import java.util.List;
+
+// Define rules — each rule is a regex pattern and a replacement string.
+// Rules are applied in order on every string attribute of every outgoing event.
+List<ObfuscationRule> obfuscationRules = Arrays.asList(
+    // Mask account IDs:  "account-83729"  →  "ACCOUNT_ID"
+    new ObfuscationRule("account-\\d+", "ACCOUNT_ID"),
+
+    // Mask auth tokens:  "token=abc123xyz"  →  "token=REDACTED"
+    new ObfuscationRule("token=[^&\"]+", "token=REDACTED"),
+
+    // Mask user path segments:  "/users/john_doe"  →  "/users/USER_ID"
+    new ObfuscationRule("/users/[^\"/]+", "/users/USER_ID")
+);
+
+NRVideoConfiguration config = new NRVideoConfiguration.Builder("application-token")
+        .autoDetectPlatform(getApplicationContext())
+        .withHarvestCycle(5 * 60)
+        .withObfuscationRules(obfuscationRules)
+        .build();
+
+NRVideo.newBuilder(getApplicationContext()).withConfiguration(config).build();
+```
+
+</p>
+</details>
+
 To start the video agent with ExoPlayer and IMA trackers:
 
 <details>
@@ -221,6 +258,9 @@ builder.setAdEventListener(adTracker.getAdEventListener());
   - `3` = QoE generated every third harvest cycle \(cycles 1, 4, 7, 10\.\.\.\)
   **Default: `1`** \(QoE generated every harvest cycle when enabled\)\. Only applies when `enableQoeAggregate` is `true`\.
 
+- **`obfuscationRules`**
+  A list of `ObfuscationRule` objects applied to every string attribute of every outgoing event immediately before HTTP transmission\. Each rule is a compiled regex pattern and a plain\-string replacement\. Rules run in the order they are declared — the output of one rule feeds into the next\. **Default: empty list** \(no obfuscation\)\.
+
 ### Quality of Experience (QoE) Metrics
 
 When `enableQoeAggregate` is enabled, the agent generates `QOE_AGGREGATE` events containing the following KPIs:
@@ -254,6 +294,64 @@ D/NRVideoTracker: QOE_AGGREGATE generated for harvest cycle 1 (KPIs changed)
 D/HarvestManager: QOE_AGGREGATE injected into harvest batch (cycle 1)
 D/NRVideoTracker: QOE_AGGREGATE skipped for harvest cycle 2 (no KPI changes)
 ```
+
+### Obfuscation Rules
+
+Obfuscation rules let you mask sensitive data — user IDs, auth tokens, account numbers, PII in URLs — before events are transmitted to New Relic. Rules are applied at send time, so no sensitive data is written to the in-memory buffer, SQLite crash-recovery storage, or the dead-letter retry queue.
+
+#### How it works
+
+1. You define a list of `ObfuscationRule` objects, each with a regex pattern and a replacement string.
+2. Pass the list to `.withObfuscationRules()` on the config builder.
+3. Just before each HTTP transmission, `ObfuscationEngine` iterates every string attribute of every event in the batch and applies the rules in order.
+4. Only string values are processed — integers, longs, booleans, and nulls are passed through unchanged.
+5. The original event objects are never mutated, so failed batches can be retried cleanly without double-obfuscation.
+
+#### `ObfuscationRule` constructor
+
+```java
+new ObfuscationRule(String pattern, String replacement)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `pattern` | `String` | A Java regex pattern string. Compiled eagerly — an invalid pattern throws `IllegalArgumentException` at construction time. |
+| `replacement` | `String` | The string to substitute for each match. Use `""` to delete matches. `$` and `\` are treated as plain characters, not back-references. |
+
+#### Common patterns
+
+| What to mask | Pattern | Replacement |
+|---|---|---|
+| Numeric account IDs | `account-\\d+` | `ACCOUNT_ID` |
+| Auth / bearer tokens | `token=[^&\"]+` | `token=REDACTED` |
+| User path segments | `/users/[^\"/]+` | `/users/USER_ID` |
+| Email addresses | `[a-zA-Z0-9._%+\\-]+@[a-zA-Z0-9.\\-]+\\.[a-zA-Z]{2,}` | `EMAIL_REDACTED` |
+| UUIDs | `[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}` | `UUID_REDACTED` |
+
+#### Rule ordering
+
+Rules are applied left-to-right. The output of rule N becomes the input of rule N+1. Order matters when one rule's replacement could match a later rule's pattern.
+
+```java
+// Rule 1 turns "/john" into "/USER", then Rule 2 sees "/USER_profile" and masks it.
+new ObfuscationRule("john", "USER"),
+new ObfuscationRule("USER_profile", "PROFILE")
+// Result: "/john_profile" → "/USER_profile" → "/PROFILE"
+```
+
+#### Edge cases
+
+| Situation | Behaviour |
+|-----------|-----------|
+| No rules configured | No-op — zero overhead, original list returned as-is |
+| Pattern matches nothing | Value is passed through unchanged |
+| Empty replacement `""` | Matched content is deleted |
+| `$` or `\` in replacement | Treated as plain characters (not regex back-references) |
+| Integer / Long / Boolean value | Skipped — only `String` values are processed |
+| `null` value | Skipped — no NullPointerException |
+| Invalid regex pattern | `IllegalArgumentException` thrown at `new ObfuscationRule(...)` construction — fails fast at startup, not silently at harvest time |
+| `null` replacement | `IllegalArgumentException` thrown at construction |
+| HTTP send fails → dead-letter retry | Original (unobfuscated) events are retried; obfuscation is re-applied correctly on the retry pass |
 
 **`NRVideoPlayerConfiguration.java`**
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,15 @@
 
 # New Relic Video Agent for Android
 
-
 The New Relic Video Agent for Android contains multiple modules necessary to instrument video players and send data to New Relic.
+
+## Features
+
+- **Comprehensive Video Tracking** - Automatic instrumentation for content playback, buffering, seeking, and errors
+- **Ad Tracking** - Support for Google IMA ad tracking with pre-roll, mid-roll, and post-roll ads
+- **Quality of Experience (QoE) Metrics** - Optional aggregate KPIs including startup time, bitrate, and rebuffering ratio
+- **Configurable Harvest Cycles** - Control data transmission frequency for regular and live streaming content
+- **Crash-Safe Buffering** - Events are persisted and retried on network failures
 
 ## Modules
 
@@ -107,12 +114,16 @@ To start the video agent with ExoPlayer tracker only:
 
 ```Java
 // Step 1: Initialize the NRVideo at main activity. i.e MainActivity.java
+// Basic configuration (QoE disabled by default):
 NRVideoConfiguration config = new NRVideoConfiguration.Builder("application-token")
         .autoDetectPlatform(getApplicationContext())
-        .withHarvestCycle(5*60) //This is in seconds, for ondemand video, please use minimum 5 minutes
-        .enableQoeAggregate(true) // Optional: Enable QoE metrics (disabled by default)
-        .withQoeAggregateIntervalMultiplier(2) // Optional: Send QoE every 2nd harvest cycle (default: 1)
+        .withHarvestCycle(5*60) // This is in seconds, for ondemand video, please use minimum 5 minutes
         .build();
+
+// Optional: Enable QoE aggregate metrics:
+// .enableQoeAggregate(true) // Enables QoE KPIs (disabled by default)
+// .withQoeAggregateIntervalMultiplier(2) // Send QoE every 2nd harvest cycle (default: 1)
+
 NRVideo.newBuilder(getApplicationContext()).withConfiguration(config).build();
 
 //Step 2: Initialize the player(it could have n number of players in your application). i.e VideoPlayer.java
@@ -129,6 +140,34 @@ void onDestroy() {
     NRVideo.releaseTracker(trackerId);
     player.stop();
 }
+```
+
+</p>
+</details>
+
+To enable Quality of Experience (QoE) aggregate metrics:
+
+<details>
+<summary>Java</summary>
+<p>
+
+```Java
+// Initialize with QoE enabled
+NRVideoConfiguration config = new NRVideoConfiguration.Builder("application-token")
+        .autoDetectPlatform(getApplicationContext())
+        .withHarvestCycle(5*60) // 5 minutes for on-demand content
+        .enableQoeAggregate(true) // Enable QoE KPIs
+        .withQoeAggregateIntervalMultiplier(1) // Send QoE every harvest cycle (default)
+        .build();
+NRVideo.newBuilder(getApplicationContext()).withConfiguration(config).build();
+
+// QoE events (QOE_AGGREGATE) will now be generated containing:
+// - startupTime, peakBitrate, averageBitrate, totalPlaytime
+// - totalRebufferingTime, rebufferingRatio
+// - hadStartupFailure, hadPlaybackFailure
+
+// Query QoE data in NRDB:
+// SELECT * FROM VideoAction WHERE actionName = 'QOE_AGGREGATE' SINCE 1 hour ago
 ```
 
 </p>
@@ -181,6 +220,40 @@ builder.setAdEventListener(adTracker.getAdEventListener());
   - `2` = QoE generated every other harvest cycle \(cycles 1, 3, 5, 7\.\.\.\)
   - `3` = QoE generated every third harvest cycle \(cycles 1, 4, 7, 10\.\.\.\)
   **Default: `1`** \(QoE generated every harvest cycle when enabled\)\. Only applies when `enableQoeAggregate` is `true`\.
+
+### Quality of Experience (QoE) Metrics
+
+When `enableQoeAggregate` is enabled, the agent generates `QOE_AGGREGATE` events containing the following KPIs:
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `startupTime` | Long (ms) | Time from `CONTENT_REQUEST` to `CONTENT_START`, minus ad time and pause time |
+| `peakBitrate` | Long (bps) | Highest observed bitrate during the session |
+| `averageBitrate` | Long (bps) | Time-weighted average bitrate during active playback (excludes pause, buffer, seek time) |
+| `totalPlaytime` | Long (ms) | Total content playtime excluding pause, buffer, and seek; computed in real-time at harvest |
+| `totalRebufferingTime` | Long (ms) | Total duration of all rebuffering events (excludes initial buffer) |
+| `rebufferingRatio` | Double (%) | Percentage of playtime spent rebuffering: `(totalRebufferingTime / totalPlaytime) * 100` |
+| `hadStartupFailure` | Boolean | `true` if an error occurred before `CONTENT_START` |
+| `hadPlaybackFailure` | Boolean | `true` if an error occurred after `CONTENT_START` |
+
+#### How QoE Works
+
+**Architecture**:
+
+1. **Early Registration** - QoE provider registers at `CONTENT_REQUEST` (not `CONTENT_START`) to capture startup failures even if content never starts
+2. **Harvest-Time Generation** - QoE events are generated at harvest time based on real-time metrics, not buffered with regular events
+3. **Dirty Check** - QoE events are only sent when KPI values have changed since the last send, reducing unnecessary data transmission
+4. **Independent Send** - QoE sends independently on qualified harvest cycles regardless of whether other VideoAction events are present
+5. **Bitrate Timer** - Automatically pauses during non-play states (pause, buffer, seek) for accurate time-weighted average bitrate calculation
+6. **Final QoE** - Built eagerly at `CONTENT_END` while tracker state is still valid, ensuring no data loss at session end
+
+**Example Log Output:**
+```
+D/NRVideoTracker: QOE provider registered at CONTENT_REQUEST
+D/NRVideoTracker: QOE_AGGREGATE generated for harvest cycle 1 (KPIs changed)
+D/HarvestManager: QOE_AGGREGATE injected into harvest batch (cycle 1)
+D/NRVideoTracker: QOE_AGGREGATE skipped for harvest cycle 2 (no KPI changes)
+```
 
 **`NRVideoPlayerConfiguration.java`**
 


### PR DESCRIPTION
## Summary

- Adds regex-based obfuscation rules that mask sensitive data (user IDs, tokens, account numbers, PII in URLs) before events are transmitted to New Relic
- Introduces `ObfuscationRule` (pattern + replacement pair) and `ObfuscationEngine` (applies rules to event batches)
- Hooks into `OptimizedHttpClient.sendEvents()` — the single convergence point for all event paths (regular events, QOE, crash recovery, dead-letter retries)
- Rules are applied to copied event maps, not originals, so failed batches retry cleanly without double-obfuscation