### PR TITLE
feat(mediatailor): add AWS MediaTailor SSAI tracker for DASH + HLS

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="17" />
+    <bytecodeTargetLevel target="21" />
   </component>
 </project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -4,13 +4,15 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
+        <option name="testRunner" value="CHOOSE_PER_TEST" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="homebrew-17" />
+        <option name="gradleJvm" value="jbr-21" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />
             <option value="$PROJECT_DIR$/NRExoPlayerTracker" />
             <option value="$PROJECT_DIR$/NRIMATracker" />
+            <option value="$PROJECT_DIR$/NRMediaTailorTracker" />
             <option value="$PROJECT_DIR$/NewRelicVideoCore" />
             <option value="$PROJECT_DIR$/app" />
           </set>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CMakeSettings">
     <configurations>
@@ -14,7 +15,7 @@
   <component name="JavadocGenerationManager">
     <option name="OUTPUT_DIRECTORY" value="$PROJECT_DIR$/docs" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## [Unreleased]
+
+### Features
+
+* **NRMediaTailorTracker** — new optional AAR module for AWS Elemental MediaTailor SSAI.
+  * Supports **DASH** (multi-period BaseURL detection + single-period SCTE‑35 EventStream) and **HLS** (segment URL + discontinuity-driven pod splitting).
+  * Implicit and explicit session-init flows (POST `/v1/session/…`); recovers `sessionId` from DASH `<Location>` when the client-side URI doesn't carry it.
+  * VOD and Live — tracking API polled once for VOD, on every manifest refresh for Live.
+  * Rich VAST metadata on `VideoAdAction` events emitted by `NRTrackerMediaTailor` (identified by `trackerName = "NRMTracker"`): `adSystem`, `vastAdId`, `creativeSequence`, `skipOffset`, `adProgramDateTime`, `availProgramDateTime`, `isBumper`, `nonLinearAvailsCount`. These attributes are **not** populated by `NRTrackerIMA`.
+  * `notifyAdSkipped()` API for skippable-ad UX integrations.
+* **NRVideoPlayerConfiguration.AdTrackerType** — `NONE` / `IMA` / `MEDIA_TAILOR` replaces the boolean `isAdEnabled` (legacy ctor preserved). `NRVideo.addPlayer` switches the ad-tracker slot accordingly.
+* **NRTrackerExoPlayer** — new `isLinkedAdBreakActive()` gate suppresses stray `CONTENT_PAUSE` / `CONTENT_RESUME` / `CONTENT_BUFFER_*` / `CONTENT_START` / `CONTENT_RENDITION_CHANGE` / `CONTENT_SEEK_START` events during SSAI ad breaks, and routes error callbacks (`onPlayerError`, `onLoadError`) to the ad tracker as `AD_ERROR` when one is active.
+
 ## [4.1.1](https://github.com/newrelic/video-agent-android/compare/v4.1.0...v4.1.1) (2026-04-22)
 
 ### Bug Fixes

--- a/DATAMODEL.md
+++ b/DATAMODEL.md
@@ -95,6 +95,8 @@ An Attribute is a piece of data associated with an event. Attributes provide add
 
 ### VideoAdAction
 
+> **About `(MediaTailor)` attributes below:** attributes tagged with *(MediaTailor)* are populated **only** on events emitted by `NRTrackerMediaTailor` (i.e. when the player is registered with `AdTrackerType.MEDIA_TAILOR`). They are **not** present on events from `NRTrackerIMA`. Filter NRQL by `trackerName = 'NRMTracker'` to scope queries to MediaTailor-only ad events.
+
 | Attribute Name           | Definition                                                                                                                                         |
 | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------- |
 | actionName               | The specific action being performed in the video player, such as play, pause, resume, content buffering, etc.                                      |
@@ -125,7 +127,15 @@ An Attribute is a piece of data associated with an event. Attributes provide add
 | adQuartile               | Quartile of the ad. 0 before first, 1 after first quartile, 2 after midpoint, 3 after third quartile, 4 when completed.                            |
 | adPosition               | The position of the ad.                                                                                                                            |
 | adCreativeId             | The creative ID of the ad.                                                                                                                         |
-| adPartner                | The ad partner, e.g., ima, freewheel.                                                                                                              |
+| adPartner                | The ad partner, e.g., ima, freewheel, aws-mediatailor.                                                                                             |
+| adSystem                 | *(MediaTailor)* The ad-server name returned in the VAST response — e.g., `GDFP`, `FreeWheel`, `SpringServe`, `Publica`.                            |
+| vastAdId                 | *(MediaTailor)* Hierarchical VAST ad identifier, useful for tracing back to ad-server logs.                                                       |
+| creativeSequence         | *(MediaTailor)* 1-based index of the creative within the ad pod.                                                                                   |
+| skipOffset               | *(MediaTailor)* `HH:MM:SS` offset after which the ad is skippable. Absent when the ad is non-skippable.                                            |
+| adProgramDateTime        | *(MediaTailor)* Wall-clock time the ad began in the personalized MPD/playlist. Useful for correlating live-stream events with ad-server logs.     |
+| availProgramDateTime     | *(MediaTailor)* Wall-clock time of the avail (ad break) containing this ad.                                                                        |
+| isBumper                 | *(MediaTailor)* `true` when the ad was served by a MediaTailor bumper configuration rather than a normal ad avail.                                |
+| nonLinearAvailsCount     | *(MediaTailor)* Number of non-linear (overlay / banner / companion) avails returned by the tracking API for this session. Non-zero means the app may want to render companion banners.  |
 | isBackgroundEvent        | If the player is hidden by another window.                                                                                                         |
 | bufferType               | When buffer starts, i.e., initial, seek, pause & connection.                                                                                       |
 | asn                      | Autonomous System Number: a unique number identifying a group of IP networks that serves the content to the end user.                              |
@@ -157,6 +167,7 @@ An Attribute is a piece of data associated with an event. Attributes provide add
 | AD_BREAK_END        | Ad break ended.                                                                             |
 | AD_QUARTILE         | Ad quartile happened.                                                                       |
 | AD_CLICK            | Ad has been clicked.                                                                        |
+| AD_SKIP             | *(MediaTailor)* User skipped a skippable ad.           |
 
 ### VideoErrorAction
 

--- a/NRExoPlayerTracker/src/main/java/com/newrelic/videoagent/exoplayer/tracker/NRTrackerExoPlayer.java
+++ b/NRExoPlayerTracker/src/main/java/com/newrelic/videoagent/exoplayer/tracker/NRTrackerExoPlayer.java
@@ -639,21 +639,33 @@ public class NRTrackerExoPlayer extends NRVideoTracker implements Player.Listene
         logOnPlayerStateChanged(player.getPlayWhenReady(), playbackState);
     }
 
