### PR TITLE
feat: add JP region support

### DIFF
--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/NRVideoConfiguration.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/NRVideoConfiguration.java
@@ -32,6 +32,8 @@ public final class NRVideoConfiguration {
         regions.put("STAGING", "STAGING");
         regions.put("DEV", "STAGING");
         regions.put("TEST", "STAGING");
+        regions.put("JP", "JP");
+        regions.put("JAPAN", "JP");
         REGION_MAPPINGS = regions; // Immutable reference
     }
 

--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/auth/TokenManager.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/auth/TokenManager.java
@@ -173,6 +173,8 @@ public final class TokenManager {
                 return "https://mobile-collector.ap.newrelic.com/mobile/v5/connect";
             case "GOV":
                 return "https://mobile-collector.gov.newrelic.com/mobile/v5/connect";
+            case "JP":
+                return "https://mobile-collector.jp.nr-data.net/mobile/v5/connect";
             default:
                 return "https://mobile-collector.newrelic.com/mobile/v5/connect";
         }

--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/harvest/OptimizedHttpClient.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/harvest/OptimizedHttpClient.java
@@ -44,6 +44,7 @@ public class OptimizedHttpClient implements HttpClientInterface {
         REGIONAL_ENDPOINTS.put("EU", "https://mobile-collector.eu.newrelic.com/mobile/v3/data");
         REGIONAL_ENDPOINTS.put("AP", "https://mobile-collector.ap.newrelic.com/mobile/v3/data");
         REGIONAL_ENDPOINTS.put("GOV", "https://mobile-collector.gov.newrelic.com/mobile/v3/data");
+        REGIONAL_ENDPOINTS.put("JP", "https://mobile-collector.jp.nr-data.net/mobile/v3/data");
         REGIONAL_ENDPOINTS.put("DEFAULT", REGIONAL_ENDPOINTS.get("US"));
     }
 


### PR DESCRIPTION
Add Japan (JP) region endpoints for mobile data collector and connect API. Adds JP to REGION_MAPPINGS, REGIONAL_ENDPOINTS, and buildTokenEndpoint(). Confirmed endpoints: mobile-collector.jp.nr-data.net.