### PR TITLE
fix: fire BUFFER_END and PAUSE correctly when user pauses during rebuffer

### DIFF
--- a/NRExoPlayerTracker/src/main/java/com/newrelic/videoagent/exoplayer/tracker/NRTrackerExoPlayer.java
+++ b/NRExoPlayerTracker/src/main/java/com/newrelic/videoagent/exoplayer/tracker/NRTrackerExoPlayer.java
@@ -698,7 +698,7 @@ public class NRTrackerExoPlayer extends NRVideoTracker implements Player.Listene
         } else {
             NRLog.d("\tVideo Paused");
 
-            if (getState().isPlaying && !player.isPlayingAd()) {
+            if (getState().isStarted && !getState().isPaused && !player.isPlayingAd()) {
                 sendPause();
             }
         }

--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/model/NRTrackerState.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/model/NRTrackerState.java
@@ -190,7 +190,7 @@ public class NRTrackerState {
     public boolean goBufferEnd() {
         if (isRequested && isBuffering) {
             isBuffering = false;
-            isPlaying = true;
+            isPlaying = !isPaused;
             return true;
         } else {
             return false;
@@ -220,7 +220,7 @@ public class NRTrackerState {
     public boolean goSeekEnd() {
         if (isStarted && isSeeking) {
             isSeeking = false;
-            isPlaying = true;
+            isPlaying = !isPaused;
             return true;
         }
         else {

--- a/NewRelicVideoCore/src/test/java/com/newrelic/videoagent/core/model/NRTrackerStateTest.java
+++ b/NewRelicVideoCore/src/test/java/com/newrelic/videoagent/core/model/NRTrackerStateTest.java
@@ -469,4 +469,109 @@ public class NRTrackerStateTest {
         assertFalse(state.isStarted);
         assertFalse(state.isPlaying);
     }
+
+    // --- Bug fix tests: pause state preserved across buffer/seek end ---
+
+    @Test
+    public void testGoBufferEndWhilePausedKeepsIsPlayingFalse() {
+        // Scenario: user pauses before network stalls, buffer fills while paused.
+        // goBufferEnd() must not flip isPlaying to true.
+        state.goRequest();
+        state.goStart();
+        state.goPause();        // user pauses
+        state.goBufferStart();  // network stalls
+
+        assertTrue(state.goBufferEnd());
+        assertFalse(state.isBuffering);
+        assertTrue(state.isPaused);
+        assertFalse(state.isPlaying);  // must stay false — player is still paused
+    }
+
+    @Test
+    public void testGoBufferEndWhileNotPausedSetsIsPlayingTrue() {
+        // Regression guard: normal rebuffer (no pause) must still resume playing.
+        state.goRequest();
+        state.goStart();
+        state.goBufferStart();
+
+        assertTrue(state.goBufferEnd());
+        assertFalse(state.isBuffering);
+        assertFalse(state.isPaused);
+        assertTrue(state.isPlaying);  // must be true — normal playback resumes
+    }
+
+    @Test
+    public void testGoSeekEndWhilePausedKeepsIsPlayingFalse() {
+        // Scenario: user pauses, then seeks to an unbuffered position.
+        // goSeekEnd() must not flip isPlaying to true.
+        state.goRequest();
+        state.goStart();
+        state.goPause();       // user pauses
+        state.goSeekStart();   // user drags progress bar
+
+        assertTrue(state.goSeekEnd());
+        assertFalse(state.isSeeking);
+        assertTrue(state.isPaused);
+        assertFalse(state.isPlaying);  // must stay false — player is still paused
+    }
+
+    @Test
+    public void testGoSeekEndWhileNotPausedSetsIsPlayingTrue() {
+        // Regression guard: normal seek (no pause) must still resume playing.
+        state.goRequest();
+        state.goStart();
+        state.goSeekStart();
+
+        assertTrue(state.goSeekEnd());
+        assertFalse(state.isSeeking);
+        assertFalse(state.isPaused);
+        assertTrue(state.isPlaying);  // must be true — normal playback resumes
+    }
+
+    @Test
+    public void testFullRebufferWhilePausedFlow() {
+        // Full scenario: stall → pause during buffer → buffer fills → resume.
+        // isPaused must survive buffer start/end and clear on resume.
+        state.goRequest();
+        state.goStart();
+        state.goBufferStart();  // network stalls while playing
+        state.goPause();        // user pauses during buffer
+
+        assertTrue(state.isPaused);
+        assertFalse(state.isPlaying);
+
+        state.goBufferEnd();    // buffer fills while still paused
+
+        assertTrue(state.isPaused);
+        assertFalse(state.isPlaying);
+        assertFalse(state.isBuffering);
+
+        state.goResume();       // user taps play
+
+        assertFalse(state.isPaused);
+        assertTrue(state.isPlaying);
+    }
+
+    @Test
+    public void testFullSeekWhilePausedFlow() {
+        // Full scenario: pause → seek → seek ends → resume.
+        state.goRequest();
+        state.goStart();
+        state.goPause();
+        state.goSeekStart();
+
+        assertTrue(state.isPaused);
+        assertFalse(state.isPlaying);
+
+        state.goSeekEnd();      // seek finishes while paused
+
+        assertTrue(state.isPaused);
+        assertFalse(state.isPlaying);
+        assertFalse(state.isSeeking);
+
+        state.goResume();
+
+        assertFalse(state.isPaused);
+        assertTrue(state.isPlaying);
+    }
 }


### PR DESCRIPTION
## Summary

This PR fixes three related bugs in `NRTrackerState` and `NRTrackerExoPlayer` where pausing during an active rebuffer or seek caused `CONTENT_PAUSE` to fire at the wrong time, `isPlaying` to be left in an incorrect state, and buffer duration metrics (`timeSinceBufferBegin`, `totalRebufferingTime`) to be over-reported in New Relic.

---

## Bug 1 — Pause during rebuffer was silently dropped

**File:** `NRTrackerExoPlayer.java`

When buffering starts, `goBufferStart()` sets `isPlaying = false` (frames are no longer rendering). If the user then taps pause while the buffer is still active, `logOnPlayerStateChanged` reached the pause branch and checked:

```java
// Old
if (getState().isPlaying && !player.isPlayingAd()) {
    sendPause();
}
```

Since `isPlaying` was already `false` (set by `goBufferStart`), this condition failed. The pause tap was completely ignored — `isPaused` was never set to `true`.

**Fix:** Use `isStarted && !isPaused` instead of `isPlaying`. This checks user *intent* (has playback started and is the user not already paused?) rather than hardware state (are frames rendering?):

```java
// New
if (getState().isStarted && !getState().isPaused && !player.isPlayingAd()) {
    sendPause();
}
```

---

## Bug 2 — `goBufferEnd()` overwrote paused state

**File:** `NRTrackerState.java`

When the buffer finished filling, `goBufferEnd()` ran:

```java
// Old
isBuffering = false;
isPlaying = true;  // blindly assumed we should be playing
```

This set `isPlaying = true` even when the user was paused. The pause branch in `logOnPlayerStateChanged` then saw `isPlaying = true` and fired `CONTENT_PAUSE` — but at the wrong moment (when the buffer ended, not when the user actually tapped pause). This caused:

- `CONTENT_PAUSE` timestamp to be wrong
- `resumeBitrateTimer()` to be called incorrectly during a pause
- `timeSinceBufferBegin` and `totalRebufferingTime` to be inflated by the pause duration

**Fix:** Preserve the paused state when the buffer ends:

```java
// New
isBuffering = false;
isPlaying = !isPaused;  // stay paused if user already paused
```

---

## Bug 3 — Same `isPlaying = true` pattern in `goSeekEnd()`

**File:** `NRTrackerState.java`

`goSeekEnd()` had the identical problem as `goBufferEnd()`:

```java
// Old
isSeeking = false;
isPlaying = true;  // same mistake
```

If a user paused while seeking, `goSeekEnd()` would blindly restore `isPlaying = true`. With Bug 1's fix protecting the event from firing incorrectly, no duplicate event would be emitted — but `isPlaying` would still be wrong in state, which could affect any downstream code that reads it.

**Fix:** Same as Bug 2:

```java
// New
isSeeking = false;
isPlaying = !isPaused;
```

---

## Event flow before and after

**Scenario: network stalls → user pauses → buffer fills → user resumes**

| Step | Before this fix | After this fix |
|------|----------------|----------------|
| Network stalls | `BUFFER_START` | `BUFFER_START` |
| User taps pause | ❌ no event (`isPlaying=false` blocked it) | ✅ `CONTENT_PAUSE` |
| Buffer fills | `BUFFER_END` + spurious `CONTENT_PAUSE` (wrong time) | ✅ `CONTENT_BUFFER_END` only |
| User resumes | `CONTENT_RESUME` | ✅ `CONTENT_RESUME` |
| `timeSinceBufferBegin` | ❌ inflated (included pause duration) | ✅ accurate |

## Test plan

- [ ] Play video, let it rebuffer, pause during the buffer, wait for buffer to fill, resume — verify `CONTENT_PAUSE` fires when paused and `CONTENT_BUFFER_END` fires when buffer fills (not when resume is tapped)
- [ ] Play video, let it rebuffer without pausing — verify `CONTENT_BUFFER_END` fires as before (no regression)
- [ ] Play video, seek to unbuffered position, pause during the seek, let seek complete, resume — verify no spurious events
- [ ] Verify `timeSinceBufferBegin` in New Relic reflects actual buffer duration, not buffer + pause time
- [ ] Verify ad buffer events are unaffected