### PR TITLE
fix: Add Obfuscation Rules Feature

### DIFF
--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/NRVideoConfiguration.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/NRVideoConfiguration.java
@@ -6,7 +6,10 @@ import android.content.pm.PackageManager;
 import com.newrelic.videoagent.core.utils.NRLog;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -45,6 +48,9 @@ public final class NRVideoConfiguration {
     private final boolean isTV;
     private final String collectorAddress;
     private final int qoeAggregateIntervalMultiplier;
+    // React analogy: this is like a frozen array in JS — Collections.unmodifiableList()
+    // means nobody can accidentally push() to it after the config is built.
+    private final List<ObfuscationRule> obfuscationRules;
 
     // Runtime configuration fields (mutable, thread-safe) - Using AtomicBoolean for better performance
     private final AtomicBoolean qoeAggregateEnabled = new AtomicBoolean(false);
@@ -88,6 +94,11 @@ public final class NRVideoConfiguration {
         this.isTV = builder.isTV;
         this.collectorAddress = builder.collectorAddress;
         this.qoeAggregateIntervalMultiplier = builder.qoeAggregateIntervalMultiplier;
+        // Make a defensive copy and wrap it as unmodifiable.
+        // React analogy: like Object.freeze([...builder.obfuscationRules]) — same idea.
+        this.obfuscationRules = Collections.unmodifiableList(
+            new ArrayList<>(builder.obfuscationRules)
+        );
 
         // Initialize runtime configuration
         this.qoeAggregateEnabled.set(builder.qoeAggregateEnabled);
@@ -107,6 +118,7 @@ public final class NRVideoConfiguration {
     public boolean isTV() { return isTV; }
     public String getCollectorAddress() { return collectorAddress; }
     public int getQoeAggregateIntervalMultiplier() { return qoeAggregateIntervalMultiplier; }
+    public List<ObfuscationRule> getObfuscationRules() { return obfuscationRules; }
 
     // Runtime configuration getters and setters
     /**
@@ -236,6 +248,8 @@ public final class NRVideoConfiguration {
         private String collectorAddress = null;
         private boolean qoeAggregateEnabled = false; // Default disabled
         private int qoeAggregateIntervalMultiplier = 1; // Default 1 (send every harvest cycle)
+        // React analogy: this starts as an empty array [] — no rules by default.
+        private List<ObfuscationRule> obfuscationRules = new ArrayList<>();
 
         public Builder(String applicationToken) {
             this.applicationToken = applicationToken;
@@ -358,6 +372,22 @@ public final class NRVideoConfiguration {
                 this.qoeAggregateIntervalMultiplier = multiplier;
             }
             return this;
+        }
+
+        /**
+         * Set regex-based rules to mask sensitive data before events are transmitted.
+         * Rules are applied in order — each rule's output becomes the next rule's input.
+         *
+         * React analogy: this is like passing an array prop to a component:
+         *   <VideoAgent obfuscationRules={[{ pattern: "account-\\d+", replacement: "ACCOUNT_ID" }]} />
+         *
+         * @param rules List of ObfuscationRule objects. Pass an empty list to disable obfuscation.
+         */
+        public Builder withObfuscationRules(List<ObfuscationRule> rules) {
+            if (rules != null) {
+                this.obfuscationRules = rules;
+            }
+            return this; // returning 'this' is what makes the dot-chaining work
         }
 
         private void applyTVOptimizations() {

--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/ObfuscationEngine.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/ObfuscationEngine.java
@@ -52,8 +52,8 @@ public class ObfuscationEngine {
                         try {
                             // quoteReplacement treats '$' and '\' in the replacement as
                             // plain characters, not regex back-references.
-                            value = rule.regex.matcher(value)
-                                              .replaceAll(Matcher.quoteReplacement(rule.replacement));
+                            value = rule.getRegex().matcher(value)
+                                              .replaceAll(Matcher.quoteReplacement(rule.getReplacement()));
                         } catch (Exception e) {
                             NRLog.w("ObfuscationEngine: rule failed on key '"
                                     + entry.getKey() + "': " + e.getMessage());

--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/ObfuscationEngine.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/ObfuscationEngine.java
@@ -1,0 +1,72 @@
+package com.newrelic.videoagent.core;
+
+import com.newrelic.videoagent.core.utils.NRLog;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+
+/**
+ * Applies a list of ObfuscationRules to a batch of events.
+ *
+ * Extracted into its own class so it can be unit-tested independently of
+ * OptimizedHttpClient (which requires Android context, HTTP connections, etc.).
+ */
+public class ObfuscationEngine {
+
+    // Static utility class — no instances needed.
+    private ObfuscationEngine() {}
+
+    /**
+     * Returns a new list of events with all obfuscation rules applied to every
+     * string-valued attribute. The original list and maps are never modified.
+     *
+     * @param events The raw event batch (may include QOE, regular, dead-letter events).
+     * @param rules  The rules from NRVideoConfiguration. Empty list is a no-op.
+     * @return A new list with obfuscated copies, or the original list if rules is empty.
+     */
+    public static List<Map<String, Object>> apply(
+            List<Map<String, Object>> events,
+            List<ObfuscationRule> rules) {
+
+        if (rules == null || rules.isEmpty()) {
+            return events; // fast path — zero overhead when not configured
+        }
+        if (events == null || events.isEmpty()) {
+            return events;
+        }
+
+        List<Map<String, Object>> result = new ArrayList<>(events.size());
+
+        for (Map<String, Object> event : events) {
+            // Shallow copy — safe because String is immutable (same in Java and JS).
+            Map<String, Object> copy = new HashMap<>(event);
+
+            for (Map.Entry<String, Object> entry : copy.entrySet()) {
+                if (entry.getValue() instanceof String) {
+                    String value = (String) entry.getValue();
+
+                    for (ObfuscationRule rule : rules) {
+                        try {
+                            // quoteReplacement treats '$' and '\' in the replacement as
+                            // plain characters, not regex back-references.
+                            value = rule.regex.matcher(value)
+                                              .replaceAll(Matcher.quoteReplacement(rule.replacement));
+                        } catch (Exception e) {
+                            NRLog.w("ObfuscationEngine: rule failed on key '"
+                                    + entry.getKey() + "': " + e.getMessage());
+                        }
+                    }
+
+                    entry.setValue(value);
+                }
+            }
+
+            result.add(copy);
+        }
+
+        return result;
+    }
+}

--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/ObfuscationRule.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/ObfuscationRule.java
@@ -1,0 +1,52 @@
+package com.newrelic.videoagent.core;
+
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+/**
+ * A single obfuscation rule — a regex pattern paired with a replacement string.
+ *
+ * React analogy: think of this as a TypeScript type:
+ *   type ObfuscationRule = { regex: RegExp; replacement: string }
+ *
+ * Usage:
+ *   new ObfuscationRule("account-\\d+", "ACCOUNT_ID")
+ *   new ObfuscationRule("/users/[^\"/]+", "/users/USER_ID")
+ *   new ObfuscationRule("token=[^&\"]+", "token=REDACTED")
+ */
+public class ObfuscationRule {
+
+    // 'final' in Java == 'const' in JS — these fields can never be reassigned after construction.
+    public final Pattern regex;
+    public final String replacement;
+
+    /**
+     * @param pattern     Regex pattern string, e.g. "account-\\d+"
+     *                    Note: Java strings need double-backslash for regex escapes,
+     *                    same as writing new RegExp("account-\\d+") in JS.
+     * @param replacement String to substitute for each match, e.g. "ACCOUNT_ID".
+     *                    Pass "" (empty string) to delete matched content entirely.
+     */
+    public ObfuscationRule(String pattern, String replacement) {
+        if (pattern == null || pattern.trim().isEmpty()) {
+            throw new IllegalArgumentException("ObfuscationRule: pattern cannot be null or empty");
+        }
+        if (replacement == null) {
+            // We allow "" (delete matches) but not null — null would NPE at apply time.
+            throw new IllegalArgumentException("ObfuscationRule: replacement cannot be null. Use \"\" to delete matches.");
+        }
+
+        this.replacement = replacement;
+
+        // Compile the regex eagerly here in the constructor.
+        // React analogy: like validating props in a constructor — fail fast at setup time,
+        // not silently during a harvest cycle when an event is about to be sent.
+        try {
+            this.regex = Pattern.compile(pattern);
+        } catch (PatternSyntaxException e) {
+            throw new IllegalArgumentException(
+                "ObfuscationRule: invalid regex pattern \"" + pattern + "\": " + e.getMessage(), e
+            );
+        }
+    }
+}

--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/ObfuscationRule.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/ObfuscationRule.java
@@ -17,8 +17,8 @@ import java.util.regex.PatternSyntaxException;
 public class ObfuscationRule {
 
     // 'final' in Java == 'const' in JS — these fields can never be reassigned after construction.
-    public final Pattern regex;
-    public final String replacement;
+    private final Pattern regex;
+    private final String replacement;
 
     /**
      * @param pattern     Regex pattern string, e.g. "account-\\d+"
@@ -48,5 +48,13 @@ public class ObfuscationRule {
                 "ObfuscationRule: invalid regex pattern \"" + pattern + "\": " + e.getMessage(), e
             );
         }
+    }
+
+    public Pattern getRegex() {
+        return regex;
+    }
+
+    public String getReplacement() {
+        return replacement;
     }
 }

--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/harvest/OptimizedHttpClient.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/harvest/OptimizedHttpClient.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import java.util.HashMap;
 import java.util.Arrays;
 import java.util.zip.GZIPOutputStream;
+import com.newrelic.videoagent.core.ObfuscationEngine;
 
 /**
  * Optimized HTTP client for mobile/TV environments
@@ -89,8 +90,19 @@ public class OptimizedHttpClient implements HttpClientInterface {
             return true;
         }
 
-        // Attempt to send with immediate retries
-        return sendEventsWithRetry(events);
+        // Apply obfuscation rules to a COPY of the events before sending.
+        //
+        // React analogy: like doing const safeEvents = events.map(e => mask(e)) before
+        // calling fetch() — the original array stays untouched.
+        //
+        // Why a copy and not mutating in place?
+        // If sendEventsWithRetry() fails, HarvestManager passes the same list to the
+        // dead letter handler for retry. If we had mutated in place, the retry would
+        // run obfuscation again on already-obfuscated values — double masking.
+        // By working on a copy, the original list stays clean for any retry path.
+        List<Map<String, Object>> safeEvents = ObfuscationEngine.apply(events, configuration.getObfuscationRules());
+
+        return sendEventsWithRetry(safeEvents);
     }
 
     private boolean sendEventsWithRetry(List<Map<String, Object>> events) {
@@ -159,6 +171,13 @@ public class OptimizedHttpClient implements HttpClientInterface {
 
             List<Object> payload = new ArrayList<>();
             payload.add(appToken);
+
+            // Build device metadata map
+            HashMap<String, Object> deviceMetadata = new HashMap<>();
+            deviceMetadata.put("size", deviceInfo.getSize());
+            deviceMetadata.put("platform", deviceInfo.getApplicationFramework());
+            deviceMetadata.put("platformVersion", deviceInfo.getApplicationFrameworkVersion());
+
             payload.add(Arrays.asList(
                     deviceInfo.getOsName(),
                     deviceInfo.getOsVersion(),
@@ -169,11 +188,7 @@ public class OptimizedHttpClient implements HttpClientInterface {
                     "",
                     "",
                     deviceInfo.getManufacturer(),
-                    new HashMap<String, Object>() {{
-                        put("size", deviceInfo.getSize());
-                        put("platform", deviceInfo.getApplicationFramework());
-                        put("platformVersion", deviceInfo.getApplicationFrameworkVersion());
-                    }}
+                    deviceMetadata
             ));
             payload.add(0);
             payload.add(new ArrayList<>()); // []

--- a/NewRelicVideoCore/src/test/java/com/newrelic/videoagent/core/ObfuscationEngineTest.java
+++ b/NewRelicVideoCore/src/test/java/com/newrelic/videoagent/core/ObfuscationEngineTest.java
@@ -1,0 +1,473 @@
+package com.newrelic.videoagent.core;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for ObfuscationEngine.apply() — the core logic that masks event attributes.
+ *
+ * Grouped into sections:
+ *   1. No-op / fast-path cases
+ *   2. Basic replacement
+ *   3. Multiple rules
+ *   4. Non-string value handling
+ *   5. Immutability — originals must never be mutated
+ *   6. Corner cases (special chars in replacement, empty strings, null values, etc.)
+ *   7. Realistic end-to-end scenarios
+ */
+public class ObfuscationEngineTest {
+
+    // =========================================================================
+    // 1. No-op / fast-path cases
+    // =========================================================================
+
+    @Test
+    public void noRules_returnsOriginalListUnchanged() {
+        List<Map<String, Object>> events = singleEvent("contentSrc", "https://cdn.com/users/john/video.mp4");
+
+        List<Map<String, Object>> result = ObfuscationEngine.apply(events, Collections.emptyList());
+
+        // With no rules the exact same list reference is returned — zero overhead.
+        assertSame(events, result);
+    }
+
+    @Test
+    public void nullRules_returnsOriginalListUnchanged() {
+        List<Map<String, Object>> events = singleEvent("contentSrc", "https://cdn.com/secret");
+
+        List<Map<String, Object>> result = ObfuscationEngine.apply(events, null);
+
+        assertSame(events, result);
+    }
+
+    @Test
+    public void emptyEventList_returnsOriginalEmptyList() {
+        List<Map<String, Object>> events = new ArrayList<>();
+        List<ObfuscationRule> rules = rules("account-\\d+", "ACCOUNT_ID");
+
+        List<Map<String, Object>> result = ObfuscationEngine.apply(events, rules);
+
+        assertSame(events, result);
+    }
+
+    @Test
+    public void nullEventList_returnsNull() {
+        List<ObfuscationRule> rules = rules("account-\\d+", "ACCOUNT_ID");
+
+        List<Map<String, Object>> result = ObfuscationEngine.apply(null, rules);
+
+        assertNull(result);
+    }
+
+    // =========================================================================
+    // 2. Basic replacement
+    // =========================================================================
+
+    @Test
+    public void singleRule_matchingValue_isReplaced() {
+        List<Map<String, Object>> events = singleEvent("contentSrc", "https://cdn.com/account-83729/video.mp4");
+        List<ObfuscationRule> rules = rules("account-\\d+", "ACCOUNT_ID");
+
+        List<Map<String, Object>> result = ObfuscationEngine.apply(events, rules);
+
+        assertEquals("https://cdn.com/ACCOUNT_ID/video.mp4", result.get(0).get("contentSrc"));
+    }
+
+    @Test
+    public void singleRule_noMatch_valueUnchanged() {
+        List<Map<String, Object>> events = singleEvent("contentSrc", "https://cdn.com/video.mp4");
+        List<ObfuscationRule> rules = rules("account-\\d+", "ACCOUNT_ID");
+
+        List<Map<String, Object>> result = ObfuscationEngine.apply(events, rules);
+
+        assertEquals("https://cdn.com/video.mp4", result.get(0).get("contentSrc"));
+    }
+
+    @Test
+    public void singleRule_multipleMatchesInSameValue_allReplaced() {
+        // regex replaceAll — every occurrence is replaced, not just the first.
+        List<Map<String, Object>> events = singleEvent("contentSrc", "account-111/sub/account-222");
+        List<ObfuscationRule> rules = rules("account-\\d+", "ACCOUNT_ID");
+
+        List<Map<String, Object>> result = ObfuscationEngine.apply(events, rules);
+
+        assertEquals("ACCOUNT_ID/sub/ACCOUNT_ID", result.get(0).get("contentSrc"));
+    }
+
+    @Test
+    public void singleRule_entireValueMatches_wholeValueReplaced() {
+        List<Map<String, Object>> events = singleEvent("userId", "john_doe_123");
+        List<ObfuscationRule> rules = rules("john_doe_\\d+", "USER_ID");
+
+        List<Map<String, Object>> result = ObfuscationEngine.apply(events, rules);
+
+        assertEquals("USER_ID", result.get(0).get("userId"));
+    }
+
+    @Test
+    public void singleRule_appliedAcrossAllEventsInBatch() {
+        Map<String, Object> e1 = event("contentSrc", "cdn.com/account-1/v.mp4");
+        Map<String, Object> e2 = event("contentSrc", "cdn.com/account-2/v.mp4");
+        Map<String, Object> e3 = event("contentSrc", "cdn.com/no-match/v.mp4");
+        List<Map<String, Object>> events = Arrays.asList(e1, e2, e3);
+        List<ObfuscationRule> rules = rules("account-\\d+", "ACCOUNT_ID");
+
+        List<Map<String, Object>> result = ObfuscationEngine.apply(events, rules);
+
+        assertEquals("cdn.com/ACCOUNT_ID/v.mp4",  result.get(0).get("contentSrc"));
+        assertEquals("cdn.com/ACCOUNT_ID/v.mp4",  result.get(1).get("contentSrc"));
+        assertEquals("cdn.com/no-match/v.mp4",     result.get(2).get("contentSrc")); // unchanged
+    }
+
+    @Test
+    public void singleRule_allStringAttributesInEventAreObfuscated() {
+        // The rule should run on every string value in the map, not just "contentSrc".
+        Map<String, Object> ev = new HashMap<>();
+        ev.put("contentSrc",   "https://cdn.com/account-99/video");
+        ev.put("contentTitle", "Show for account-99 subscribers");
+        ev.put("eventType",    "CONTENT_START");
+        List<ObfuscationRule> rules = rules("account-\\d+", "ACCOUNT_ID");
+
+        List<Map<String, Object>> result = ObfuscationEngine.apply(Collections.singletonList(ev), rules);
+        Map<String, Object> out = result.get(0);
+
+        assertEquals("https://cdn.com/ACCOUNT_ID/video", out.get("contentSrc"));
+        assertEquals("Show for ACCOUNT_ID subscribers",  out.get("contentTitle"));
+        assertEquals("CONTENT_START",                    out.get("eventType")); // no match — unchanged
+    }
+
+    // =========================================================================
+    // 3. Multiple rules
+    // =========================================================================
+
+    @Test
+    public void multipleRules_allAppliedInOrder() {
+        Map<String, Object> ev = event("url", "https://cdn.com/account-42/token=secret99");
+        List<ObfuscationRule> rules = Arrays.asList(
+            new ObfuscationRule("account-\\d+", "ACCOUNT_ID"),
+            new ObfuscationRule("token=[^&\"]+", "token=REDACTED")
+        );
+
+        List<Map<String, Object>> result = ObfuscationEngine.apply(Collections.singletonList(ev), rules);
+
+        assertEquals("https://cdn.com/ACCOUNT_ID/token=REDACTED", result.get(0).get("url"));
+    }
+
+    @Test
+    public void multipleRules_orderMatters_secondRuleSeesOutputOfFirst() {
+        // Rule 1 turns "john" → "USER", then Rule 2 turns "USER_profile" → "PROFILE".
+        // If applied to the original (not chained), Rule 2 would never match "USER_profile".
+        Map<String, Object> ev = event("path", "/john_profile");
+        List<ObfuscationRule> rules = Arrays.asList(
+            new ObfuscationRule("john", "USER"),       // /john_profile → /USER_profile
+            new ObfuscationRule("USER_profile", "PROFILE") // /USER_profile → /PROFILE
+        );
+
+        List<Map<String, Object>> result = ObfuscationEngine.apply(Collections.singletonList(ev), rules);
+
+        assertEquals("/PROFILE", result.get(0).get("path"));
+    }
+
+    // =========================================================================
+    // 4. Non-string value handling
+    // =========================================================================
+
+    @Test
+    public void integerValues_areNotObfuscated() {
+        Map<String, Object> ev = event("bitrate", 5000000); // Integer, not String
+        List<ObfuscationRule> rules = rules("\\d+", "REDACTED");
+
+        List<Map<String, Object>> result = ObfuscationEngine.apply(Collections.singletonList(ev), rules);
+
+        assertEquals(5000000, result.get(0).get("bitrate")); // unchanged
+    }
+
+    @Test
+    public void longValues_areNotObfuscated() {
+        Map<String, Object> ev = event("timestamp", 1712345678000L);
+        List<ObfuscationRule> rules = rules("\\d+", "REDACTED");
+
+        List<Map<String, Object>> result = ObfuscationEngine.apply(Collections.singletonList(ev), rules);
+
+        assertEquals(1712345678000L, result.get(0).get("timestamp"));
+    }
+
+    @Test
+    public void doubleValues_areNotObfuscated() {
+        Map<String, Object> ev = event("bufferLength", 2.5);
+        List<ObfuscationRule> rules = rules("\\d+", "REDACTED");
+
+        List<Map<String, Object>> result = ObfuscationEngine.apply(Collections.singletonList(ev), rules);
+
+        assertEquals(2.5, result.get(0).get("bufferLength"));
+    }
+
+    @Test
+    public void booleanValues_areNotObfuscated() {
+        Map<String, Object> ev = event("contentIsLive", true);
+        List<ObfuscationRule> rules = rules("true", "REDACTED");
+
+        List<Map<String, Object>> result = ObfuscationEngine.apply(Collections.singletonList(ev), rules);
+
+        assertEquals(true, result.get(0).get("contentIsLive")); // still Boolean, not a String
+    }
+
+    @Test
+    public void nullValue_isSkipped_noNullPointerException() {
+        // A map entry with a null value must not throw — instanceof String returns false for null.
+        Map<String, Object> ev = new HashMap<>();
+        ev.put("contentId", null);
+        ev.put("contentSrc", "https://cdn.com/account-5/v.mp4");
+        List<ObfuscationRule> rules = rules("account-\\d+", "ACCOUNT_ID");
+
+        List<Map<String, Object>> result = ObfuscationEngine.apply(Collections.singletonList(ev), rules);
+
+        assertNull(result.get(0).get("contentId"));                              // null preserved
+        assertEquals("https://cdn.com/ACCOUNT_ID/v.mp4", result.get(0).get("contentSrc")); // string replaced
+    }
+
+    // =========================================================================
+    // 5. Immutability — originals must never be mutated
+    // =========================================================================
+
+    @Test
+    public void originalList_isNotMutated() {
+        List<Map<String, Object>> events = singleEvent("contentSrc", "cdn.com/account-1/v.mp4");
+        List<ObfuscationRule> rules = rules("account-\\d+", "ACCOUNT_ID");
+
+        ObfuscationEngine.apply(events, rules);
+
+        // The original list must still hold the unobfuscated value.
+        assertEquals("cdn.com/account-1/v.mp4", events.get(0).get("contentSrc"));
+    }
+
+    @Test
+    public void originalMaps_areNotMutated() {
+        Map<String, Object> original = event("contentSrc", "cdn.com/account-1/v.mp4");
+        List<ObfuscationRule> rules = rules("account-\\d+", "ACCOUNT_ID");
+
+        ObfuscationEngine.apply(Collections.singletonList(original), rules);
+
+        // The original map object must be untouched.
+        assertEquals("cdn.com/account-1/v.mp4", original.get("contentSrc"));
+    }
+
+    @Test
+    public void returnedList_isDifferentInstance() {
+        List<Map<String, Object>> events = singleEvent("contentSrc", "cdn.com/account-1/v.mp4");
+        List<ObfuscationRule> rules = rules("account-\\d+", "ACCOUNT_ID");
+
+        List<Map<String, Object>> result = ObfuscationEngine.apply(events, rules);
+
+        assertNotSame(events, result);           // different list
+        assertNotSame(events.get(0), result.get(0)); // different map
+    }
+
+    @Test
+    public void immutability_critical_deadLetterRetryGetsCleanOriginal() {
+        // Simulates what HarvestManager does: pass the same events list to sendEvents()
+        // and, on failure, to the dead-letter handler. The dead-letter handler must see
+        // unobfuscated values so the next retry obfuscates them correctly.
+        Map<String, Object> original = event("contentSrc", "cdn.com/account-99/v.mp4");
+        List<Map<String, Object>> events = Collections.singletonList(original);
+        List<ObfuscationRule> rules = rules("account-\\d+", "ACCOUNT_ID");
+
+        // Simulate first send attempt (obfuscate + send)
+        List<Map<String, Object>> firstAttempt = ObfuscationEngine.apply(events, rules);
+        assertEquals("cdn.com/ACCOUNT_ID/v.mp4", firstAttempt.get(0).get("contentSrc"));
+
+        // Simulate dead-letter retry: apply again on the ORIGINAL list
+        List<Map<String, Object>> retryAttempt = ObfuscationEngine.apply(events, rules);
+        assertEquals("cdn.com/ACCOUNT_ID/v.mp4", retryAttempt.get(0).get("contentSrc")); // still correct
+        assertEquals("cdn.com/account-99/v.mp4", events.get(0).get("contentSrc"));       // original clean
+    }
+
+    // =========================================================================
+    // 6. Corner cases
+    // =========================================================================
+
+    @Test
+    public void emptyStringValue_ruleDoesNotMatch_valueUnchanged() {
+        List<Map<String, Object>> events = singleEvent("contentTitle", "");
+        List<ObfuscationRule> rules = rules("account-\\d+", "ACCOUNT_ID");
+
+        List<Map<String, Object>> result = ObfuscationEngine.apply(events, rules);
+
+        assertEquals("", result.get(0).get("contentTitle"));
+    }
+
+    @Test
+    public void emptyReplacement_deletesMatchedContent() {
+        List<Map<String, Object>> events = singleEvent("url", "https://cdn.com/account-42/video");
+        List<ObfuscationRule> rules = rules("account-\\d+", "");
+
+        List<Map<String, Object>> result = ObfuscationEngine.apply(events, rules);
+
+        assertEquals("https://cdn.com//video", result.get(0).get("url"));
+    }
+
+    @Test
+    public void replacementWithDollarSign_treatedAsLiteral() {
+        // Without Matcher.quoteReplacement(), "$ID" would be treated as a back-reference
+        // and throw IllegalArgumentException or produce wrong output.
+        List<Map<String, Object>> events = singleEvent("contentSrc", "cdn.com/account-7/v.mp4");
+        List<ObfuscationRule> rules = rules("account-\\d+", "$ACCOUNT_ID");
+
+        List<Map<String, Object>> result = ObfuscationEngine.apply(events, rules);
+
+        // '$' must appear literally in the output, not cause an exception.
+        assertEquals("cdn.com/$ACCOUNT_ID/v.mp4", result.get(0).get("contentSrc"));
+    }
+
+    @Test
+    public void replacementWithBackslash_treatedAsLiteral() {
+        List<Map<String, Object>> events = singleEvent("contentSrc", "cdn.com/account-7/v.mp4");
+        List<ObfuscationRule> rules = rules("account-\\d+", "\\REDACTED");
+
+        List<Map<String, Object>> result = ObfuscationEngine.apply(events, rules);
+
+        assertEquals("cdn.com/\\REDACTED/v.mp4", result.get(0).get("contentSrc"));
+    }
+
+    @Test
+    public void eventWithOnlyNonStringValues_copiedAsIs() {
+        Map<String, Object> ev = new HashMap<>();
+        ev.put("bitrate",    5000000);
+        ev.put("timestamp",  1712345678000L);
+        ev.put("isLive",     false);
+        List<ObfuscationRule> rules = rules("\\d+", "REDACTED");
+
+        List<Map<String, Object>> result = ObfuscationEngine.apply(Collections.singletonList(ev), rules);
+
+        assertEquals(5000000,          result.get(0).get("bitrate"));
+        assertEquals(1712345678000L,   result.get(0).get("timestamp"));
+        assertEquals(false,            result.get(0).get("isLive"));
+    }
+
+    @Test
+    public void mixedBatch_regularAndQoeEvents_allObfuscated() {
+        // Simulates the real harvest batch: regular events + QOE event injected afterwards.
+        Map<String, Object> contentStart = new HashMap<>();
+        contentStart.put("eventType", "CONTENT_START");
+        contentStart.put("contentSrc", "https://cdn.com/account-10/video.mp4");
+
+        Map<String, Object> qoeEvent = new HashMap<>();
+        qoeEvent.put("eventType", "QOE_AGGREGATE");
+        qoeEvent.put("contentSrc", "https://cdn.com/account-10/video.mp4");
+        qoeEvent.put("totalPlaytime", 30000L); // Long — must not be touched
+
+        List<Map<String, Object>> batch = Arrays.asList(contentStart, qoeEvent);
+        List<ObfuscationRule> rules = rules("account-\\d+", "ACCOUNT_ID");
+
+        List<Map<String, Object>> result = ObfuscationEngine.apply(batch, rules);
+
+        assertEquals("https://cdn.com/ACCOUNT_ID/video.mp4", result.get(0).get("contentSrc"));
+        assertEquals("https://cdn.com/ACCOUNT_ID/video.mp4", result.get(1).get("contentSrc"));
+        assertEquals(30000L, result.get(1).get("totalPlaytime")); // Long untouched
+    }
+
+    @Test
+    public void resultListHasSameSizeAsInput() {
+        List<Map<String, Object>> events = Arrays.asList(
+            event("contentSrc", "cdn.com/account-1/v.mp4"),
+            event("contentSrc", "cdn.com/account-2/v.mp4"),
+            event("contentSrc", "cdn.com/account-3/v.mp4")
+        );
+        List<ObfuscationRule> rules = rules("account-\\d+", "ACCOUNT_ID");
+
+        List<Map<String, Object>> result = ObfuscationEngine.apply(events, rules);
+
+        assertEquals(3, result.size());
+    }
+
+    // =========================================================================
+    // 7. Realistic end-to-end scenarios
+    // =========================================================================
+
+    @Test
+    public void scenario_maskUserIdInUrl() {
+        List<Map<String, Object>> events = singleEvent(
+            "contentSrc", "https://stream.example.com/users/john_doe_123/live.m3u8"
+        );
+        List<ObfuscationRule> rules = rules("/users/[^\"/]+", "/users/USER_ID");
+
+        List<Map<String, Object>> result = ObfuscationEngine.apply(events, rules);
+
+        assertEquals(
+            "https://stream.example.com/users/USER_ID/live.m3u8",
+            result.get(0).get("contentSrc")
+        );
+    }
+
+    @Test
+    public void scenario_maskAuthToken() {
+        List<Map<String, Object>> events = singleEvent(
+            "contentSrc", "https://cdn.com/video.mp4?token=eyJhbGciOiJIUzI1NiJ9&quality=HD"
+        );
+        List<ObfuscationRule> rules = rules("token=[^&\"]+", "token=REDACTED");
+
+        List<Map<String, Object>> result = ObfuscationEngine.apply(events, rules);
+
+        assertEquals(
+            "https://cdn.com/video.mp4?token=REDACTED&quality=HD",
+            result.get(0).get("contentSrc")
+        );
+    }
+
+    @Test
+    public void scenario_threeRulesOnRealWorldEvent() {
+        Map<String, Object> ev = new HashMap<>();
+        ev.put("eventType",    "CONTENT_START");
+        ev.put("contentSrc",   "https://cdn.com/account-42/users/jane/token=secret99&q=HD");
+        ev.put("contentTitle", "Premium content for account-42");
+        ev.put("bitrate",      4500000); // non-string, must be untouched
+        ev.put("timestamp",    1712345678000L);
+
+        List<ObfuscationRule> rules = Arrays.asList(
+            new ObfuscationRule("account-\\d+",  "ACCOUNT_ID"),
+            new ObfuscationRule("/users/[^/\"?&]+", "/users/USER_ID"),
+            new ObfuscationRule("token=[^&\"]+", "token=REDACTED")
+        );
+
+        List<Map<String, Object>> result = ObfuscationEngine.apply(Collections.singletonList(ev), rules);
+        Map<String, Object> out = result.get(0);
+
+        assertEquals("CONTENT_START", out.get("eventType")); // no match
+        assertEquals(
+            "https://cdn.com/ACCOUNT_ID/users/USER_ID/token=REDACTED&q=HD",
+            out.get("contentSrc")
+        );
+        assertEquals("Premium content for ACCOUNT_ID",  out.get("contentTitle"));
+        assertEquals(4500000,          out.get("bitrate"));    // Integer untouched
+        assertEquals(1712345678000L,   out.get("timestamp"));  // Long untouched
+    }
+
+    // =========================================================================
+    // Helpers — keep test bodies readable
+    // =========================================================================
+
+    /** Creates a single-entry event list with one key-value pair. */
+    private List<Map<String, Object>> singleEvent(String key, Object value) {
+        return Collections.singletonList(event(key, value));
+    }
+
+    /** Creates a single event map with one key-value pair. */
+    private Map<String, Object> event(String key, Object value) {
+        Map<String, Object> map = new HashMap<>();
+        map.put(key, value);
+        return map;
+    }
+
+    /** Creates a single-rule list from a pattern and replacement string. */
+    private List<ObfuscationRule> rules(String pattern, String replacement) {
+        return Collections.singletonList(new ObfuscationRule(pattern, replacement));
+    }
+}

--- a/NewRelicVideoCore/src/test/java/com/newrelic/videoagent/core/ObfuscationRuleTest.java
+++ b/NewRelicVideoCore/src/test/java/com/newrelic/videoagent/core/ObfuscationRuleTest.java
@@ -20,8 +20,8 @@ public class ObfuscationRuleTest {
     public void validRule_compilesSuccessfully() {
         ObfuscationRule rule = new ObfuscationRule("account-\\d+", "ACCOUNT_ID");
 
-        assertNotNull(rule.regex);
-        assertEquals("ACCOUNT_ID", rule.replacement);
+        assertNotNull(rule.getRegex());
+        assertEquals("ACCOUNT_ID", rule.getReplacement());
     }
 
     @Test
@@ -29,8 +29,8 @@ public class ObfuscationRuleTest {
         // Empty string means "delete matches" — a legitimate use case.
         ObfuscationRule rule = new ObfuscationRule("secret-\\w+", "");
 
-        assertNotNull(rule.regex);
-        assertEquals("", rule.replacement);
+        assertNotNull(rule.getRegex());
+        assertEquals("", rule.getReplacement());
     }
 
     @Test
@@ -39,7 +39,7 @@ public class ObfuscationRuleTest {
         // that with Matcher.quoteReplacement(). The rule itself should accept any string.
         ObfuscationRule rule = new ObfuscationRule("price-\\d+", "$PRICE");
 
-        assertEquals("$PRICE", rule.replacement);
+        assertEquals("$PRICE", rule.getReplacement());
     }
 
     @Test
@@ -47,7 +47,7 @@ public class ObfuscationRuleTest {
         // Same as above — '\' is special in replacements but quoteReplacement handles it.
         ObfuscationRule rule = new ObfuscationRule("path-\\w+", "\\REDACTED");
 
-        assertEquals("\\REDACTED", rule.replacement);
+        assertEquals("\\REDACTED", rule.getReplacement());
     }
 
     @Test
@@ -55,10 +55,10 @@ public class ObfuscationRuleTest {
         // A realistic URL masking pattern
         ObfuscationRule rule = new ObfuscationRule("/users/[^\"/]+", "/users/USER_ID");
 
-        assertNotNull(rule.regex);
+        assertNotNull(rule.getRegex());
         // Verify the compiled regex actually matches what we expect
-        assertTrue(rule.regex.matcher("/users/john_doe/profile").find());
-        assertFalse(rule.regex.matcher("/products/shoes").find());
+        assertTrue(rule.getRegex().matcher("/users/john_doe/profile").find());
+        assertFalse(rule.getRegex().matcher("/products/shoes").find());
     }
 
     @Test
@@ -66,9 +66,9 @@ public class ObfuscationRuleTest {
         // Patterns with inline flags like (?i) for case-insensitive
         ObfuscationRule rule = new ObfuscationRule("(?i)token=[^&]+", "token=REDACTED");
 
-        assertNotNull(rule.regex);
-        assertTrue(rule.regex.matcher("TOKEN=abc123").find());
-        assertTrue(rule.regex.matcher("token=abc123").find());
+        assertNotNull(rule.getRegex());
+        assertTrue(rule.getRegex().matcher("TOKEN=abc123").find());
+        assertTrue(rule.getRegex().matcher("token=abc123").find());
     }
 
     // -------------------------------------------------------------------------
@@ -130,17 +130,17 @@ public class ObfuscationRuleTest {
     public void compiledPattern_matchesExpectedInput() {
         ObfuscationRule rule = new ObfuscationRule("account-\\d+", "ACCOUNT_ID");
 
-        assertTrue(rule.regex.matcher("account-83729").matches());
-        assertTrue(rule.regex.matcher("account-1").matches());
-        assertFalse(rule.regex.matcher("account-abc").matches()); // letters, not digits
-        assertFalse(rule.regex.matcher("account-").matches());    // no digits at all
+        assertTrue(rule.getRegex().matcher("account-83729").matches());
+        assertTrue(rule.getRegex().matcher("account-1").matches());
+        assertFalse(rule.getRegex().matcher("account-abc").matches()); // letters, not digits
+        assertFalse(rule.getRegex().matcher("account-").matches());    // no digits at all
     }
 
     @Test
     public void compiledPattern_tokenMasking_matchesExpectedInput() {
         ObfuscationRule rule = new ObfuscationRule("token=[^&\"]+", "token=REDACTED");
 
-        assertTrue(rule.regex.matcher("token=abc123xyz").find());
-        assertFalse(rule.regex.matcher("token=").find()); // empty value — no match
+        assertTrue(rule.getRegex().matcher("token=abc123xyz").find());
+        assertFalse(rule.getRegex().matcher("token=").find()); // empty value — no match
     }
 }

--- a/NewRelicVideoCore/src/test/java/com/newrelic/videoagent/core/ObfuscationRuleTest.java
+++ b/NewRelicVideoCore/src/test/java/com/newrelic/videoagent/core/ObfuscationRuleTest.java
@@ -1,0 +1,146 @@
+package com.newrelic.videoagent.core;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for ObfuscationRule construction and validation.
+ *
+ * These are pure JUnit 4 tests — no Android context needed because ObfuscationRule
+ * only uses java.util.regex.Pattern, which is plain Java.
+ */
+public class ObfuscationRuleTest {
+
+    // -------------------------------------------------------------------------
+    // Happy path
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void validRule_compilesSuccessfully() {
+        ObfuscationRule rule = new ObfuscationRule("account-\\d+", "ACCOUNT_ID");
+
+        assertNotNull(rule.regex);
+        assertEquals("ACCOUNT_ID", rule.replacement);
+    }
+
+    @Test
+    public void validRule_emptyReplacement_isAllowed() {
+        // Empty string means "delete matches" — a legitimate use case.
+        ObfuscationRule rule = new ObfuscationRule("secret-\\w+", "");
+
+        assertNotNull(rule.regex);
+        assertEquals("", rule.replacement);
+    }
+
+    @Test
+    public void validRule_replacementWithDollarSign_isAllowed() {
+        // '$' is special in Java regex replacements, but ObfuscationEngine guards against
+        // that with Matcher.quoteReplacement(). The rule itself should accept any string.
+        ObfuscationRule rule = new ObfuscationRule("price-\\d+", "$PRICE");
+
+        assertEquals("$PRICE", rule.replacement);
+    }
+
+    @Test
+    public void validRule_replacementWithBackslash_isAllowed() {
+        // Same as above — '\' is special in replacements but quoteReplacement handles it.
+        ObfuscationRule rule = new ObfuscationRule("path-\\w+", "\\REDACTED");
+
+        assertEquals("\\REDACTED", rule.replacement);
+    }
+
+    @Test
+    public void validRule_complexPattern_compilesSuccessfully() {
+        // A realistic URL masking pattern
+        ObfuscationRule rule = new ObfuscationRule("/users/[^\"/]+", "/users/USER_ID");
+
+        assertNotNull(rule.regex);
+        // Verify the compiled regex actually matches what we expect
+        assertTrue(rule.regex.matcher("/users/john_doe/profile").find());
+        assertFalse(rule.regex.matcher("/products/shoes").find());
+    }
+
+    @Test
+    public void validRule_patternWithFlags_compilesSuccessfully() {
+        // Patterns with inline flags like (?i) for case-insensitive
+        ObfuscationRule rule = new ObfuscationRule("(?i)token=[^&]+", "token=REDACTED");
+
+        assertNotNull(rule.regex);
+        assertTrue(rule.regex.matcher("TOKEN=abc123").find());
+        assertTrue(rule.regex.matcher("token=abc123").find());
+    }
+
+    // -------------------------------------------------------------------------
+    // Null / empty pattern
+    // -------------------------------------------------------------------------
+
+    @Test(expected = IllegalArgumentException.class)
+    public void nullPattern_throwsIllegalArgumentException() {
+        new ObfuscationRule(null, "REPLACEMENT");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void emptyPattern_throwsIllegalArgumentException() {
+        new ObfuscationRule("", "REPLACEMENT");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void blankPattern_whitespaceOnly_throwsIllegalArgumentException() {
+        // "   " is technically non-empty but trim() makes it empty — should still reject.
+        new ObfuscationRule("   ", "REPLACEMENT");
+    }
+
+    // -------------------------------------------------------------------------
+    // Null replacement
+    // -------------------------------------------------------------------------
+
+    @Test(expected = IllegalArgumentException.class)
+    public void nullReplacement_throwsIllegalArgumentException() {
+        // null replacement would NPE silently at apply time — reject it eagerly.
+        new ObfuscationRule("account-\\d+", null);
+    }
+
+    // -------------------------------------------------------------------------
+    // Invalid regex
+    // -------------------------------------------------------------------------
+
+    @Test(expected = IllegalArgumentException.class)
+    public void invalidRegex_unclosedGroup_throwsIllegalArgumentException() {
+        // "(unclosed" is a malformed regex — should fail at construction, not at harvest.
+        new ObfuscationRule("(unclosed", "REPLACEMENT");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void invalidRegex_danglingQuantifier_throwsIllegalArgumentException() {
+        // "*" with nothing to quantify is invalid
+        new ObfuscationRule("*invalid", "REPLACEMENT");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void invalidRegex_unclosedBracket_throwsIllegalArgumentException() {
+        new ObfuscationRule("[unclosed", "REPLACEMENT");
+    }
+
+    // -------------------------------------------------------------------------
+    // Pattern correctness (verify the compiled regex behaves as expected)
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void compiledPattern_matchesExpectedInput() {
+        ObfuscationRule rule = new ObfuscationRule("account-\\d+", "ACCOUNT_ID");
+
+        assertTrue(rule.regex.matcher("account-83729").matches());
+        assertTrue(rule.regex.matcher("account-1").matches());
+        assertFalse(rule.regex.matcher("account-abc").matches()); // letters, not digits
+        assertFalse(rule.regex.matcher("account-").matches());    // no digits at all
+    }
+
+    @Test
+    public void compiledPattern_tokenMasking_matchesExpectedInput() {
+        ObfuscationRule rule = new ObfuscationRule("token=[^&\"]+", "token=REDACTED");
+
+        assertTrue(rule.regex.matcher("token=abc123xyz").find());
+        assertFalse(rule.regex.matcher("token=").find()); // empty value — no match
+    }
+}

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The New Relic Video Agent for Android contains multiple modules necessary to ins
 - **Quality of Experience (QoE) Metrics** - Optional aggregate KPIs including startup time, bitrate, and rebuffering ratio
 - **Configurable Harvest Cycles** - Control data transmission frequency for regular and live streaming content
 - **Crash-Safe Buffering** - Events are persisted and retried on network failures
+- **Obfuscation Rules** - Regex-based masking of sensitive data (user IDs, tokens, account numbers) before events leave the device
 
 ## Modules
 
@@ -173,6 +174,42 @@ NRVideo.newBuilder(getApplicationContext()).withConfiguration(config).build();
 </p>
 </details>
 
+To mask sensitive data using obfuscation rules:
+
+<details>
+<summary>Java</summary>
+<p>
+
+```java
+import com.newrelic.videoagent.core.ObfuscationRule;
+import java.util.Arrays;
+import java.util.List;
+
+// Define rules — each rule is a regex pattern and a replacement string.
+// Rules are applied in order on every string attribute of every outgoing event.
+List<ObfuscationRule> obfuscationRules = Arrays.asList(
+    // Mask account IDs:  "account-83729"  →  "ACCOUNT_ID"
+    new ObfuscationRule("account-\\d+", "ACCOUNT_ID"),
+
+    // Mask auth tokens:  "token=abc123xyz"  →  "token=REDACTED"
+    new ObfuscationRule("token=[^&\"]+", "token=REDACTED"),
+
+    // Mask user path segments:  "/users/john_doe"  →  "/users/USER_ID"
+    new ObfuscationRule("/users/[^\"/]+", "/users/USER_ID")
+);
+
+NRVideoConfiguration config = new NRVideoConfiguration.Builder("application-token")
+        .autoDetectPlatform(getApplicationContext())
+        .withHarvestCycle(5 * 60)
+        .withObfuscationRules(obfuscationRules)
+        .build();
+
+NRVideo.newBuilder(getApplicationContext()).withConfiguration(config).build();
+```
+
+</p>
+</details>
+
 To start the video agent with ExoPlayer and IMA trackers:
 
 <details>
@@ -221,6 +258,9 @@ builder.setAdEventListener(adTracker.getAdEventListener());
   - `3` = QoE generated every third harvest cycle \(cycles 1, 4, 7, 10\.\.\.\)
   **Default: `1`** \(QoE generated every harvest cycle when enabled\)\. Only applies when `enableQoeAggregate` is `true`\.
 
+- **`obfuscationRules`**
+  A list of `ObfuscationRule` objects applied to every string attribute of every outgoing event immediately before HTTP transmission\. Each rule is a compiled regex pattern and a plain\-string replacement\. Rules run in the order they are declared — the output of one rule feeds into the next\. **Default: empty list** \(no obfuscation\)\.
+
 ### Quality of Experience (QoE) Metrics
 
 When `enableQoeAggregate` is enabled, the agent generates `QOE_AGGREGATE` events containing the following KPIs:
@@ -254,6 +294,64 @@ D/NRVideoTracker: QOE_AGGREGATE generated for harvest cycle 1 (KPIs changed)
 D/HarvestManager: QOE_AGGREGATE injected into harvest batch (cycle 1)
 D/NRVideoTracker: QOE_AGGREGATE skipped for harvest cycle 2 (no KPI changes)
 ```
+
+### Obfuscation Rules
+
+Obfuscation rules let you mask sensitive data — user IDs, auth tokens, account numbers, PII in URLs — before events are transmitted to New Relic. Rules are applied at send time, so no sensitive data is written to the in-memory buffer, SQLite crash-recovery storage, or the dead-letter retry queue.
+
+#### How it works
+
+1. You define a list of `ObfuscationRule` objects, each with a regex pattern and a replacement string.
+2. Pass the list to `.withObfuscationRules()` on the config builder.
+3. Just before each HTTP transmission, `ObfuscationEngine` iterates every string attribute of every event in the batch and applies the rules in order.
+4. Only string values are processed — integers, longs, booleans, and nulls are passed through unchanged.
+5. The original event objects are never mutated, so failed batches can be retried cleanly without double-obfuscation.
+
+#### `ObfuscationRule` constructor
+
+```java
+new ObfuscationRule(String pattern, String replacement)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `pattern` | `String` | A Java regex pattern string. Compiled eagerly — an invalid pattern throws `IllegalArgumentException` at construction time. |
+| `replacement` | `String` | The string to substitute for each match. Use `""` to delete matches. `$` and `\` are treated as plain characters, not back-references. |
+
+#### Common patterns
+
+| What to mask | Pattern | Replacement |
+|---|---|---|
+| Numeric account IDs | `account-\\d+` | `ACCOUNT_ID` |
+| Auth / bearer tokens | `token=[^&\"]+` | `token=REDACTED` |
+| User path segments | `/users/[^\"/]+` | `/users/USER_ID` |
+| Email addresses | `[a-zA-Z0-9._%+\\-]+@[a-zA-Z0-9.\\-]+\\.[a-zA-Z]{2,}` | `EMAIL_REDACTED` |
+| UUIDs | `[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}` | `UUID_REDACTED` |
+
+#### Rule ordering
+
+Rules are applied left-to-right. The output of rule N becomes the input of rule N+1. Order matters when one rule's replacement could match a later rule's pattern.
+
+```java
+// Rule 1 turns "/john" into "/USER", then Rule 2 sees "/USER_profile" and masks it.
+new ObfuscationRule("john", "USER"),
+new ObfuscationRule("USER_profile", "PROFILE")
+// Result: "/john_profile" → "/USER_profile" → "/PROFILE"
+```
+
+#### Edge cases
+
+| Situation | Behaviour |
+|-----------|-----------|
+| No rules configured | No-op — zero overhead, original list returned as-is |
+| Pattern matches nothing | Value is passed through unchanged |
+| Empty replacement `""` | Matched content is deleted |
+| `$` or `\` in replacement | Treated as plain characters (not regex back-references) |
+| Integer / Long / Boolean value | Skipped — only `String` values are processed |
+| `null` value | Skipped — no NullPointerException |
+| Invalid regex pattern | `IllegalArgumentException` thrown at `new ObfuscationRule(...)` construction — fails fast at startup, not silently at harvest time |
+| `null` replacement | `IllegalArgumentException` thrown at construction |
+| HTTP send fails → dead-letter retry | Original (unobfuscated) events are retried; obfuscation is re-applied correctly on the retry pass |
 
 **`NRVideoPlayerConfiguration.java`**
 


### PR DESCRIPTION
Summary
Adds regex-based obfuscation rules that mask sensitive data (user IDs, tokens, account numbers, PII in URLs) before events are transmitted to New Relic
Introduces ObfuscationRule (pattern + replacement pair) and ObfuscationEngine (applies rules to event batches)
Hooks into OptimizedHttpClient.sendEvents() — the single convergence point for all event paths (regular events, QOE, crash recovery, dead-letter retries)
Rules are applied to copied event maps, not originals, so failed batches retry cleanly without double-obfuscation

Screenshots:
<img width="681" height="267" alt="Screenshot 2026-04-10 at 2 10 48 PM" src="https://github.com/user-attachments/assets/41f4a73c-a449-473c-9adb-da8b32a9163f" />
<img width="1125" height="335" alt="Screenshot 2026-04-10 at 2 12 18 PM" src="https://github.com/user-attachments/assets/c1694a0b-c9dd-40bb-9365-6053ad9f23ff" />