+    /**
+     * Returns true when the linked ad tracker reports an active ad break
+     * (SSAI case — {@code player.isPlayingAd()} stays false for server-side
+     * stitched ads, so we also consult the paired ad tracker's state).
+     */
+    private boolean isLinkedAdBreakActive() {
+        if (!(linkedTracker instanceof NRVideoTracker)) return false;
+        return ((NRVideoTracker) linkedTracker).getState().isAdBreak;
+    }
+
     private void logOnPlayerStateChanged(boolean playWhenReady, int playbackState) {
         NRLog.d("onPlayerStateChanged, payback state = " + playbackState + " {");
+
+        boolean inAd = player.isPlayingAd() || isLinkedAdBreakActive();
 
         if (playbackState == Player.STATE_READY) {
             NRLog.d("\tVideo Is Ready");
 
-            if (getState().isBuffering) {
+            if (getState().isBuffering && !inAd) {
                 sendBufferEnd();
             }
 
-            if (getState().isSeeking) {
+            if (getState().isSeeking && !inAd) {
                 sendSeekEnd();
             }
 
-            if (getState().isRequested && !getState().isStarted) {
+            if (getState().isRequested && !getState().isStarted && !inAd) {
                 sendStart();
             }
         } else if (playbackState == Player.STATE_ENDED) {
@@ -674,7 +686,7 @@ public class NRTrackerExoPlayer extends NRVideoTracker implements Player.Listene
                 sendRequest();
             }
 
-            if (!getState().isBuffering && !player.isPlayingAd()) {
+            if (!getState().isBuffering && !inAd) {
                 sendBufferStart();
             }
         }
@@ -682,13 +694,13 @@ public class NRTrackerExoPlayer extends NRVideoTracker implements Player.Listene
         if (playWhenReady && playbackState == Player.STATE_READY) {
             NRLog.d("\tVideo Playing");
 
-            if (getState().isRequested && !getState().isStarted) {
+            if (getState().isRequested && !getState().isStarted && !inAd) {
                 sendStart();
-            } else if (getState().isPaused && !player.isPlayingAd()) {
+            } else if (getState().isPaused && !inAd) {
                 sendResume();
             } else if (!getState().isRequested && !getState().isStarted) {
-                NRLog.d("LAST CHANCE TO SEND REQUEST START. isPlayingAd = " + player.isPlayingAd());
-                if (!player.isPlayingAd()) {
+                NRLog.d("LAST CHANCE TO SEND REQUEST START. inAd = " + inAd);
+                if (!inAd) {
                     sendRequest();
                     sendStart();
                 }
@@ -698,7 +710,7 @@ public class NRTrackerExoPlayer extends NRVideoTracker implements Player.Listene
         } else {
             NRLog.d("\tVideo Paused");
 
-            if (getState().isPlaying && !player.isPlayingAd()) {
+            if (getState().isPlaying && !inAd) {
                 sendPause();
             }
         }
@@ -709,7 +721,12 @@ public class NRTrackerExoPlayer extends NRVideoTracker implements Player.Listene
     @Override
     public void onPlayerError(@NonNull PlaybackException error) {
         NRLog.d("onPlayerError");
-        sendError(error);
+        if (isLinkedAdBreakActive()) {
+            // SSAI ad break active — attribute the error to the ad, not content.
+            ((NRVideoTracker) linkedTracker).sendError(error);
+        } else {
+            sendError(error);
+        }
     }
 
     // ExoPlayer AnalyticsListener
@@ -719,7 +736,7 @@ public class NRTrackerExoPlayer extends NRVideoTracker implements Player.Listene
         if (reason == Player.DISCONTINUITY_REASON_SEEK) {
             NRLog.d("onSeekStarted analytics");
 
-            if (!getState().isSeeking) {
+            if (!getState().isSeeking && !isLinkedAdBreakActive()) {
                 sendSeekStart();
             }
         }
@@ -740,7 +757,11 @@ public class NRTrackerExoPlayer extends NRVideoTracker implements Player.Listene
     @Override
     public void onLoadError(@NonNull EventTime eventTime, @NonNull LoadEventInfo loadEventInfo, @NonNull MediaLoadData mediaLoadData, @NonNull IOException error, boolean wasCanceled) {
         NRLog.d("onLoadError analytics");
-        sendError(error);
+        if (isLinkedAdBreakActive()) {
+            ((NRVideoTracker) linkedTracker).sendError(error);
+        } else {
+            sendError(error);
+        }
     }
 
     @Override
@@ -794,7 +815,7 @@ public class NRTrackerExoPlayer extends NRVideoTracker implements Player.Listene
         int height = videoSize.height;
         NRLog.d("onVideoSizeChanged analytics, H = " + height + " W = " + width);
 
-        if (player.isPlayingAd()) return;
+        if (player.isPlayingAd() || isLinkedAdBreakActive()) return;
 
         long currMul = (long) width * height;
         long lastMul = (long) lastWidth * lastHeight;

--- a/NRMediaTailorTracker/build.gradle
+++ b/NRMediaTailorTracker/build.gradle
@@ -1,0 +1,62 @@
+plugins {
+    id 'com.android.library'
+    id 'maven-publish'
+}
+android {
+    compileSdkVersion 34
+    buildToolsVersion "34.0.0"
+
+    defaultConfig {
+        minSdkVersion 24
+        targetSdkVersion 34
+        versionCode 1
+        versionName GLOBAL_VERSION_NAME
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        consumerProguardFiles "consumer-rules.pro"
+    }
+    buildTypes {
+        debug {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            buildConfigField("long", "VERSION_CODE", "${defaultConfig.versionCode}")
+            buildConfigField("String","VERSION_NAME","\"${defaultConfig.versionName}\"")
+        }
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            buildConfigField("long", "VERSION_CODE", "${defaultConfig.versionCode}")
+            buildConfigField("String","VERSION_NAME","\"${defaultConfig.versionName}\"")
+        }
+    }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
+    }
+    namespace 'com.newrelic.videoagent.mediatailor'
+}
+dependencies {
+    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'com.google.android.material:material:1.2.1'
+    implementation project(path: ':NewRelicVideoCore')
+    implementation 'androidx.media3:media3-exoplayer:1.2.0'
+    implementation 'androidx.media3:media3-exoplayer-dash:1.2.0'
+    implementation 'androidx.media3:media3-exoplayer-hls:1.2.0'
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.robolectric:robolectric:4.10.3'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+    androidTestImplementation 'androidx.test:runner:1.5.2'
+    androidTestImplementation 'androidx.test:rules:1.5.0'
+}
+afterEvaluate {
+    publishing {
+        publications {
+            release(MavenPublication) {
+                from components.release
+                groupId = 'com.github.newrelic'
+                artifactId = 'NRMediaTailorTracker'
+                version = "${android.defaultConfig.versionName}"
+            }
+        }
+    }
+}

--- a/NRMediaTailorTracker/consumer-rules.pro
+++ b/NRMediaTailorTracker/consumer-rules.pro
@@ -1,0 +1,4 @@
+-keep class com.newrelic.videoagent.mediatailor.tracker.NRTrackerMediaTailor {
+    public <init>(...);
+    public *;
+}

--- a/NRMediaTailorTracker/proguard-rules.pro
+++ b/NRMediaTailorTracker/proguard-rules.pro
@@ -1,0 +1,6 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html

--- a/NRMediaTailorTracker/src/main/AndroidManifest.xml
+++ b/NRMediaTailorTracker/src/main/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+</manifest>

--- a/NRMediaTailorTracker/src/main/java/com/newrelic/videoagent/mediatailor/MTConstants.java
+++ b/NRMediaTailorTracker/src/main/java/com/newrelic/videoagent/mediatailor/MTConstants.java
@@ -1,0 +1,67 @@
+package com.newrelic.videoagent.mediatailor;
+
+/**
+ * Central bag of compile-time constants used across the MediaTailor tracker.
+ *
+ * <p>Grouped by concern:</p>
+ * <ul>
+ *   <li><b>URL markers</b> — substrings we look for in content-source URLs
+ *       ({@link #MT_URL_MARKER}) and in ad-period BaseURLs / segment URLs
+ *       ({@link #MT_SEGMENT_PATTERN}, {@link #MT_DASHSEGMENT_PATH_PATTERN},
+ *       {@link #MT_HLSSEGMENT_PATH_PATTERN}).</li>
+ *   <li><b>Manifest &amp; stream types</b> — logical strings used internally
+ *       ({@link #MANIFEST_TYPE_HLS}, {@link #MANIFEST_TYPE_DASH},
+ *       {@link #STREAM_TYPE_VOD}, {@link #STREAM_TYPE_LIVE}).</li>
+ *   <li><b>Event identity</b> — values reported on every {@code VideoAdAction}
+ *       event produced by the tracker ({@link #TRACKER_NAME},
+ *       {@link #AD_PARTNER}).</li>
+ *   <li><b>Timing thresholds</b> — {@link #MIN_AD_DURATION_MS} filters false
+ *       positives; {@link #AD_TIMING_TOLERANCE_MS} controls de-dup tolerance
+ *       when merging manifest-detected breaks with tracking-API avails;
+ *       {@link #PLAYHEAD_POLL_INTERVAL_MS} is the tick cadence.</li>
+ *   <li><b>HTTP timeouts</b> — {@link #TRACKING_TIMEOUT_MS},
+ *       {@link #TRACKING_MAX_RETRIES}.</li>
+ *   <li><b>Quartile fractions</b> — {@link #QUARTILE_Q1}, {@link #QUARTILE_Q2},
+ *       {@link #QUARTILE_Q3}.</li>
+ *   <li><b>VAST beacon event types</b> — used by {@link com.newrelic.videoagent.mediatailor.net.MTBeaconFirer}
+ *       when client-side reporting is enabled (see {@code BEACON_*}).</li>
+ * </ul>
+ */
+public final class MTConstants {
+
+    private MTConstants() {}
+
+    public static final String MT_URL_MARKER = "mediatailor";
+    public static final String MT_SEGMENT_PATTERN = "segments.mediatailor";
+    // Alternative MediaTailor ad-period markers — used when responses are served
+    // through MediaTailor's own/CDN rewrite host (see user guide p.183 for DASH).
+    public static final String MT_DASHSEGMENT_PATH_PATTERN = "/v1/dashsegment/";
+    public static final String MT_HLSSEGMENT_PATH_PATTERN = "/v1/hlssegment/";
+
+    public static final String SCTE35_SCHEME_MARKER = "scte35";
+
+    public static final String MANIFEST_TYPE_HLS = "hls";
+    public static final String MANIFEST_TYPE_DASH = "dash";
+
+    public static final String STREAM_TYPE_VOD = "vod";
+    public static final String STREAM_TYPE_LIVE = "live";
+
+    public static final String AD_POSITION_PRE = "pre";
+    public static final String AD_POSITION_MID = "mid";
+    public static final String AD_POSITION_POST = "post";
+
+    public static final String AD_PARTNER = "aws-mediatailor";
+    public static final String TRACKER_NAME = "NRMTracker";
+
+    public static final long MIN_AD_DURATION_MS = 500L;
+    public static final long AD_TIMING_TOLERANCE_MS = 500L;
+
+    public static final long PLAYHEAD_POLL_INTERVAL_MS = 250L;
+
+    public static final int TRACKING_TIMEOUT_MS = 5000;
+    public static final int TRACKING_MAX_RETRIES = 1;
+
+    public static final double QUARTILE_Q1 = 0.25;
+    public static final double QUARTILE_Q2 = 0.50;
+    public static final double QUARTILE_Q3 = 0.75;
+}

--- a/NRMediaTailorTracker/src/main/java/com/newrelic/videoagent/mediatailor/detection/MTDashParser.java
+++ b/NRMediaTailorTracker/src/main/java/com/newrelic/videoagent/mediatailor/detection/MTDashParser.java
@@ -1,0 +1,106 @@
+package com.newrelic.videoagent.mediatailor.detection;
+
+import androidx.annotation.OptIn;
+import androidx.media3.common.util.UnstableApi;
+import androidx.media3.exoplayer.dash.manifest.AdaptationSet;
+import androidx.media3.exoplayer.dash.manifest.BaseUrl;
+import androidx.media3.exoplayer.dash.manifest.DashManifest;
+import androidx.media3.exoplayer.dash.manifest.EventStream;
+import androidx.media3.exoplayer.dash.manifest.Period;
+import androidx.media3.exoplayer.dash.manifest.Representation;
+import androidx.media3.extractor.metadata.emsg.EventMessage;
+
+import com.newrelic.videoagent.mediatailor.MTConstants;
+import com.newrelic.videoagent.mediatailor.model.MTAdBreak;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Turns a Media3 {@link DashManifest} into a list of {@link MTAdBreak}s.
+ *
+ * <p>Two shapes are recognised:</p>
+ * <ul>
+ *   <li><b>Multi-period:</b> a period whose representations point at a base URL
+ *       containing {@code segments.mediatailor} is treated as an ad period.
+ *       Media3 1.2 exposes {@code BaseUrl}s on {@link Representation}, not on
+ *       {@link Period} directly — we walk down.</li>
+ *   <li><b>Single-period:</b> SCTE-35 {@link EventStream}s inside the period.</li>
+ * </ul>
+ */
+@OptIn(markerClass = UnstableApi.class)
+public final class MTDashParser {
+
+    private MTDashParser() {}
+
+    public static List<MTAdBreak> parse(DashManifest manifest) {
+        List<MTAdBreak> breaks = new ArrayList<>();
+        if (manifest == null) return breaks;
+
+        int periodCount = manifest.getPeriodCount();
+        if (periodCount <= 0) return breaks;
+
+        if (periodCount > 1) {
+            parseMultiPeriod(manifest, breaks);
+        } else {
+            parseSinglePeriod(manifest.getPeriod(0), breaks);
+        }
+        return breaks;
+    }
+
+    private static void parseMultiPeriod(DashManifest manifest, List<MTAdBreak> out) {
+        int count = manifest.getPeriodCount();
+        for (int i = 0; i < count; i++) {
+            Period period = manifest.getPeriod(i);
+            if (!isMediaTailorAdPeriod(period)) continue;
+
+            long startMs = period.startMs;
+            long durationMs = manifest.getPeriodDurationMs(i);
+            if (durationMs < MTConstants.MIN_AD_DURATION_MS) continue;
+
+            String id = period.id != null ? period.id : ("mt-period-" + startMs);
+            out.add(new MTAdBreak(id, startMs, durationMs));
+        }
+    }
+
+    private static void parseSinglePeriod(Period period, List<MTAdBreak> out) {
+        if (period == null || period.eventStreams == null) return;
+
+        for (EventStream stream : period.eventStreams) {
+            String scheme = stream.schemeIdUri != null ? stream.schemeIdUri : "";
+            if (!scheme.toLowerCase().contains(MTConstants.SCTE35_SCHEME_MARKER)) continue;
+
+            long[] times = stream.presentationTimesUs;
+            EventMessage[] events = stream.events;
+            if (times == null || events == null) continue;
+            int n = Math.min(times.length, events.length);
+
+            for (int i = 0; i < n; i++) {
+                long startMs = times[i] / 1000L;
+                long durationMs = events[i] != null ? events[i].durationMs : 0L;
+                if (durationMs < MTConstants.MIN_AD_DURATION_MS) continue;
+
+                String id = events[i] != null && events[i].id != 0
+                        ? "scte35-" + events[i].id
+                        : "scte35-" + startMs;
+                out.add(new MTAdBreak(id, startMs, durationMs));
+            }
+        }
+    }
+
+    private static boolean isMediaTailorAdPeriod(Period period) {
+        if (period == null || period.adaptationSets == null) return false;
+        for (AdaptationSet set : period.adaptationSets) {
+            if (set == null || set.representations == null) continue;
+            for (Representation rep : set.representations) {
+                if (rep == null || rep.baseUrls == null) continue;
+                for (BaseUrl b : rep.baseUrls) {
+                    if (b == null || b.url == null) continue;
+                    if (b.url.contains(MTConstants.MT_SEGMENT_PATTERN)) return true;
+                    if (b.url.contains(MTConstants.MT_DASHSEGMENT_PATH_PATTERN)) return true;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/NRMediaTailorTracker/src/main/java/com/newrelic/videoagent/mediatailor/detection/MTDetector.java
+++ b/NRMediaTailorTracker/src/main/java/com/newrelic/videoagent/mediatailor/detection/MTDetector.java
@@ -1,0 +1,72 @@
+package com.newrelic.videoagent.mediatailor.detection;
+
+import android.net.Uri;
+
+import com.newrelic.videoagent.mediatailor.MTConstants;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * URL-level heuristics for recognising MediaTailor streams and deriving
+ * companion endpoints.
+ *
+ * <ul>
+ *   <li>{@link #isMediaTailorUri(Uri)} — gate that activates the tracker only
+ *       when the {@link androidx.media3.common.MediaItem} URI looks like a
+ *       MediaTailor playback endpoint.</li>
+ *   <li>{@link #manifestType(Uri)} — DASH vs HLS from file extension.</li>
+ *   <li>{@link #extractTrackingUrl(Uri)} / {@link #extractSessionId(Uri)} —
+ *       rewrite a sessionized manifest URL ({@code ?aws.sessionId=…} or
+ *       {@code ?sessionId=…}) into its sibling {@code /v1/tracking/…/<sessionId>}
+ *       URL used by {@link com.newrelic.videoagent.mediatailor.net.MTTrackingClient}
+ *       to pull ad metadata.</li>
+ * </ul>
+ */
+public final class MTDetector {
+
+    private static final Pattern SESSION_ID = Pattern.compile("sessionId=([^&]+)");
+    private static final Pattern MANIFEST_SEGMENT =
+            Pattern.compile("/v1/(master|session|dash)/");
+    private static final Pattern MANIFEST_FILE =
+            Pattern.compile("/[^/]*\\.(m3u8|mpd)(\\?.*)?$");
+
+    private MTDetector() {}
+
+    public static boolean isMediaTailorUri(Uri uri) {
+        if (uri == null) return false;
+        String s = uri.toString();
+        return s != null && s.contains(MTConstants.MT_URL_MARKER);
+    }
+
+    public static String manifestType(Uri uri) {
+        if (uri == null) return MTConstants.MANIFEST_TYPE_HLS;
+        String path = uri.getPath();
+        if (path == null) return MTConstants.MANIFEST_TYPE_HLS;
+        if (path.endsWith(".mpd")) return MTConstants.MANIFEST_TYPE_DASH;
+        if (path.endsWith(".m3u8")) return MTConstants.MANIFEST_TYPE_HLS;
+        return MTConstants.MANIFEST_TYPE_HLS;
+    }
+
+    public static String extractTrackingUrl(Uri uri) {
+        if (uri == null) return null;
+        String full = uri.toString();
+        if (full == null) return null;
+        Matcher m = SESSION_ID.matcher(full);
+        if (!m.find()) return null;
+        String sessionId = m.group(1);
+        String rewritten = MANIFEST_SEGMENT.matcher(full).replaceFirst("/v1/tracking/");
+        rewritten = MANIFEST_FILE.matcher(rewritten).replaceFirst("/" + sessionId);
+        int q = rewritten.indexOf('?');
+        if (q >= 0) rewritten = rewritten.substring(0, q);
+        return rewritten;
+    }
+
+    public static String extractSessionId(Uri uri) {
+        if (uri == null) return null;
+        String full = uri.toString();
+        if (full == null) return null;
+        Matcher m = SESSION_ID.matcher(full);
+        return m.find() ? m.group(1) : null;
+    }
+}

--- a/NRMediaTailorTracker/src/main/java/com/newrelic/videoagent/mediatailor/detection/MTHlsParser.java
+++ b/NRMediaTailorTracker/src/main/java/com/newrelic/videoagent/mediatailor/detection/MTHlsParser.java
@@ -1,0 +1,89 @@
+package com.newrelic.videoagent.mediatailor.detection;
+
+import androidx.annotation.OptIn;
+import androidx.media3.common.util.UnstableApi;
+import androidx.media3.exoplayer.hls.HlsManifest;
+import androidx.media3.exoplayer.hls.playlist.HlsMediaPlaylist;
+
+import com.newrelic.videoagent.mediatailor.MTConstants;
+import com.newrelic.videoagent.mediatailor.model.MTAdBreak;
+import com.newrelic.videoagent.mediatailor.model.MTAdPod;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Turns a Media3 {@link HlsManifest} into a list of {@link MTAdBreak}s.
+ *
+ * <p>Media3 strips {@code #EXT-X-CUE-OUT} / {@code #EXT-X-CUE-IN} from the
+ * typed model, so we detect ad segments by URL pattern:
+ * either {@code segments.mediatailor} (hostname) or {@code /v1/hlssegment/}
+ * (path, used when responses are served through MediaTailor's own/CDN rewrite host).
+ * Pod boundaries inside a break are detected via
+ * {@link HlsMediaPlaylist.Segment#relativeDiscontinuitySequence} changes.</p>
+ */
+@OptIn(markerClass = UnstableApi.class)
+public final class MTHlsParser {
+
+    private MTHlsParser() {}
+
+    public static List<MTAdBreak> parse(HlsManifest manifest) {
+        List<MTAdBreak> breaks = new ArrayList<>();
+        if (manifest == null || manifest.mediaPlaylist == null) return breaks;
+        HlsMediaPlaylist playlist = manifest.mediaPlaylist;
+        if (playlist.segments == null || playlist.segments.isEmpty()) return breaks;
+
+        MTAdBreak currentBreak = null;
+        MTAdPod currentPod = null;
+        int lastDiscontinuity = Integer.MIN_VALUE;
+
+        for (HlsMediaPlaylist.Segment seg : playlist.segments) {
+            if (seg == null) continue;
+            long startMs = seg.relativeStartTimeUs / 1000L;
+            long durMs = Math.max(seg.durationUs / 1000L, 0L);
+
+            if (isMediaTailorSegment(seg)) {
+                if (currentBreak == null) {
+                    currentBreak = new MTAdBreak("hls-break-" + startMs, startMs, 0L);
+                    currentPod = new MTAdPod(startMs, 0L);
+                    lastDiscontinuity = seg.relativeDiscontinuitySequence;
+                } else if (seg.relativeDiscontinuitySequence != lastDiscontinuity) {
+                    closePod(currentBreak, currentPod);
+                    currentPod = new MTAdPod(startMs, 0L);
+                    lastDiscontinuity = seg.relativeDiscontinuitySequence;
+                }
+                currentBreak.durationMs += durMs;
+                if (currentPod != null) currentPod.durationMs += durMs;
+            } else if (currentBreak != null) {
+                closeBreak(breaks, currentBreak, currentPod);
+                currentBreak = null;
+                currentPod = null;
+                lastDiscontinuity = Integer.MIN_VALUE;
+            }
+        }
+        if (currentBreak != null) {
+            closeBreak(breaks, currentBreak, currentPod);
+        }
+        return breaks;
+    }
+
+    private static boolean isMediaTailorSegment(HlsMediaPlaylist.Segment seg) {
+        if (seg.url == null) return false;
+        return seg.url.contains(MTConstants.MT_SEGMENT_PATTERN)
+                || seg.url.contains(MTConstants.MT_HLSSEGMENT_PATH_PATTERN);
+    }
+
+    private static void closePod(MTAdBreak br, MTAdPod pod) {
+        if (pod == null) return;
+        if (pod.durationMs < MTConstants.MIN_AD_DURATION_MS) return;
+        pod.endTimeMs = pod.startTimeMs + pod.durationMs;
+        br.pods.add(pod);
+    }
+
+    private static void closeBreak(List<MTAdBreak> out, MTAdBreak br, MTAdPod pod) {
+        closePod(br, pod);
+        if (br.durationMs < MTConstants.MIN_AD_DURATION_MS) return;
+        br.endTimeMs = br.startTimeMs + br.durationMs;
+        out.add(br);
+    }
+}

--- a/NRMediaTailorTracker/src/main/java/com/newrelic/videoagent/mediatailor/model/MTAdBreak.java
+++ b/NRMediaTailorTracker/src/main/java/com/newrelic/videoagent/mediatailor/model/MTAdBreak.java
@@ -1,0 +1,72 @@
+package com.newrelic.videoagent.mediatailor.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A contiguous server-stitched ad slot in the player timeline (equivalent to a
+ * MediaTailor "avail" or a VAST {@code <AdBreak>}). One or more
+ * {@link MTAdPod}s play back-to-back inside the break.
+ *
+ * <p>Populated from two sources that are merged by
+ * {@link com.newrelic.videoagent.mediatailor.schedule.MTAdScheduleMerger}:</p>
+ * <ol>
+ *   <li>Manifest parse ({@link com.newrelic.videoagent.mediatailor.detection.MTDashParser}
+ *       / {@link com.newrelic.videoagent.mediatailor.detection.MTHlsParser}) —
+ *       provides timing and pod boundaries from discontinuities.</li>
+ *   <li>Tracking API ({@link com.newrelic.videoagent.mediatailor.net.MTTrackingClient})
+ *       — fills in titles, VAST IDs, tracking beacon URLs, skippability.</li>
+ * </ol>
+ *
+ * <p>All time fields are <strong>milliseconds</strong>, relative to the
+ * content timeline (first content frame = 0). "Fired" flags prevent
+ * duplicate emission of AD_BREAK_START / AD_START / quartile events from the
+ * tracker's playhead-poll loop.</p>
+ */
+public class MTAdBreak {
+
+    public String id;
+    public long startTimeMs;
+    public long durationMs;
+    public long endTimeMs;
+
+    public String title;
+    public String adId;                    // VAST <Ad id="…">
+    public String creativeId;              // VAST <Creative id="…">
+    public String adSystem;                // ad server name
+    public String creativeSequence;        // 1-based index
+    public String vastAdId;
+    public String skipOffset;
+    public String availProgramDateTime;    // wall clock of avail (Live)
+    public String adPosition;
+    public boolean confirmedByTracking;
+
+    public boolean hasFiredStart;
+    public boolean hasFiredEnd;
+    public boolean hasFiredAdStart;
+    public boolean hasFiredQ1;
+    public boolean hasFiredQ2;
+    public boolean hasFiredQ3;
+
+    public final List<MTAdPod> pods = new ArrayList<>();
+
+    public MTAdBreak(String id, long startTimeMs, long durationMs) {
+        this.id = id;
+        this.startTimeMs = startTimeMs;
+        this.durationMs = durationMs;
+        this.endTimeMs = startTimeMs + durationMs;
+    }
+
+    public boolean contains(long positionMs) {
+        return positionMs >= startTimeMs && positionMs < endTimeMs;
+    }
+
+    public MTAdPod findActivePod(long positionMs) {
+        for (MTAdPod pod : pods) {
+            if (pod.contains(positionMs)) {
+                return pod;
+            }
+        }
+        return null;
+    }
+}

--- a/NRMediaTailorTracker/src/main/java/com/newrelic/videoagent/mediatailor/model/MTAdPod.java
+++ b/NRMediaTailorTracker/src/main/java/com/newrelic/videoagent/mediatailor/model/MTAdPod.java
@@ -1,0 +1,42 @@
+package com.newrelic.videoagent.mediatailor.model;
+
+/**
+ * A single ad creative inside an {@link MTAdBreak}. Roughly equivalent to a
+ * VAST {@code <Ad>} / {@code <Creative>} pair. Multiple pods play sequentially
+ * within one break.
+ *
+ * <p>Timing fields are absolute-to-the-content-timeline milliseconds. The
+ * quartile flags ({@code hasFiredQ1/Q2/Q3}) are set by the tracker's poll loop
+ * to ensure each quartile event fires at most once.</p>
+ */
+public class MTAdPod {
+
+    public long startTimeMs;
+    public long durationMs;
+    public long endTimeMs;
+
+    public String title;
+    public String adId;               // VAST <Ad id="…"> — exposed as adId in NR events
+    public String creativeId;         // VAST <Creative id="…"> — exposed as adCreativeId
+    public String adSystem;           // ad server name
+    public String creativeSequence;   // 1-based index within pod
+    public String vastAdId;
+    public String skipOffset;         // HH:MM:SS, null if not skippable
+    public String adProgramDateTime;  // wall clock
+    public boolean isBumper;
+
+    public boolean hasFiredStart;
+    public boolean hasFiredQ1;
+    public boolean hasFiredQ2;
+    public boolean hasFiredQ3;
+
+    public MTAdPod(long startTimeMs, long durationMs) {
+        this.startTimeMs = startTimeMs;
+        this.durationMs = durationMs;
+        this.endTimeMs = startTimeMs + durationMs;
+    }
+
+    public boolean contains(long positionMs) {
+        return positionMs >= startTimeMs && positionMs < endTimeMs;
+    }
+}

--- a/NRMediaTailorTracker/src/main/java/com/newrelic/videoagent/mediatailor/net/MTTrackingClient.java
+++ b/NRMediaTailorTracker/src/main/java/com/newrelic/videoagent/mediatailor/net/MTTrackingClient.java
@@ -1,0 +1,175 @@
+package com.newrelic.videoagent.mediatailor.net;
+
+import com.newrelic.videoagent.core.utils.NRLog;
+import com.newrelic.videoagent.mediatailor.MTConstants;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Fetches and parses AWS MediaTailor's client-side tracking metadata.
+ *
+ * <p>Instance lifecycle:</p>
+ * <ol>
+ *   <li>Construct once per tracking-fetch attempt.</li>
+ *   <li>Call {@link #fetch(String)} from a worker thread — the request
+ *       synchronously blocks that thread until the response arrives or the
+ *       configured timeout elapses.</li>
+ *   <li>If disposal races in, call {@link #cancel()} to abort the open
+ *       connection; the in-flight {@code fetch} then returns {@code null}.</li>
+ * </ol>
+ *
+ * <p>Implementation notes:</p>
+ * <ul>
+ *   <li>Uses only {@link HttpURLConnection} + {@code org.json} — the module
+ *       deliberately avoids OkHttp and the AWS SDK.</li>
+ *   <li>Cache-busts each request with a {@code ?t=<millis>} query param
+ *       (MediaTailor otherwise serves cached JSON).</li>
+ *   <li>Retries once on exception; returns {@code null} after that.</li>
+ * </ul>
+ */
+public class MTTrackingClient {
+
+    private final AtomicBoolean cancelled = new AtomicBoolean(false);
+    private volatile HttpURLConnection activeConnection;
+
+    public void cancel() {
+        cancelled.set(true);
+        HttpURLConnection c = activeConnection;
+        if (c != null) {
+            try { c.disconnect(); } catch (Exception ignored) {}
+        }
+    }
+
+    public MTTrackingResponse fetch(String trackingUrl) {
+        int attempts = 0;
+        while (attempts <= MTConstants.TRACKING_MAX_RETRIES) {
+            if (cancelled.get()) return null;
+            try {
+                return fetchOnce(trackingUrl);
+            } catch (Exception e) {
+                if (cancelled.get()) return null;
+                NRLog.d("MT tracking fetch attempt " + (attempts + 1) + " failed: " + e);
+                attempts++;
+            }
+        }
+        return null;
+    }
+
+    private MTTrackingResponse fetchOnce(String trackingUrl) throws IOException, JSONException {
+        URL url = new URL(trackingUrl + "?t=" + System.currentTimeMillis());
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        activeConnection = conn;
+        try {
+            conn.setRequestMethod("GET");
+            conn.setConnectTimeout(MTConstants.TRACKING_TIMEOUT_MS);
+            conn.setReadTimeout(MTConstants.TRACKING_TIMEOUT_MS);
+            conn.setRequestProperty("Accept", "application/json");
+
+            int code = conn.getResponseCode();
+            if (code < 200 || code >= 300) {
+                throw new IOException("Tracking API HTTP " + code);
+            }
+
+            StringBuilder sb = new StringBuilder();
+            try (BufferedReader r = new BufferedReader(
+                    new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8))) {
+                String line;
+                while ((line = r.readLine()) != null) {
+                    if (cancelled.get()) return null;
+                    sb.append(line);
+                }
+            }
+            return parse(sb.toString());
+        } finally {
+            activeConnection = null;
+            try { conn.disconnect(); } catch (Exception ignored) {}
+        }
+    }
+
+    static MTTrackingResponse parse(String json) throws JSONException {
+        MTTrackingResponse out = new MTTrackingResponse();
+        JSONObject root = new JSONObject(json);
+        JSONArray availsJson = root.optJSONArray("avails");
+        if (availsJson != null) {
+            for (int i = 0; i < availsJson.length(); i++) {
+                out.avails.add(parseAvail(availsJson.getJSONObject(i)));
+            }
+        }
+        JSONArray nonLinearJson = root.optJSONArray("nonLinearAvails");
+        if (nonLinearJson != null) {
+            for (int i = 0; i < nonLinearJson.length(); i++) {
+                JSONObject n = nonLinearJson.getJSONObject(i);
+                MTTrackingResponse.NonLinearAvail nl = new MTTrackingResponse.NonLinearAvail();
+                nl.availId = n.optString("availId", null);
+                nl.startTimeMs = toMs(n.opt("startTimeInSeconds"));
+                nl.durationMs = toMs(n.opt("durationInSeconds"));
+                JSONArray ads = n.optJSONArray("ads");
+                nl.adCount = ads != null ? ads.length() : 0;
+                out.nonLinearAvails.add(nl);
+            }
+        }
+        return out;
+    }
+
+    private static MTTrackingResponse.Avail parseAvail(JSONObject a) throws JSONException {
+        MTTrackingResponse.Avail avail = new MTTrackingResponse.Avail();
+        avail.availId = a.optString("availId", null);
+        avail.startTimeMs = toMs(a.opt("startTimeInSeconds"));
+        avail.durationMs = toMs(a.opt("durationInSeconds"));
+        avail.availProgramDateTime = a.optString("availProgramDateTime", null);
+        JSONArray adsJson = a.optJSONArray("ads");
+        if (adsJson != null) {
+            for (int j = 0; j < adsJson.length(); j++) {
+                avail.ads.add(parseAd(adsJson.getJSONObject(j)));
+            }
+        }
+        return avail;
+    }
+
+    private static MTTrackingResponse.Ad parseAd(JSONObject adJson) throws JSONException {
+        MTTrackingResponse.Ad ad = new MTTrackingResponse.Ad();
+        ad.adId = adJson.optString("adId", null);
+        ad.adTitle = adJson.optString("adTitle", null);
+        ad.startTimeMs = toMs(adJson.opt("startTimeInSeconds"));
+        ad.durationMs = toMs(adJson.opt("durationInSeconds"));
+        ad.adSystem = adJson.optString("adSystem", null);
+        ad.creativeId = adJson.optString("creativeId", null);
+        ad.creativeSequence = adJson.optString("creativeSequence", null);
+        ad.vastAdId = adJson.optString("vastAdId", null);
+        ad.skipOffset = adJson.optString("skipOffset", null);
+        ad.adProgramDateTime = adJson.optString("adProgramDateTime", null);
+        // Heuristic: MediaTailor bumpers aren't explicitly flagged in the JSON,
+        // but they typically surface with an ad system name like "Bumper" or
+        // an ad title/id containing "bumper". Loose match, case-insensitive.
+        ad.isBumper = containsIgnoreCase(ad.adSystem, "bumper")
+                || containsIgnoreCase(ad.adTitle, "bumper")
+                || containsIgnoreCase(ad.adId, "bumper");
+        return ad;
+    }
+
+    private static boolean containsIgnoreCase(String haystack, String needle) {
+        return haystack != null && haystack.toLowerCase().contains(needle);
+    }
+
+    private static long toMs(Object seconds) {
+        if (seconds == null) return 0L;
+        if (seconds instanceof Number) {
+            return Math.round(((Number) seconds).doubleValue() * 1000.0);
+        }
+        try {
+            return Math.round(Double.parseDouble(seconds.toString()) * 1000.0);
+        } catch (NumberFormatException e) {
+            return 0L;
+        }
+    }
+}

--- a/NRMediaTailorTracker/src/main/java/com/newrelic/videoagent/mediatailor/net/MTTrackingResponse.java
+++ b/NRMediaTailorTracker/src/main/java/com/newrelic/videoagent/mediatailor/net/MTTrackingResponse.java
@@ -1,0 +1,57 @@
+package com.newrelic.videoagent.mediatailor.net;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Typed Java view of the JSON returned by MediaTailor's client-side tracking
+ * API ({@code GET /v1/tracking/<accountId>/<config>/<sessionId>}).
+ *
+ * <p>Populated by {@link MTTrackingClient#parse(String)} and consumed by
+ * {@link com.newrelic.videoagent.mediatailor.schedule.MTAdScheduleMerger} to
+ * enrich the manifest-derived ad schedule with creative metadata and, when the
+ * app opts in, VAST beacon URLs to fire client-side.</p>
+ *
+ * <p>Only fields the tracker uses are modelled; extensions, companion ads,
+ * icons, and ad-verification payloads are ignored. Time fields are
+ * normalised to milliseconds at parse time — the wire format uses seconds.</p>
+ */
+public class MTTrackingResponse {
+
+    public final List<Avail> avails = new ArrayList<>();
+    /** Overlay / banner / VPAID non-linear avails. */
+    public final List<NonLinearAvail> nonLinearAvails = new ArrayList<>();
+
+    public static class Avail {
+        public String availId;
+        public long startTimeMs;
+        public long durationMs;
+        public String availProgramDateTime;
+        public final List<Ad> ads = new ArrayList<>();
+    }
+
+    public static class Ad {
+        public String adId;             // VAST <Ad id="…">
+        public String adTitle;
+        public long startTimeMs;
+        public long durationMs;
+        public String adSystem;         // ad server name (GDFP, FreeWheel, SpringServe, Publica)
+        public String creativeId;       // VAST <Creative id="…"> — different from adId
+        public String creativeSequence; // 1-based index of creative within an ad pod
+        public String vastAdId;         // VAST hierarchical ad identifier
+        public String skipOffset;       // HH:MM:SS for skippable ads (null if not skippable)
+        public String adProgramDateTime; // wall clock of ad start (Live correlation)
+        public boolean isBumper;        // ad stitched in from a MediaTailor bumper configuration
+    }
+
+    /**
+     * A single non-linear (overlay/banner) ad avail. Full rendering is the
+     * app's responsibility; the tracker only surfaces that they exist.
+     */
+    public static class NonLinearAvail {
+        public String availId;
+        public long startTimeMs;
+        public long durationMs;
+        public int adCount;
+    }
+}

--- a/NRMediaTailorTracker/src/main/java/com/newrelic/videoagent/mediatailor/schedule/MTAdScheduleMerger.java
+++ b/NRMediaTailorTracker/src/main/java/com/newrelic/videoagent/mediatailor/schedule/MTAdScheduleMerger.java
@@ -1,0 +1,195 @@
+package com.newrelic.videoagent.mediatailor.schedule;
+
+import com.newrelic.videoagent.mediatailor.MTConstants;
+import com.newrelic.videoagent.mediatailor.model.MTAdBreak;
+import com.newrelic.videoagent.mediatailor.model.MTAdPod;
+import com.newrelic.videoagent.mediatailor.net.MTTrackingResponse;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Combines ad-break data from two independent sources into a single sorted
+ * schedule owned by the tracker:
+ *
+ * <ol>
+ *   <li><b>Manifest parse</b> — timing and pod boundaries discovered by
+ *       {@link com.newrelic.videoagent.mediatailor.detection.MTDashParser}
+ *       or {@link com.newrelic.videoagent.mediatailor.detection.MTHlsParser}.</li>
+ *   <li><b>Tracking API</b> — rich VAST metadata (titles, creative IDs,
+ *       ad system, skip offsets, tracking beacons) returned by
+ *       {@link com.newrelic.videoagent.mediatailor.net.MTTrackingClient}.</li>
+ * </ol>
+ *
+ * <p>De-duplication uses {@code startTimeMs} matching within
+ * {@link MTConstants#AD_TIMING_TOLERANCE_MS} so that a break first seen by
+ * the manifest parser and later confirmed by the tracking API is kept as a
+ * single entry rather than counted twice.</p>
+ *
+ * <p>Pure utility — no I/O, no mutable state — so it's safe to call from the
+ * main thread during poll-loop ticks.</p>
+ */
+public final class MTAdScheduleMerger {
+
+    private MTAdScheduleMerger() {}
+
+    /**
+     * Merges newly-detected ad breaks into the existing schedule, de-duplicating
+     * by {@code startTimeMs} within {@link MTConstants#AD_TIMING_TOLERANCE_MS}.
+     * Preserves fired-flag state on existing breaks.
+     */
+    public static List<MTAdBreak> mergeSchedule(List<MTAdBreak> existing, List<MTAdBreak> incoming) {
+        List<MTAdBreak> merged = new ArrayList<>(existing);
+        for (MTAdBreak candidate : incoming) {
+            if (candidate == null) continue;
+            MTAdBreak match = findMatch(merged, candidate.startTimeMs);
+            if (match == null) {
+                merged.add(candidate);
+            } else if (!match.confirmedByTracking && candidate.confirmedByTracking) {
+                copyMetadata(candidate, match);
+            }
+        }
+        sortByStart(merged);
+        return merged;
+    }
+
+    /**
+     * Enriches the schedule with tracking API metadata. Existing breaks gain
+     * titles/creativeIds/pods; avails not present in the schedule are appended.
+     */
+    public static List<MTAdBreak> enrichWithTracking(List<MTAdBreak> schedule, MTTrackingResponse tracking) {
+        if (tracking == null) return schedule;
+        List<MTAdBreak> out = new ArrayList<>(schedule);
+
+        for (MTTrackingResponse.Avail avail : tracking.avails) {
+            if (avail == null) continue;
+            long availStart = resolveAvailStart(avail);
+            if (availStart < 0) continue;
+
+            MTAdBreak match = findMatch(out, availStart);
+            if (match != null) {
+                enrich(match, avail);
+            } else {
+                out.add(fromAvail(avail, availStart));
+            }
+        }
+        sortByStart(out);
+        return out;
+    }
+
+    private static MTAdBreak findMatch(List<MTAdBreak> list, long startMs) {
+        for (MTAdBreak b : list) {
+            if (Math.abs(b.startTimeMs - startMs) < MTConstants.AD_TIMING_TOLERANCE_MS) {
+                return b;
+            }
+        }
+        return null;
+    }
+
+    private static void copyMetadata(MTAdBreak from, MTAdBreak into) {
+        into.id = from.id;
+        into.title = from.title;
+        into.creativeId = from.creativeId;
+        into.confirmedByTracking = from.confirmedByTracking;
+        if (from.durationMs > 0) {
+            into.durationMs = from.durationMs;
+            into.endTimeMs = into.startTimeMs + from.durationMs;
+        }
+    }
+
+    private static void enrich(MTAdBreak target, MTTrackingResponse.Avail avail) {
+        if (avail.availId != null) target.id = avail.availId;
+        target.confirmedByTracking = true;
+        target.availProgramDateTime = avail.availProgramDateTime;
+        if (avail.durationMs > 0) {
+            target.durationMs = avail.durationMs;
+            target.endTimeMs = target.startTimeMs + avail.durationMs;
+        }
+        if (!avail.ads.isEmpty()) {
+            MTTrackingResponse.Ad first = avail.ads.get(0);
+            if (first.adTitle != null) target.title = first.adTitle;
+            target.adId = first.adId;
+            target.creativeId = first.creativeId;
+            target.adSystem = first.adSystem;
+            target.creativeSequence = first.creativeSequence;
+            target.vastAdId = first.vastAdId;
+            target.skipOffset = first.skipOffset;
+        }
+
+        if (!target.pods.isEmpty() && target.pods.size() == avail.ads.size()) {
+            for (int i = 0; i < target.pods.size(); i++) {
+                copyAdToPod(avail.ads.get(i), target.pods.get(i));
+            }
+        } else {
+            target.pods.clear();
+            for (MTTrackingResponse.Ad ad : avail.ads) {
+                MTAdPod pod = new MTAdPod(ad.startTimeMs, ad.durationMs);
+                copyAdToPod(ad, pod);
+                target.pods.add(pod);
+            }
+        }
+    }
+
+    private static void copyAdToPod(MTTrackingResponse.Ad ad, MTAdPod pod) {
+        pod.title = ad.adTitle;
+        pod.adId = ad.adId;
+        pod.creativeId = ad.creativeId;
+        pod.adSystem = ad.adSystem;
+        pod.creativeSequence = ad.creativeSequence;
+        pod.vastAdId = ad.vastAdId;
+        pod.skipOffset = ad.skipOffset;
+        pod.adProgramDateTime = ad.adProgramDateTime;
+        pod.isBumper = ad.isBumper;
+        if (ad.durationMs > 0) {
+            pod.durationMs = ad.durationMs;
+            pod.endTimeMs = pod.startTimeMs + ad.durationMs;
+        }
+    }
+
+    private static MTAdBreak fromAvail(MTTrackingResponse.Avail avail, long startMs) {
+        String id = avail.availId != null ? avail.availId : ("avail-" + startMs);
+        long durationMs = avail.durationMs > 0 ? avail.durationMs : sumAdDurations(avail);
+        MTAdBreak b = new MTAdBreak(id, startMs, durationMs);
+        b.confirmedByTracking = true;
+        b.availProgramDateTime = avail.availProgramDateTime;
+        if (!avail.ads.isEmpty()) {
+            MTTrackingResponse.Ad first = avail.ads.get(0);
+            b.title = first.adTitle;
+            b.adId = first.adId;
+            b.creativeId = first.creativeId;
+            b.adSystem = first.adSystem;
+            b.creativeSequence = first.creativeSequence;
+            b.vastAdId = first.vastAdId;
+            b.skipOffset = first.skipOffset;
+            for (MTTrackingResponse.Ad ad : avail.ads) {
+                MTAdPod pod = new MTAdPod(ad.startTimeMs, ad.durationMs);
+                copyAdToPod(ad, pod);
+                b.pods.add(pod);
+            }
+        }
+        return b;
+    }
+
+    private static long resolveAvailStart(MTTrackingResponse.Avail avail) {
+        if (avail.startTimeMs > 0) return avail.startTimeMs;
+        if (!avail.ads.isEmpty()) return avail.ads.get(0).startTimeMs;
+        return -1L;
+    }
+
+    private static long sumAdDurations(MTTrackingResponse.Avail avail) {
+        long total = 0L;
+        for (MTTrackingResponse.Ad ad : avail.ads) total += Math.max(ad.durationMs, 0L);
+        return total;
+    }
+
+    private static void sortByStart(List<MTAdBreak> list) {
+        Collections.sort(list, new Comparator<MTAdBreak>() {
+            @Override
+            public int compare(MTAdBreak a, MTAdBreak b) {
+                return Long.compare(a.startTimeMs, b.startTimeMs);
+            }
+        });
+    }
+}

--- a/NRMediaTailorTracker/src/main/java/com/newrelic/videoagent/mediatailor/tracker/NRTrackerMediaTailor.java
+++ b/NRMediaTailorTracker/src/main/java/com/newrelic/videoagent/mediatailor/tracker/NRTrackerMediaTailor.java
@@ -1,0 +1,768 @@
+package com.newrelic.videoagent.mediatailor.tracker;
+
+import android.net.Uri;
+import android.os.Handler;
+import android.os.Looper;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.OptIn;
+import androidx.media3.common.C;
+import androidx.media3.common.MediaItem;
+import androidx.media3.common.MediaLibraryInfo;
+import androidx.media3.common.Metadata;
+import androidx.media3.common.Player;
+import androidx.media3.common.Timeline;
+import androidx.media3.common.util.UnstableApi;
+import androidx.media3.exoplayer.ExoPlayer;
+import androidx.media3.exoplayer.dash.manifest.DashManifest;
+import androidx.media3.exoplayer.hls.HlsManifest;
+import androidx.media3.extractor.metadata.emsg.EventMessage;
+
+import com.newrelic.videoagent.core.NRVideoConfiguration;
+import com.newrelic.videoagent.core.tracker.NRVideoTracker;
+import com.newrelic.videoagent.core.utils.NRLog;
+import com.newrelic.videoagent.mediatailor.BuildConfig;
+import com.newrelic.videoagent.mediatailor.MTConstants;
+import com.newrelic.videoagent.mediatailor.detection.MTDashParser;
+import com.newrelic.videoagent.mediatailor.detection.MTDetector;
+import com.newrelic.videoagent.mediatailor.detection.MTHlsParser;
+import com.newrelic.videoagent.mediatailor.model.MTAdBreak;
+import com.newrelic.videoagent.mediatailor.model.MTAdPod;
+import com.newrelic.videoagent.mediatailor.net.MTTrackingClient;
+import com.newrelic.videoagent.mediatailor.net.MTTrackingResponse;
+import com.newrelic.videoagent.mediatailor.schedule.MTAdScheduleMerger;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * AWS Elemental MediaTailor SSAI tracker for Media3 ExoPlayer.
+ *
+ * <p>Lives in the ad-tracker slot of an {@code NRTrackerPair}. Its
+ * {@code state.isAd} flag is set to {@code true} by
+ * {@code NewRelicVideoAgent.start(...)}, so every {@code sendStart/sendEnd/
+ * sendAdBreakStart/...} call produces {@code VideoAdAction} events, and the
+ * base class automatically pauses/resumes the linked content tracker at
+ * break boundaries.</p>
+ *
+ * <p>Event production pipeline:</p>
+ * <ol>
+ *   <li>{@code onMediaItemTransition} / {@code onTimelineChanged} — detect
+ *       MediaTailor URIs ({@link MTDetector#isMediaTailorUri}), pick parser
+ *       (DASH / HLS) from the file extension, and derive the tracking URL
+ *       either from the URI query or from {@code DashManifest.location}.</li>
+ *   <li>Typed manifest parsing —
+ *       {@link MTDashParser#parse(DashManifest)} or
+ *       {@link MTHlsParser#parse(HlsManifest)} — builds an in-memory schedule
+ *       of {@link MTAdBreak}s.</li>
+ *   <li>Tracking API — {@link MTTrackingClient} fetches rich VAST metadata
+ *       (titles, creative IDs, ad system, skip offsets, beacon URLs).
+ *       {@link MTAdScheduleMerger} merges manifest + tracking data.</li>
+ *   <li>250 ms playhead poll — compares the player's current position to the
+ *       schedule, fires {@code AD_BREAK_START / AD_REQUEST / AD_START /
+ *       AD_QUARTILE / AD_END / AD_BREAK_END} at the right transitions, and
+ *       (optionally) fires VAST beacons client-side via {@link MTBeaconFirer}.</li>
+ * </ol>
+ *
+ * <p>Public API surfaces for app integration:</p>
+ * <ul>
+ *   <li>{@link #setTrackingUrl(String)} — plug in a tracking URL obtained
+ *       from an external session-init flow.</li>
+ *   <li>{@link #setClientSideBeacons(boolean)} — enable when the session was
+ *       initialised with {@code reportingMode=client}.</li>
+ *   <li>{@link #notifyAdSkipped()} — call from the app's "Skip ad" button.</li>
+ * </ul>
+ */
+@OptIn(markerClass = UnstableApi.class)
+public class NRTrackerMediaTailor extends NRVideoTracker implements Player.Listener {
+
+    private ExoPlayer player;
+
+    private boolean activated;
+    private String manifestType;
+    private String streamType;
+    private String mediaTailorEndpoint;
+    private String trackingUrl;
+
+    private final List<MTAdBreak> adSchedule = Collections.synchronizedList(new ArrayList<MTAdBreak>());
+    private MTAdBreak currentAdBreak;
+    private MTAdPod currentAdPod;
+    private Long currentQuartile;
+
+    private final AtomicBoolean isDisposed = new AtomicBoolean(false);
+    private final AtomicBoolean hasAttemptedTrackingFetch = new AtomicBoolean(false);
+
+    private Handler pollHandler;
+    private Runnable pollRunnable;
+    private MTTrackingClient trackingClient;
+    private Thread trackingWorker;
+
+    private int nonLinearAvailsCount = 0;
+
+    public NRTrackerMediaTailor(NRVideoConfiguration configuration) {
+        super(configuration);
+    }
+
+    @Deprecated
+    public NRTrackerMediaTailor() {
+        super();
+    }
+
+    public NRTrackerMediaTailor(NRVideoConfiguration configuration, ExoPlayer player) {
+        super(configuration);
+        setPlayer(player);
+    }
+
+    @Override
+    public void setPlayer(Object player) {
+        this.player = (ExoPlayer) player;
+        registerListeners();
+    }
+
+    @Override
+    public void registerListeners() {
+        super.registerListeners();
+        if (player != null) {
+            player.addListener(this);
+        }
+    }
+
+    @Override
+    public void unregisterListeners() {
+        super.unregisterListeners();
+        if (player != null) {
+            player.removeListener(this);
+        }
+    }
+
+    @Override
+    public void dispose() {
+        if (!isDisposed.compareAndSet(false, true)) return;
+
+        stopPolling();
+        cancelTrackingFetch();
+        unregisterListeners();
+
+        synchronized (adSchedule) { adSchedule.clear(); }
+        currentAdBreak = null;
+        currentAdPod = null;
+        player = null;
+
+        super.dispose();
+    }
+
+    /**
+     * Escape hatch for setting the MediaTailor tracking URL manually.
+     *
+     * <p>In the common case the tracker auto-derives the tracking URL from
+     * the sessionized manifest URI that ExoPlayer loads (either the query
+     * {@code aws.sessionId=…} on first playback, or the DASH MPD
+     * {@code <Location>} element). Only call this if you're handing the
+     * player a pre-sessionized URL without {@code aws.sessionId}, or if your
+     * CDN/proxy strips the session id from the URI the player sees.</p>
+     */
+    public void setTrackingUrl(String trackingUrl) {
+        this.trackingUrl = trackingUrl;
+    }
+
+    /**
+     * App-invoked when the user taps skip on a skippable ad. Emits an
+     * {@code AD_SKIP} New Relic event.
+     */
+    public void notifyAdSkipped() {
+        if (isDisposed.get() || currentAdBreak == null) return;
+        NRLog.d("MT AD_SKIP (user skipped)");
+        sendVideoAdEvent("AD_SKIP");
+    }
+
+    // ── Player.Listener ───────────────────────────────────────────────────
+
+    @Override
+    public void onMediaItemTransition(MediaItem mediaItem, int reason) {
+        if (isDisposed.get()) return;
+        Uri uri = mediaItem != null && mediaItem.localConfiguration != null
+                ? mediaItem.localConfiguration.uri : null;
+        detectSource(uri);
+    }
+
+    @Override
+    public void onTimelineChanged(@NonNull Timeline timeline, int reason) {
+        if (isDisposed.get()) return;
+        if (!activated && player != null && player.getCurrentMediaItem() != null) {
+            MediaItem mi = player.getCurrentMediaItem();
+            detectSource(mi.localConfiguration != null ? mi.localConfiguration.uri : null);
+        }
+        if (activated) {
+            detectStreamTypeIfNeeded();
+            reparseManifest();
+        }
+    }
+
+    @Override
+    public void onMetadata(@NonNull Metadata metadata) {
+        if (isDisposed.get() || !activated) return;
+        handleMetadata(metadata);
+    }
+
+    @Override
+    public void onPlaybackStateChanged(int playbackState) {
+        if (isDisposed.get() || !activated) return;
+        if (playbackState == Player.STATE_READY) {
+            detectStreamTypeIfNeeded();
+            reparseManifest();
+        }
+        if (currentAdBreak == null) return;
+        // During an ad break, translate buffering + seek state into AD_*
+        // events rather than letting the content tracker emit CONTENT_*.
+        if (playbackState == Player.STATE_BUFFERING) {
+            NRLog.d("MT AD_BUFFER_START (buffering inside ad break)");
+            sendBufferStart();
+        } else if (playbackState == Player.STATE_READY) {
+            if (getState().isBuffering) {
+                NRLog.d("MT AD_BUFFER_END (buffering resolved inside ad break)");
+                sendBufferEnd();
+            }
+            if (getState().isSeeking) {
+                NRLog.d("MT AD_SEEK_END (seek resolved inside ad break)");
+                sendSeekEnd();
+            }
+        }
+    }
+
+    @Override
+    public void onPositionDiscontinuity(@NonNull Player.PositionInfo oldPosition,
+                                        @NonNull Player.PositionInfo newPosition,
+                                        int reason) {
+        if (isDisposed.get() || !activated) return;
+        if (currentAdBreak == null) return;
+        if (reason == Player.DISCONTINUITY_REASON_SEEK && !getState().isSeeking) {
+            NRLog.d("MT AD_SEEK_START (user seek during ad break)");
+            sendSeekStart();
+        }
+    }
+
+    @Override
+    public void onPlayWhenReadyChanged(boolean playWhenReady, int reason) {
+        if (isDisposed.get() || !activated) return;
+        if (currentAdBreak == null) return;
+        if (!playWhenReady) {
+            NRLog.d("MT AD_PAUSE (user pause during ad break)");
+            sendPause();
+        } else {
+            if (getState().isPaused) {
+                NRLog.d("MT AD_RESUME (user resume during ad break)");
+                sendResume();
+            }
+        }
+    }
+
+    // ── detection & activation ────────────────────────────────────────────
+
+    private void detectSource(Uri uri) {
+        if (!MTDetector.isMediaTailorUri(uri)) {
+            NRLog.d("MT detectSource: not a MediaTailor URI, staying inert. uri="
+                    + (uri != null ? uri : "null"));
+            if (activated) {
+                // Source swapped to non-MT content; quiesce.
+                deactivate();
+            }
+            return;
+        }
+        if (activated && uri != null && uri.toString().equals(mediaTailorEndpoint)) {
+            return;
+        }
+        activate(uri);
+    }
+
+    private void activate(Uri uri) {
+        activated = true;
+        mediaTailorEndpoint = uri.toString();
+        manifestType = MTDetector.manifestType(uri);
+        if (trackingUrl == null) {
+            trackingUrl = MTDetector.extractTrackingUrl(uri);
+        }
+        hasAttemptedTrackingFetch.set(false);
+        synchronized (adSchedule) { adSchedule.clear(); }
+        currentAdBreak = null;
+        currentAdPod = null;
+        NRLog.d("MT activated: type=" + manifestType
+                + " trackingUrl=" + trackingUrl
+                + " endpoint=" + mediaTailorEndpoint);
+        startPolling();
+    }
+
+    private void deactivate() {
+        activated = false;
+        stopPolling();
+        cancelTrackingFetch();
+        synchronized (adSchedule) { adSchedule.clear(); }
+        currentAdBreak = null;
+        currentAdPod = null;
+    }
+
+    private void detectStreamTypeIfNeeded() {
+        if (streamType != null || player == null) return;
+        long duration = player.getDuration();
+        // MediaTailor emits type="dynamic" MPDs even for VOD (live-style window),
+        // so player.isCurrentMediaItemLive() returns true for SSAI VOD too. The
+        // only reliable signal is whether the manifest declares a finite
+        // mediaPresentationDuration — VOD does, live does not.
+        boolean live = duration == C.TIME_UNSET || duration <= 0;
+        streamType = live ? MTConstants.STREAM_TYPE_LIVE : MTConstants.STREAM_TYPE_VOD;
+        NRLog.d("MT stream type: " + streamType
+                + " (duration=" + duration + "ms, isCurrentMediaItemLive="
+                + player.isCurrentMediaItemLive() + ")");
+    }
+
+    // ── manifest parsing ──────────────────────────────────────────────────
+
+    private void reparseManifest() {
+        if (player == null) return;
+        Object manifest = player.getCurrentManifest();
+        if (manifest instanceof DashManifest) {
+            DashManifest dash = (DashManifest) manifest;
+            // Implicit-session rescue: if our trackingUrl is still null because the
+            // MediaItem URI didn't carry `sessionId=` (MediaTailor redirected to it
+            // but ExoPlayer keeps the original request URI), the MPD's <Location>
+            // element — exposed by Media3 as DashManifest.location — carries the
+            // sessionized URL. Derive the tracking URL from it.
+            if (trackingUrl == null && dash.location != null) {
+                String derived = MTDetector.extractTrackingUrl(dash.location);
+                if (derived != null) {
+                    trackingUrl = derived;
+                    NRLog.d("MT trackingUrl recovered from <Location>: " + trackingUrl);
+                }
+            }
+            List<MTAdBreak> parsed = MTDashParser.parse(dash);
+            NRLog.d("MT DashManifest parsed: periods=" + dash.getPeriodCount()
+                    + " adBreaks=" + parsed.size()
+                    + " location=" + (dash.location != null ? dash.location : "null"));
+            if (!parsed.isEmpty()) {
+                applyNewBreaks(parsed);
+            }
+        } else if (manifest instanceof HlsManifest) {
+            HlsManifest hls = (HlsManifest) manifest;
+            int segCount = hls.mediaPlaylist != null && hls.mediaPlaylist.segments != null
+                    ? hls.mediaPlaylist.segments.size() : 0;
+            List<MTAdBreak> parsed = MTHlsParser.parse(hls);
+            NRLog.d("MT HlsManifest parsed: segments=" + segCount
+                    + " adBreaks=" + parsed.size());
+            if (!parsed.isEmpty()) {
+                applyNewBreaks(parsed);
+            }
+        } else if (manifest != null) {
+            NRLog.d("MT getCurrentManifest is neither DASH nor HLS: "
+                    + manifest.getClass().getName());
+        } else {
+            NRLog.d("MT getCurrentManifest() returned null — manifest not loaded yet");
+        }
+        maybeFetchTracking();
+    }
+
+    private void handleMetadata(Metadata metadata) {
+        for (int i = 0; i < metadata.length(); i++) {
+            Metadata.Entry entry = metadata.get(i);
+            if (!(entry instanceof EventMessage)) continue;
+            EventMessage em = (EventMessage) entry;
+            if (em.schemeIdUri == null
+                    || !em.schemeIdUri.toLowerCase().contains(MTConstants.SCTE35_SCHEME_MARKER)) {
+                continue;
+            }
+            long positionMs = player != null ? player.getCurrentPosition() : 0L;
+            long startMs = Math.max(positionMs, 0L);
+            long durationMs = em.durationMs;
+            NRLog.d("MT emsg SCTE-35: scheme=" + em.schemeIdUri
+                    + " id=" + em.id + " startMs=" + startMs + " durationMs=" + durationMs);
+            if (durationMs < MTConstants.MIN_AD_DURATION_MS) continue;
+            String id = em.id != 0 ? "emsg-" + em.id : "emsg-" + startMs;
+            MTAdBreak br = new MTAdBreak(id, startMs, durationMs);
+            applyNewBreaks(Collections.singletonList(br));
+        }
+    }
+
+    private void applyNewBreaks(List<MTAdBreak> incoming) {
+        int before;
+        int after;
+        synchronized (adSchedule) {
+            before = adSchedule.size();
+            List<MTAdBreak> merged = MTAdScheduleMerger.mergeSchedule(
+                    new ArrayList<>(adSchedule), incoming);
+            adSchedule.clear();
+            adSchedule.addAll(merged);
+            after = adSchedule.size();
+            StringBuilder sb = new StringBuilder();
+            sb.append("MT schedule (").append(after).append(" breaks, was ").append(before).append("): ");
+            for (int i = 0; i < adSchedule.size(); i++) {
+                MTAdBreak b = adSchedule.get(i);
+                if (i > 0) sb.append(", ");
+                sb.append("[").append(b.startTimeMs).append("ms +").append(b.durationMs).append("ms");
+                if (!b.pods.isEmpty()) sb.append(" pods=").append(b.pods.size());
+                if (b.confirmedByTracking) sb.append(" ✓tracking");
+                sb.append("]");
+            }
+            NRLog.d(sb.toString());
+        }
+        maybeFetchTracking();
+    }
+
+    // ── tracking API ──────────────────────────────────────────────────────
+
+    private void maybeFetchTracking() {
+        if (trackingUrl == null) return;
+        // VOD: fetch once after the schedule is built. Live: fetch on every
+        // manifest refresh (onTimelineChanged drives reparseManifest), but
+        // skip if a fetch is already in flight to avoid piling up connections.
+        if (MTConstants.STREAM_TYPE_VOD.equals(streamType)) {
+            if (!hasAttemptedTrackingFetch.compareAndSet(false, true)) return;
+        } else if (trackingWorker != null && trackingWorker.isAlive()) {
+            return;
+        }
+        startTrackingFetch();
+    }
+
+    private void startTrackingFetch() {
+        cancelTrackingFetch();
+        trackingClient = new MTTrackingClient();
+        final String url = trackingUrl;
+        NRLog.d("MT tracking fetch: " + url);
+        trackingWorker = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                MTTrackingResponse resp = trackingClient.fetch(url);
+                if (isDisposed.get()) return;
+                if (resp == null) {
+                    NRLog.w("MT tracking fetch returned null (failed or cancelled)");
+                    return;
+                }
+                applyTrackingResponse(resp);
+            }
+        }, "NR-MT-tracking");
+        trackingWorker.setDaemon(true);
+        trackingWorker.start();
+    }
+
+    private void cancelTrackingFetch() {
+        if (trackingClient != null) {
+            trackingClient.cancel();
+            trackingClient = null;
+        }
+        if (trackingWorker != null) {
+            trackingWorker.interrupt();
+            trackingWorker = null;
+        }
+    }
+
+    private void applyTrackingResponse(final MTTrackingResponse resp) {
+        NRLog.d("MT tracking API returned " + resp.avails.size() + " avail(s), "
+                + resp.nonLinearAvails.size() + " non-linear avail(s)");
+        Handler main = pollHandler;
+        if (main == null) main = new Handler(Looper.getMainLooper());
+        main.post(new Runnable() {
+            @Override
+            public void run() {
+                if (isDisposed.get()) return;
+                nonLinearAvailsCount = resp.nonLinearAvails.size();
+                synchronized (adSchedule) {
+                    List<MTAdBreak> enriched = MTAdScheduleMerger.enrichWithTracking(
+                            new ArrayList<>(adSchedule), resp);
+                    adSchedule.clear();
+                    adSchedule.addAll(enriched);
+                    NRLog.d("MT schedule enriched: " + adSchedule.size()
+                            + " breaks, confirmed="
+                            + countConfirmed(adSchedule));
+                }
+            }
+        });
+    }
+
+    private static int countConfirmed(List<MTAdBreak> list) {
+        int n = 0;
+        for (MTAdBreak b : list) if (b.confirmedByTracking) n++;
+        return n;
+    }
+
+    // ── playhead poll loop ────────────────────────────────────────────────
+
+    private void startPolling() {
+        if (pollHandler != null) return;
+        pollHandler = new Handler(Looper.getMainLooper());
+        pollRunnable = new Runnable() {
+            @Override
+            public void run() {
+                if (isDisposed.get()) return;
+                try {
+                    tick();
+                } finally {
+                    if (!isDisposed.get() && pollHandler != null) {
+                        pollHandler.postDelayed(this, MTConstants.PLAYHEAD_POLL_INTERVAL_MS);
+                    }
+                }
+            }
+        };
+        pollHandler.postDelayed(pollRunnable, MTConstants.PLAYHEAD_POLL_INTERVAL_MS);
+    }
+
+    private void stopPolling() {
+        if (pollHandler != null) {
+            pollHandler.removeCallbacksAndMessages(null);
+            pollHandler = null;
+        }
+        pollRunnable = null;
+    }
+
+    private void tick() {
+        if (player == null) return;
+        long position = player.getCurrentPosition();
+
+        MTAdBreak active;
+        synchronized (adSchedule) {
+            active = findActiveBreak(position);
+        }
+
+        if (active != null) {
+            handleInsideBreak(active, position);
+        } else if (currentAdBreak != null) {
+            handleExitingBreak();
+        }
+    }
+
+    private MTAdBreak findActiveBreak(long positionMs) {
+        for (MTAdBreak br : adSchedule) {
+            if (br.contains(positionMs)) return br;
+        }
+        return null;
+    }
+
+    private void handleInsideBreak(MTAdBreak active, long position) {
+        if (!active.hasFiredStart) {
+            currentAdBreak = active;
+            active.adPosition = computeAdPosition(active);
+            NRLog.d("MT AD_BREAK_START at " + active.startTimeMs + "ms pos=" + active.adPosition);
+            sendAdBreakStart();
+            active.hasFiredStart = true;
+        }
+
+        if (!active.pods.isEmpty()) {
+            MTAdPod pod = active.findActivePod(position);
+            if (pod != null && pod != currentAdPod) {
+                if (currentAdPod != null) {
+                    NRLog.d("MT AD_END (pod transition)");
+                    sendEnd();
+                }
+                currentAdPod = pod;
+                NRLog.d("MT AD_START (new pod)");
+                sendRequest();
+                sendStart();
+                pod.hasFiredStart = true;
+            }
+            if (pod != null) {
+                trackQuartiles(pod, position - pod.startTimeMs);
+            }
+        } else if (!active.hasFiredAdStart) {
+            NRLog.d("MT AD_START (no pods)");
+            sendRequest();
+            sendStart();
+            active.hasFiredAdStart = true;
+        }
+
+        if (active.pods.isEmpty()) {
+            trackQuartiles(active, position - active.startTimeMs);
+        }
+    }
+
+    private void handleExitingBreak() {
+        if (currentAdPod != null) {
+            NRLog.d("MT AD_END (final pod)");
+            sendEnd();
+            currentAdPod = null;
+        } else if (currentAdBreak != null && currentAdBreak.hasFiredAdStart) {
+            NRLog.d("MT AD_END (no-pods break)");
+            sendEnd();
+        }
+        if (currentAdBreak != null && !currentAdBreak.hasFiredEnd) {
+            NRLog.d("MT AD_BREAK_END");
+            sendAdBreakEnd();
+            currentAdBreak.hasFiredEnd = true;
+        }
+        currentAdBreak = null;
+        currentQuartile = null;
+    }
+
+    private void trackQuartiles(Object target, long progressMs) {
+        long durationMs;
+        boolean q1, q2, q3;
+        if (target instanceof MTAdPod) {
+            MTAdPod p = (MTAdPod) target;
+            durationMs = p.durationMs; q1 = p.hasFiredQ1; q2 = p.hasFiredQ2; q3 = p.hasFiredQ3;
+        } else {
+            MTAdBreak b = (MTAdBreak) target;
+            durationMs = b.durationMs; q1 = b.hasFiredQ1; q2 = b.hasFiredQ2; q3 = b.hasFiredQ3;
+        }
+        if (durationMs <= 0) return;
+
+        double progress = (double) progressMs / (double) durationMs;
+        if (progress >= MTConstants.QUARTILE_Q1 && !q1) fireQuartile(target, 1L);
+        if (progress >= MTConstants.QUARTILE_Q2 && !getFlag(target, 2)) fireQuartile(target, 2L);
+        if (progress >= MTConstants.QUARTILE_Q3 && !getFlag(target, 3)) fireQuartile(target, 3L);
+    }
+
+    private boolean getFlag(Object target, int n) {
+        if (target instanceof MTAdPod) {
+            MTAdPod p = (MTAdPod) target;
+            return n == 1 ? p.hasFiredQ1 : n == 2 ? p.hasFiredQ2 : p.hasFiredQ3;
+        }
+        MTAdBreak b = (MTAdBreak) target;
+        return n == 1 ? b.hasFiredQ1 : n == 2 ? b.hasFiredQ2 : b.hasFiredQ3;
+    }
+
+    private void fireQuartile(Object target, long quartile) {
+        currentQuartile = quartile;
+        NRLog.d("MT AD_QUARTILE " + (quartile * 25) + "%");
+        sendAdQuartile();
+        if (target instanceof MTAdPod) {
+            MTAdPod p = (MTAdPod) target;
+            if (quartile == 1L) p.hasFiredQ1 = true;
+            else if (quartile == 2L) p.hasFiredQ2 = true;
+            else p.hasFiredQ3 = true;
+        } else {
+            MTAdBreak b = (MTAdBreak) target;
+            if (quartile == 1L) b.hasFiredQ1 = true;
+            else if (quartile == 2L) b.hasFiredQ2 = true;
+            else b.hasFiredQ3 = true;
+        }
+    }
+
+    private String computeAdPosition(MTAdBreak br) {
+        if (MTConstants.STREAM_TYPE_LIVE.equals(streamType)) return null;
+        int idx = -1;
+        synchronized (adSchedule) {
+            for (int i = 0; i < adSchedule.size(); i++) {
+                if (adSchedule.get(i) == br) { idx = i; break; }
+            }
+            if (idx == 0) return MTConstants.AD_POSITION_PRE;
+            if (idx == adSchedule.size() - 1) return MTConstants.AD_POSITION_POST;
+            return MTConstants.AD_POSITION_MID;
+        }
+    }
+
+    // ── attribute getters ─────────────────────────────────────────────────
+
+    @Override public String getTrackerName() { return MTConstants.TRACKER_NAME; }
+    @Override public String getTrackerVersion() { return BuildConfig.VERSION_NAME; }
+    // Mirror NRTrackerExoPlayer so ad events carry the same player identity as
+    // the linked content tracker (Media3 library tag + version).
+    @Override public String getPlayerName() { return MediaLibraryInfo.TAG; }
+    @Override public String getPlayerVersion() { return MediaLibraryInfo.VERSION; }
+    @Override public String getAdPartner() { return MTConstants.AD_PARTNER; }
+
+    @Override
+    public String getAdPosition() {
+        return currentAdBreak != null ? currentAdBreak.adPosition : null;
+    }
+
+    @Override
+    public Long getAdQuartile() {
+        return currentQuartile;
+    }
+
+    @Override
+    public String getTitle() {
+        if (currentAdPod != null && currentAdPod.title != null) return currentAdPod.title;
+        if (currentAdBreak != null && currentAdBreak.title != null) return currentAdBreak.title;
+        return currentAdBreak != null ? currentAdBreak.id : null;
+    }
+
+    @Override
+    public String getAdCreativeId() {
+        // VAST <Creative id="…"> — distinct from adId per the VAST spec.
+        if (currentAdPod != null && currentAdPod.creativeId != null) return currentAdPod.creativeId;
+        return currentAdBreak != null ? currentAdBreak.creativeId : null;
+    }
+
+    @Override
+    public String getVideoId() {
+        // VAST <Ad id="…"> — MediaTailor's ad.adId from the tracking response.
+        if (currentAdPod != null && currentAdPod.adId != null) return currentAdPod.adId;
+        if (currentAdBreak != null && currentAdBreak.adId != null) return currentAdBreak.adId;
+        return currentAdBreak != null ? currentAdBreak.id : null;
+    }
+
+    @Override
+    public Long getDuration() {
+        if (currentAdPod != null) return currentAdPod.durationMs;
+        if (currentAdBreak != null) return currentAdBreak.durationMs;
+        return null;
+    }
+
+    @Override
+    public String getSrc() {
+        if (trackingUrl != null) return trackingUrl;
+        return mediaTailorEndpoint;
+    }
+
+    @Override
+    public Long getPlayhead() {
+        if (player == null || currentAdBreak == null) return 0L;
+        return Math.max(player.getCurrentPosition() - currentAdBreak.startTimeMs, 0L);
+    }
+
+    /**
+     * Injects MediaTailor-specific ad metadata pulled from the tracking API
+     * that isn't covered by {@link NRVideoTracker}'s fixed attribute set.
+     *
+     * <p>Scope — these attributes appear only on events emitted by this
+     * tracker instance (identifiable as {@code trackerName="NRMTracker"}) AND
+     * only while {@link #currentAdBreak} is non-null. They are not written to:</p>
+     * <ul>
+     *   <li>{@code VideoAction} / {@code VideoErrorAction} from
+     *       {@link com.newrelic.videoagent.exoplayer.tracker.NRTrackerExoPlayer}</li>
+     *   <li>{@code VideoAdAction} from {@code NRTrackerIMA}</li>
+     *   <li>{@code QOE_AGGREGATE} (generated by the content tracker)</li>
+     *   <li>This tracker's {@code TRACKER_READY} (gated by the
+     *       {@code currentAdBreak} check)</li>
+     * </ul>
+     *
+     * <p>Attributes added: {@code adSystem}, {@code vastAdId},
+     * {@code creativeSequence}, {@code skipOffset}, {@code adProgramDateTime},
+     * {@code availProgramDateTime}, {@code isBumper},
+     * {@code nonLinearAvailsCount}.</p>
+     */
+    @Override
+    public java.util.Map<String, Object> getAttributes(String action, java.util.Map<String, Object> attributes) {
+        java.util.Map<String, Object> attr = super.getAttributes(action, attributes);
+        if (currentAdBreak == null) return attr;
+
+        String adSystem = pick(currentAdPod != null ? currentAdPod.adSystem : null, currentAdBreak.adSystem);
+        String vastAdId = pick(currentAdPod != null ? currentAdPod.vastAdId : null, currentAdBreak.vastAdId);
+        String creativeSequence = pick(
+                currentAdPod != null ? currentAdPod.creativeSequence : null,
+                currentAdBreak.creativeSequence);
+        String skipOffset = pick(currentAdPod != null ? currentAdPod.skipOffset : null, currentAdBreak.skipOffset);
+        String adProgramDateTime = currentAdPod != null ? currentAdPod.adProgramDateTime : null;
+        String availProgramDateTime = currentAdBreak.availProgramDateTime;
+
+        if (adSystem != null) attr.put("adSystem", adSystem);
+        if (vastAdId != null) attr.put("vastAdId", vastAdId);
+        if (creativeSequence != null) attr.put("creativeSequence", creativeSequence);
+        if (skipOffset != null) attr.put("skipOffset", skipOffset);
+        if (adProgramDateTime != null) attr.put("adProgramDateTime", adProgramDateTime);
+        if (availProgramDateTime != null) attr.put("availProgramDateTime", availProgramDateTime);
+        if (currentAdPod != null && currentAdPod.isBumper) {
+            attr.put("isBumper", Boolean.TRUE);
+        } else if (currentAdBreak != null) {
+            boolean breakIsBumper = false;
+            for (MTAdPod p : currentAdBreak.pods) {
+                if (p.isBumper) { breakIsBumper = true; break; }
+            }
+            if (breakIsBumper) attr.put("isBumper", Boolean.TRUE);
+        }
+        if (nonLinearAvailsCount > 0) attr.put("nonLinearAvailsCount", nonLinearAvailsCount);
+        return attr;
+    }
+
+    private static String pick(String first, String second) {
+        return first != null ? first : second;
+    }
+}

--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/NRVideo.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/NRVideo.java
@@ -71,14 +71,21 @@ public final class NRVideo {
         // Create content tracker with ExoPlayer instance
         NRTracker contentTracker = createContentTracker(instance.configuration);
         NRTracker adsTracker = null;
-        if (config.isAdEnabled()) {
-            adsTracker = createAdTracker(instance.configuration);
-            NRLog.d("add tracker is added");
+        NRVideoPlayerConfiguration.AdTrackerType adType = config.getAdTrackerType();
+        if (adType != NRVideoPlayerConfiguration.AdTrackerType.NONE) {
+            adsTracker = createAdTracker(instance.configuration, adType);
+            NRLog.d("ad tracker created: " + adType);
         }
 
         // Now start the tracker system
         Integer trackerId = NewRelicVideoAgent.getInstance().start(contentTracker, adsTracker);
         ((NRVideoTracker) contentTracker).setPlayer(config.getPlayer());
+        // MediaTailor needs the ExoPlayer reference to register Player.Listener;
+        // IMA does not (it wires via AdEventListener externally).
+        if (adsTracker instanceof NRVideoTracker
+                && adType == NRVideoPlayerConfiguration.AdTrackerType.MEDIA_TAILOR) {
+            ((NRVideoTracker) adsTracker).setPlayer(config.getPlayer());
+        }
         NRLog.i("NRVideo initialization completed successfully with tracker ID: " + trackerId + " and player name:" + config.getPlayerName());
         if (config.getCustomAttributes() != null && !config.getCustomAttributes().isEmpty()) {
             for (Map.Entry<String, Object> entry : config.getCustomAttributes().entrySet()) {
@@ -284,20 +291,39 @@ public final class NRVideo {
         }
     }
 
-    private static NRTracker createAdTracker(NRVideoConfiguration config) {
+    private static NRTracker createAdTracker(NRVideoConfiguration config,
+                                              NRVideoPlayerConfiguration.AdTrackerType type) {
+        String className;
+        switch (type) {
+            case MEDIA_TAILOR:
+                className = "com.newrelic.videoagent.mediatailor.tracker.NRTrackerMediaTailor";
+                break;
+            case IMA:
+            default:
+                className = "com.newrelic.videoagent.ima.tracker.NRTrackerIMA";
+                break;
+        }
         try {
-            // Always use IMA tracker for ads with configuration
-            Class<?> imaTrackerClass = Class.forName("com.newrelic.videoagent.ima.tracker.NRTrackerIMA");
-            return (NRTracker) imaTrackerClass.getConstructor(NRVideoConfiguration.class).newInstance(config);
+            Class<?> clazz = Class.forName(className);
+            return (NRTracker) clazz.getConstructor(NRVideoConfiguration.class).newInstance(config);
         } catch (Exception e) {
-            // Fallback to deprecated constructor for backward compatibility
+            // Fallback to no-arg ctor for backward compatibility
             try {
-                Class<?> imaTrackerClass = Class.forName("com.newrelic.videoagent.ima.tracker.NRTrackerIMA");
-                return (NRTracker) imaTrackerClass.newInstance();
+                Class<?> clazz = Class.forName(className);
+                return (NRTracker) clazz.newInstance();
             } catch (Exception fallbackException) {
+                NRLog.w("Failed to load ad tracker " + className + ": " + fallbackException);
                 return null;
             }
         }
+    }
+
+    /**
+     * @deprecated Kept for source compatibility — routes to IMA.
+     */
+    @Deprecated
+    private static NRTracker createAdTracker(NRVideoConfiguration config) {
+        return createAdTracker(config, NRVideoPlayerConfiguration.AdTrackerType.IMA);
     }
 
     /**

--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/NRVideoPlayerConfiguration.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/NRVideoPlayerConfiguration.java
@@ -5,27 +5,56 @@ import androidx.media3.exoplayer.ExoPlayer;
 import java.util.Map;
 
 public class NRVideoPlayerConfiguration {
-    private String playerName;
-    private ExoPlayer player;
-    private Map<String, Object> customAttributes;
-    private boolean isAdEnabled = false;
+
+    /**
+     * Selects which ad tracker implementation is paired with the content
+     * tracker. Mutually exclusive per player — only one ad tracker slot
+     * exists in {@code NRTrackerPair}.
+     */
+    public enum AdTrackerType {
+        NONE,
+        IMA,
+        MEDIA_TAILOR
+    }
+
+    private final String playerName;
+    private final ExoPlayer player;
+    private final Map<String, Object> customAttributes;
+    private final AdTrackerType adTrackerType;
 
     public NRVideoPlayerConfiguration(String playerName, ExoPlayer player, boolean isAdEnabled, Map<String, Object> customAttributes) {
+        this(playerName, player, isAdEnabled ? AdTrackerType.IMA : AdTrackerType.NONE, customAttributes);
+    }
+
+    public NRVideoPlayerConfiguration(String playerName, ExoPlayer player, AdTrackerType adTrackerType, Map<String, Object> customAttributes) {
         this.playerName = playerName;
         this.player = player;
+        this.adTrackerType = adTrackerType != null ? adTrackerType : AdTrackerType.NONE;
         this.customAttributes = customAttributes;
-        this.isAdEnabled = isAdEnabled;
     }
+
     public String getPlayerName() {
         return playerName;
     }
+
     public ExoPlayer getPlayer() {
         return player;
     }
+
     public Map<String, Object> getCustomAttributes() {
         return customAttributes;
     }
+
+    public AdTrackerType getAdTrackerType() {
+        return adTrackerType;
+    }
+
+    /**
+     * @deprecated Use {@link #getAdTrackerType()}. Kept for backward compat —
+     * returns {@code true} when any ad tracker is selected.
+     */
+    @Deprecated
     public boolean isAdEnabled() {
-        return isAdEnabled;
+        return adTrackerType != AdTrackerType.NONE;
     }
 }

--- a/README.md
+++ b/README.md
@@ -58,12 +58,16 @@ dependencies {
     // ExoPlayer (Media3) tracker
     implementation 'com.github.newrelic.video-agent-android:NRExoPlayerTracker:v4.1.0'
 
-    // Google IMA ad tracker (optional)
+    // Google IMA ad tracker (optional — for client-side ad insertion)
     implementation 'com.github.newrelic.video-agent-android:NRIMATracker:v4.1.0'
+
+    // AWS MediaTailor ad tracker (optional — for server-side ad insertion / SSAI)
+    implementation 'com.github.newrelic.video-agent-android:NRMediaTailorTracker:v4.1.0'
 }
 ```
 
 > **Note:** Replace `v4.1.0` with the desired [release version](https://github.com/newrelic/video-agent-android/releases).
+> `NRIMATracker` and `NRMediaTailorTracker` are mutually exclusive per player — pick one based on whether your stream uses CSAI (IMA) or SSAI (MediaTailor).
 
 ### Option 2: Install Manually Using AAR Files
 
@@ -118,7 +122,8 @@ The Video Agent is composed of three modules:
 |--------|-------------|----------|
 | **NewRelicVideoCore** | Base classes for tracker management, event generation, and data harvesting. Depends on the New Relic Android Agent. | Yes |
 | **NRExoPlayerTracker** | Video tracker for ExoPlayer (Media3). Automatically hooks into player lifecycle events. | Yes (for ExoPlayer) |
-| **NRIMATracker** | Ad tracker for the Google IMA SDK. Captures ad lifecycle events including quartiles, breaks, and errors. | Optional |
+| **NRIMATracker** | Ad tracker for the Google IMA SDK (client-side ad insertion / CSAI). Captures ad lifecycle events including quartiles, breaks, and errors. | Optional |
+| **NRMediaTailorTracker** | Ad tracker for AWS Elemental MediaTailor (server-side ad insertion / SSAI). Supports DASH and HLS, explicit and implicit session init, live + VOD, with rich VAST metadata. | Optional |
 
 ## Usage
 
@@ -162,6 +167,51 @@ protected void onDestroy() {
     super.onDestroy();
 }
 ```
+
+### Setup with ExoPlayer and AWS MediaTailor (SSAI)
+
+```java
+// Step 1: Initialize NRVideo (same as basic setup)
+
+// Step 2: Explicit MediaTailor session init — POST to /v1/session/…, get back
+//         a sessionized manifest URL plus a tracking URL.
+//   POST  https://<hash>.mediatailor.<region>.amazonaws.com/v1/session/<hash>/<config>/<manifestFile>
+//   body  {"reportingMode":"server", "adsParams":{…custom targeting…}}
+//   resp  {"manifestUrl":"/v1/dash/…?aws.sessionId=…", "trackingUrl":"/v1/tracking/…"}
+// Both paths are relative — prefix them with your MediaTailor host.
+
+String manifestUrl = /* absolute URL from session init */;
+String trackingUrl = /* absolute URL from session init */;
+
+ExoPlayer player = new ExoPlayer.Builder(this).build();
+
+// Step 3: Register with MEDIA_TAILOR as the ad tracker type.
+NRVideoPlayerConfiguration playerConfig = new NRVideoPlayerConfiguration(
+        "mediatailor-player",
+        player,
+        NRVideoPlayerConfiguration.AdTrackerType.MEDIA_TAILOR,
+        /* custom attrs */ null);
+Integer trackerId = NRVideo.addPlayer(playerConfig);
+
+// Step 4: Hand ExoPlayer the sessionized manifest URL and start playback.
+//         The tracker auto-derives the tracking URL from aws.sessionId in
+//         this URI — no extra wiring needed in the normal flow.
+player.setMediaItem(MediaItem.fromUri(manifestUrl));
+player.prepare();
+player.setPlayWhenReady(true);
+
+// Step 5 (Optional): For a "Skip ad" button in your UI, fire AD_SKIP via
+// NRTrackerMediaTailor adTracker = (NRTrackerMediaTailor)
+//         NewRelicVideoAgent.getInstance().getAdTracker(trackerId);
+// adTracker.notifyAdSkipped();
+```
+
+What the tracker emits on `VideoAdAction`:
+`AD_BREAK_START`, `AD_REQUEST`, `AD_START`, `AD_PAUSE`, `AD_RESUME`,
+`AD_SEEK_START`, `AD_SEEK_END`, `AD_BUFFER_START`, `AD_BUFFER_END`,
+`AD_QUARTILE` (25/50/75%), `AD_END`, `AD_BREAK_END`, `AD_SKIP`, `AD_ERROR`.
+All events carry `trackerName="NRMTracker"`, `adPartner="aws-mediatailor"`,
+plus rich VAST metadata (see [DATAMODEL.md](./DATAMODEL.md)).
 
 ### Setup with ExoPlayer and IMA Ads
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -59,6 +59,7 @@ dependencies {
     implementation project(path: ':NewRelicVideoCore')
     implementation project(path: ':NRExoPlayerTracker')
     implementation project(path: ':NRIMATracker')
+    implementation project(path: ':NRMediaTailorTracker')
     testImplementation 'junit:junit:4.13.2'
 
     // Updated AndroidX Test dependencies that are compatible with Android 12+

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.NRVideoProject">
@@ -14,6 +15,11 @@
             android:theme="@style/Theme.NRVideoProject.NoActionBar"
             android:exported="false"></activity>
         <activity android:name=".VideoPlayer" android:exported="false" />
+        <activity
+            android:name=".VideoPlayerMediaTailor"
+            android:label="@string/title_activity_video_player_mediatailor"
+            android:theme="@style/Theme.NRVideoProject.NoActionBar"
+            android:exported="false" />
         <activity android:name=".MainActivity" android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/newrelic/nrvideoproject/MainActivity.java
+++ b/app/src/main/java/com/newrelic/nrvideoproject/MainActivity.java
@@ -16,6 +16,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
 
     Switch adsSwitch;
     Switch qoeSwitch;
+    Switch mediaTailorSwitch;
     int counter = 0;
     NRVideoConfiguration config;
 
@@ -24,7 +25,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         super.onCreate(savedInstanceState);
         NRVideoConfiguration config = new NRVideoConfiguration.Builder(BuildConfig.NR_APPLICATION_TOKEN)
                 .autoDetectPlatform(getApplicationContext())
-                .withHarvestCycle(60)
+                .withHarvestCycle(30)
                 .enableLogging()
                 .enableQoeAggregate(BuildConfig.QOE_AGGREGATE_DEFAULT)
                 .build();
@@ -33,6 +34,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
 
         adsSwitch = findViewById(R.id.ads_switch);
         qoeSwitch = findViewById(R.id.qoe_switch);
+        mediaTailorSwitch = findViewById(R.id.mediatailor_switch);
 
         // Initialize QOE switch with current configuration state
         qoeSwitch.setChecked(config.isQoeAggregateEnabled());
@@ -85,11 +87,12 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
     }
 
     Class getVideoActivity() {
+        if (mediaTailorSwitch.isChecked()) {
+            return VideoPlayerMediaTailor.class;
+        }
         if (adsSwitch.isChecked()) {
             return VideoPlayerAds.class;
         }
-        else {
-            return VideoPlayer.class;
-        }
+        return VideoPlayer.class;
     }
 }

--- a/app/src/main/java/com/newrelic/nrvideoproject/VideoPlayerMediaTailor.java
+++ b/app/src/main/java/com/newrelic/nrvideoproject/VideoPlayerMediaTailor.java
@@ -1,0 +1,281 @@
+package com.newrelic.nrvideoproject;
+
+import android.net.Uri;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
+import android.util.Log;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.media3.common.MediaItem;
+import androidx.media3.exoplayer.ExoPlayer;
+import androidx.media3.ui.PlayerView;
+
+import com.newrelic.videoagent.core.NRVideo;
+import com.newrelic.videoagent.core.NRVideoPlayerConfiguration;
+import com.newrelic.videoagent.core.NRVideoPlayerConfiguration.AdTrackerType;
+
+import org.json.JSONObject;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.security.cert.X509Certificate;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
+/**
+ * Sample that drives a MediaTailor SSAI stream end-to-end:
+ *
+ * <ol>
+ *     <li>POST the MediaTailor session-init endpoint →
+ *         {@code { "manifestUrl": "...?aws.sessionId=...", "trackingUrl": "..." }}.</li>
+ *     <li>Prefix both returned paths with the MediaTailor hostname.</li>
+ *     <li>Hand the sessionized manifest URL to ExoPlayer.</li>
+ *     <li>Pass the tracking URL explicitly to {@link NRTrackerMediaTailor#setTrackingUrl(String)}
+ *         so the tracker doesn't have to parse it out of the manifest URL.</li>
+ * </ol>
+ *
+ * <p>This is the recommended flow. Implicit sessions (client just GETs
+ * {@code /v1/dash/.../index.mpd}) also work — the tracker rescues the session
+ * id from the MPD {@code <Location>} element — but explicit is more reliable.</p>
+ */
+public class VideoPlayerMediaTailor extends AppCompatActivity {
+
+    private static final String TAG = "VideoPlayerMT";
+
+    // ── MediaTailor config prefixes (one per protocol) ───────────────────────
+    // Paste the "Session initialization prefix" from the AWS MediaTailor console
+    // for each of your configs (HLS, DASH). Only the one matching PROTOCOL
+    // below is used at runtime; both can be set for quick switching.
+    //
+    // Example from the console:
+    //   https://<hash>.mediatailor.<region>.amazonaws.com/v1/session/<hash>/<configName>/
+
+    private static final String MT_DASH_SESSION_INIT_PREFIX =
+            "https://<HASH>.mediatailor.<REGION>.amazonaws.com"
+                    + "/v1/session/<ACCOUNT>/<DASH_CONFIG>/";
+    private static final String MT_DASH_MANIFEST_PATH = "index.mpd";
+
+    private static final String MT_HLS_SESSION_INIT_PREFIX =
+            "https://<HASH>.mediatailor.<REGION>.amazonaws.com"
+                    + "/v1/session/<ACCOUNT>/<HLS_CONFIG>/";
+    private static final String MT_HLS_MANIFEST_PATH = "master.m3u8";
+
+    // Which protocol to exercise. Can be overridden at runtime via the
+    // `protocol` intent extra (values: "dash" | "hls").
+    private static final String DEFAULT_PROTOCOL = "hls";
+
+    // MediaTailor reporting mode passed to session init.
+    private static final String MT_REPORTING_MODE = "server";
+
+    // Custom adsParams forwarded to MediaTailor at session init and then to
+    // the ADS (Google Ad Manager, FreeWheel, etc.) via [player_params.*] tokens
+    // configured in the MediaTailor ADS request template.
+    // Example keys: deviceType, contentCategory, userId, geoCountry, rating.
+    private static final Map<String, String> MT_ADS_PARAMS = new HashMap<>();
+    static {
+        MT_ADS_PARAMS.put("deviceType", "androidmobile");
+        MT_ADS_PARAMS.put("platform", "nr-video-agent-android");
+    }
+
+    private ExoPlayer player;
+    private Integer trackerId;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_video_player_mediatailor);
+
+        // DEBUG-ONLY: relax SSL trust so content segments served from a
+        // Cloudflare quick-tunnel (or any host whose cert chain isn't in the
+        // emulator's trust store) can be fetched. This installs a global
+        // trust-all socket factory — do not ship this.
+        if (BuildConfig.DEBUG) {
+            installTrustAllSsl();
+        }
+
+        String protocol = getIntent().getStringExtra("protocol");
+        if (protocol == null || protocol.isEmpty()) protocol = DEFAULT_PROTOCOL;
+        boolean hls = "hls".equalsIgnoreCase(protocol);
+
+        String overrideInit = getIntent().getStringExtra("sessionInitUrl");
+        String sessionInitUrl;
+        if (overrideInit != null && !overrideInit.isEmpty()) {
+            sessionInitUrl = overrideInit;
+        } else if (hls) {
+            sessionInitUrl = MT_HLS_SESSION_INIT_PREFIX + MT_HLS_MANIFEST_PATH;
+        } else {
+            sessionInitUrl = MT_DASH_SESSION_INIT_PREFIX + MT_DASH_MANIFEST_PATH;
+        }
+
+        Log.v(TAG, "Protocol=" + protocol + " Session init URL: " + sessionInitUrl);
+
+        // POST on a worker thread; resume player setup on main thread.
+        final String finalInitUrl = sessionInitUrl;
+        new Thread(() -> {
+            try {
+                SessionInitResult r = postSessionInit(finalInitUrl);
+                Log.d(TAG, "manifestUrl=" + r.manifestUrl + " trackingUrl=" + r.trackingUrl);
+                new Handler(Looper.getMainLooper()).post(
+                        () -> startPlayback(r.manifestUrl, r.trackingUrl));
+            } catch (Exception e) {
+                Log.e(TAG, "Session init failed", e);
+            }
+        }, "MT-session-init").start();
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        if (trackerId != null) {
+            NRVideo.releaseTracker(trackerId);
+        }
+        if (player != null) {
+            player.stop();
+            player.release();
+            player = null;
+        }
+    }
+
+    // ── main-thread wiring once session init returns ─────────────────────────
+
+    private void startPlayback(String manifestUrl, String trackingUrl) {
+        player = new ExoPlayer.Builder(this).build();
+
+        Map<String, Object> customAttrs = new HashMap<>();
+        customAttrs.put("contentTitle", "MediaTailor SSAI Sample");
+        customAttrs.put("contentProvider", "aws-mediatailor-demo");
+
+        NRVideoPlayerConfiguration cfg = new NRVideoPlayerConfiguration(
+                "mediatailor-player",
+                player,
+                AdTrackerType.MEDIA_TAILOR,
+                customAttrs);
+
+        trackerId = NRVideo.addPlayer(cfg);
+        Log.d(TAG, "MediaTailor tracker registered, id=" + trackerId);
+
+        // The tracker auto-derives the tracking URL from the sessionized
+        // manifest URL passed to ExoPlayer below — no setTrackingUrl() call
+        // needed in the normal flow. If you ever hand ExoPlayer a manifest
+        // URL that doesn't carry aws.sessionId (rare), grab the adTracker
+        // via NewRelicVideoAgent.getInstance().getAdTracker(trackerId) and
+        // call setTrackingUrl(trackingUrl) explicitly.
+
+        PlayerView playerView = findViewById(R.id.player);
+        playerView.setPlayer(player);
+
+        player.setMediaItem(MediaItem.fromUri(Uri.parse(manifestUrl)));
+        player.setPlayWhenReady(true);
+        player.prepare();
+    }
+
+    // ── DEBUG-ONLY SSL relaxation ────────────────────────────────────────────
+
+    private static boolean sslInstalled = false;
+
+    private static void installTrustAllSsl() {
+        if (sslInstalled) return;
+        try {
+            TrustManager[] trustAll = new TrustManager[] {
+                new X509TrustManager() {
+                    @Override public void checkClientTrusted(X509Certificate[] chain, String authType) {}
+                    @Override public void checkServerTrusted(X509Certificate[] chain, String authType) {}
+                    @Override public X509Certificate[] getAcceptedIssuers() { return new X509Certificate[0]; }
+                }
+            };
+            SSLContext sc = SSLContext.getInstance("TLS");
+            sc.init(null, trustAll, new SecureRandom());
+            HttpsURLConnection.setDefaultSSLSocketFactory(sc.getSocketFactory());
+            HttpsURLConnection.setDefaultHostnameVerifier(new HostnameVerifier() {
+                @Override public boolean verify(String hostname, SSLSession session) { return true; }
+            });
+            sslInstalled = true;
+            Log.w(TAG, "DEBUG SSL trust-all installed — do not ship this");
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to install trust-all SSL", e);
+        }
+    }
+
+    // ── explicit session init ────────────────────────────────────────────────
+
+    private static class SessionInitResult {
+        final String manifestUrl;
+        final String trackingUrl;
+        SessionInitResult(String m, String t) { this.manifestUrl = m; this.trackingUrl = t; }
+    }
+
+    /**
+     * POSTs the MediaTailor session-init endpoint and resolves the returned
+     * {@code manifestUrl} / {@code trackingUrl} against the endpoint hostname.
+     * MediaTailor returns those as root-relative paths (e.g. {@code /v1/dash/...})
+     * — the caller has to prepend the host.
+     */
+    private static SessionInitResult postSessionInit(String initUrl) throws IOException {
+        URL url = new URL(initUrl);
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        try {
+            conn.setRequestMethod("POST");
+            conn.setConnectTimeout(5000);
+            conn.setReadTimeout(5000);
+            conn.setDoOutput(true);
+            conn.setRequestProperty("Content-Type", "application/json");
+            conn.setRequestProperty("Accept", "application/json");
+            JSONObject requestBody = new JSONObject();
+            requestBody.put("reportingMode", MT_REPORTING_MODE);
+            if (!MT_ADS_PARAMS.isEmpty()) {
+                requestBody.put("adsParams", new JSONObject(MT_ADS_PARAMS));
+            }
+            byte[] body = requestBody.toString().getBytes(StandardCharsets.UTF_8);
+            try (OutputStream os = conn.getOutputStream()) {
+                os.write(body);
+            }
+            int code = conn.getResponseCode();
+            Log.d(TAG, "Session init HTTP " + code);
+            if (code < 200 || code >= 300) {
+                throw new IOException("Session init HTTP " + code);
+            }
+            StringBuilder sb = new StringBuilder();
+            try (BufferedReader r = new BufferedReader(
+                    new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8))) {
+                String line;
+                while ((line = r.readLine()) != null) sb.append(line);
+            }
+            String responseJson = sb.toString();
+            Log.d(TAG, "Session init response: "
+                    + (responseJson.length() > 800
+                            ? responseJson.substring(0, 800) + "…[truncated]"
+                            : responseJson));
+            JSONObject resp = new JSONObject(responseJson);
+            String manifestPath = resp.optString("manifestUrl", null);
+            String trackingPath = resp.optString("trackingUrl", null);
+            if (manifestPath == null) {
+                throw new IOException("Session init response missing manifestUrl");
+            }
+            String host = url.getProtocol() + "://" + url.getHost()
+                    + (url.getPort() == -1 ? "" : (":" + url.getPort()));
+            String manifest = manifestPath.startsWith("http") ? manifestPath : host + manifestPath;
+            String tracking = trackingPath == null
+                    ? null
+                    : (trackingPath.startsWith("http") ? trackingPath : host + trackingPath);
+            return new SessionInitResult(manifest, tracking);
+        } catch (org.json.JSONException je) {
+            throw new IOException("Session init JSON parse failed", je);
+        } finally {
+            conn.disconnect();
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -78,6 +78,18 @@
         android:layout_height="wrap_content"
         android:layout_marginBottom="16dp"
         android:text="Enable QOE Aggregate"
+        app:layout_constraintBottom_toTopOf="@+id/mediatailor_switch"
+        android:layout_marginRight="8dp"
+        app:layout_constraintRight_toRightOf="parent"
+        android:layout_marginLeft="8dp"
+        app:layout_constraintLeft_toLeftOf="parent"/>
+
+    <Switch
+        android:id="@+id/mediatailor_switch"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp"
+        android:text="MediaTailor SSAI"
         app:layout_constraintBottom_toTopOf="@+id/ads_switch"
         android:layout_marginRight="8dp"
         app:layout_constraintRight_toRightOf="parent"

--- a/app/src/main/res/layout/activity_video_player_mediatailor.xml
+++ b/app/src/main/res/layout/activity_video_player_mediatailor.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".VideoPlayerMediaTailor">
+
+    <androidx.media3.ui.PlayerView
+        android:id="@+id/player"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,5 +2,6 @@
     <string name="app_name">NRVideoProject</string>
     <string name="title_activity_video_player">VideoPlayer</string>
     <string name="title_activity_video_player_ads">VideoPlayerAds</string>
+    <string name="title_activity_video_player_mediatailor">VideoPlayerMediaTailor</string>
     <string name="ad_tag_url"><![CDATA[http://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/ad_rule_samples&ciu_szs=300x250&ad_rule=1&impl=s&gdfp_req=1&env=vp&output=xml_vmap1&unviewed_position_start=1&cust_params=sample_ar%3Dpremidpostpod%26deployment%3Dgmf-js&cmsid=496&vid=short_onecue&correlator=]]></string>
 </resources>

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Dev-only trust relaxation for debugging MediaTailor segment playback on
+  emulators with stale cert stores. Trusts the system CAs plus the user CAs
+  (so you can install your own root for proxying with Charles/mitmproxy).
+  Do NOT ship this in release builds of production apps.
+-->
+<network-security-config>
+    <base-config cleartextTrafficPermitted="false">
+        <trust-anchors>
+            <certificates src="system"/>
+            <certificates src="user"/>
+        </trust-anchors>
+    </base-config>
+    <debug-overrides>
+        <trust-anchors>
+            <certificates src="system"/>
+            <certificates src="user"/>
+        </trust-anchors>
+    </debug-overrides>
+</network-security-config>

--- a/local.properties
+++ b/local.properties
@@ -1,9 +1,0 @@
-## This file must *NOT* be checked into Version Control Systems,
-# as it contains information specific to your local configuration.
-#
-# Location of the SDK. This is only used by Gradle.
-# For customization when using a Version Control System, please read the
-# header note.
-#Thu Feb 05 11:43:29 IST 2026
-nr.qoeAggregate=true
-sdk.dir=/Users/swatijha/Library/Android/sdk

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,5 @@
 include ':NRIMATracker'
+include ':NRMediaTailorTracker'
 include ':NRExoPlayerTracker'
 include ':NewRelicVideoCore'
 include ':app'


### PR DESCRIPTION
New optional AAR module NRMediaTailorTracker with full DASH + HLS support, explicit and implicit session-init flows, live + VOD, and rich VAST metadata pulled from the MediaTailor tracking API.

Highlights:

* DASH parser — multi-period (BaseURL pattern for ad periods) and single-period (SCTE-35 EventStream) shapes, plus DASH emsg metadata for dynamic mid-roll insertion on live streams; DashManifest.location rescue for implicit sessions.
* HLS parser — walks the typed HlsManifest, detects contiguous ad segments via URL pattern (segments.mediatailor / /v1/hlssegment/) and splits pods on relativeDiscontinuitySequence boundaries.
* Tracking API — auto-derives tracking URL from aws.sessionId in the sessionized manifest URI; polls once for VOD and on every manifest refresh for live; merges manifest-detected breaks with tracking-API avails by startTime (+/- 0.5 s tolerance).
* AdTrackerType enum (NONE / IMA / MEDIA_TAILOR) on NRVideoPlayerConfiguration replaces the boolean isAdEnabled (legacy constructor preserved). NRVideo.addPlayer reflection-loads the matching ad tracker class.
* NRTrackerExoPlayer — new isLinkedAdBreakActive() gate suppresses stray CONTENT_PAUSE / CONTENT_RESUME / CONTENT_BUFFER_* / CONTENT_START / CONTENT_RENDITION_CHANGE / CONTENT_SEEK_START during SSAI ad breaks and routes onPlayerError / onLoadError callbacks to the ad tracker as AD_ERROR when one is active.
* Rich VAST metadata on VideoAdAction events emitted by NRTrackerMediaTailor (trackerName=NRMTracker): adSystem, vastAdId, creativeSequence, skipOffset, adProgramDateTime, availProgramDateTime, isBumper, nonLinearAvailsCount. These are MediaTailor-only — NRTrackerIMA events are unaffected.
* Observability-only — this tracker does not fire VAST impression / quartile / complete beacons to the ad server. MediaTailor's default reportingMode=server handles those server-side; reportingMode=client remains the player's / VAST library's responsibility.
* Sample — new VideoPlayerMediaTailor activity with explicit POST session-init flow, DASH + HLS dual-config (switchable via "protocol" intent extra), and a dev-only trust-all SSL config for cert-stale emulators.

Docs: README, DATAMODEL, CHANGELOG updated.