### PR TITLE
fix(sample): remove trust-all SSL bypass flagged by CodeQL

### DIFF
--- a/app/src/main/java/com/newrelic/nrvideoproject/VideoPlayerMediaTailor.java
+++ b/app/src/main/java/com/newrelic/nrvideoproject/VideoPlayerMediaTailor.java
@@ -24,17 +24,8 @@ import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.security.SecureRandom;
-import java.security.cert.X509Certificate;
 import java.util.HashMap;
 import java.util.Map;
-
-import javax.net.ssl.HostnameVerifier;
-import javax.net.ssl.HttpsURLConnection;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLSession;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.X509TrustManager;
 
 /**
  * Sample that drives a MediaTailor SSAI stream end-to-end:
@@ -99,13 +90,10 @@ public class VideoPlayerMediaTailor extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_video_player_mediatailor);
 
-        // DEBUG-ONLY: relax SSL trust so content segments served from a
-        // Cloudflare quick-tunnel (or any host whose cert chain isn't in the
-        // emulator's trust store) can be fetched. This installs a global
-        // trust-all socket factory — do not ship this.
-        if (BuildConfig.DEBUG) {
-            installTrustAllSsl();
-        }
+        // For debug-time cert relaxation (e.g. testing through a Cloudflare
+        // quick-tunnel or a local proxy with a user-installed root CA), rely
+        // on res/xml/network_security_config.xml's <debug-overrides>, which
+        // trusts user CAs only in debug builds. Do not bypass SSL in code.
 
         String protocol = getIntent().getStringExtra("protocol");
         if (protocol == null || protocol.isEmpty()) protocol = DEFAULT_PROTOCOL;
@@ -181,33 +169,6 @@ public class VideoPlayerMediaTailor extends AppCompatActivity {
         player.setMediaItem(MediaItem.fromUri(Uri.parse(manifestUrl)));
         player.setPlayWhenReady(true);
         player.prepare();
-    }
-
-    // ── DEBUG-ONLY SSL relaxation ────────────────────────────────────────────
-
-    private static boolean sslInstalled = false;
-
-    private static void installTrustAllSsl() {
-        if (sslInstalled) return;
-        try {
-            TrustManager[] trustAll = new TrustManager[] {
-                new X509TrustManager() {
-                    @Override public void checkClientTrusted(X509Certificate[] chain, String authType) {}
-                    @Override public void checkServerTrusted(X509Certificate[] chain, String authType) {}
-                    @Override public X509Certificate[] getAcceptedIssuers() { return new X509Certificate[0]; }
-                }
-            };
-            SSLContext sc = SSLContext.getInstance("TLS");
-            sc.init(null, trustAll, new SecureRandom());
-            HttpsURLConnection.setDefaultSSLSocketFactory(sc.getSocketFactory());
-            HttpsURLConnection.setDefaultHostnameVerifier(new HostnameVerifier() {
-                @Override public boolean verify(String hostname, SSLSession session) { return true; }
-            });
-            sslInstalled = true;
-            Log.w(TAG, "DEBUG SSL trust-all installed — do not ship this");
-        } catch (Exception e) {
-            Log.e(TAG, "Failed to install trust-all SSL", e);
-        }
     }
 
     // ── explicit session init ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Addresses two CodeQL findings on PR #142:

- **TrustManager that accepts all certificates** ([alert #2](https://github.com/newrelic/video-agent-android/security/code-scanning/2))
- **Unsafe hostname verification** ([alert #3](https://github.com/newrelic/video-agent-android/security/code-scanning/3))

Both came from the debug-only `installTrustAllSsl()` helper in `VideoPlayerMediaTailor` — a global trust-all `X509TrustManager` and a permissive `HostnameVerifier` installed via `HttpsURLConnection.setDefault*`. Even gated on `BuildConfig.DEBUG`, CodeQL flags this pattern (and rightly — it's a footgun for sample code).

## Fix

- Removed the `installTrustAllSsl()` method and its `onCreate` call.
- Removed the now-unused SSL imports (`SSLContext`, `TrustManager`, `X509TrustManager`, `HostnameVerifier`, `SSLSession`, `HttpsURLConnection`, `SecureRandom`, `X509Certificate`).
- Replaced the inline comment with a pointer to `app/src/main/res/xml/network_security_config.xml`, which already has `<debug-overrides>` trusting system + user CAs — the platform-native, CodeQL-clean way to do debug-time cert relaxation.

No functional regression for dev workflows: developers proxying through Charles/mitmproxy or self-signed tunnels just install their root into the user CA store, exactly as the existing network security config expects.

## Test plan

- [x] `./gradlew :app:compileDebugJavaWithJavac` passes