### PR TITLE
feat: Add new QOE attributes

### DIFF
--- a/DATAMODEL.md
+++ b/DATAMODEL.md
@@ -214,6 +214,14 @@ Quality of Experience aggregate attributes sent with `CONTENT_END` events.
 | `averageBitrate` | Long | Time-weighted average bitrate (bps) |
 | `hadPlaybackError` | Boolean | Error occurred during playback |
 | `totalPlaytime` | Long | Actual viewing time (ms) |
+| `avgDownloadRate` | Long | Mean of every observed network download throughput sample during content (bps). Omitted when no sample was observed. |
+| `minDownloadRate` | Long | Minimum observed network download throughput sample during content (bps). Omitted when no sample was observed. |
+| `maxDownloadRate` | Long | Maximum observed network download throughput sample during content (bps). Omitted when no sample was observed. |
+| `totalSwitchUps` | Long | Count of content rendition changes whose new bitrate was higher than the previous rendition. |
+| `totalSwitchDowns` | Long | Count of content rendition changes whose new bitrate was lower than the previous rendition. |
+| `totalTimeSwitchedDown` | Long | Total time spent at a content rendition below the session's all-time max rendition (ms). Includes any open interval at emit time. |
+| `totalPauseTime` | Long | Total content pause duration (ms). Includes any currently-open pause at emit time. |
+| `totalVariantsPlayed` | Long | Count of distinct content rendition bitrates observed during the session. |
 | `qoeAggregateVersion` | String | Algorithm version (e.g. "1.0.0") |
 
 ### VideoCustomAction

--- a/DATAMODEL.md
+++ b/DATAMODEL.md
@@ -221,7 +221,7 @@ Quality of Experience aggregate attributes sent with `CONTENT_END` events.
 | `totalSwitchDowns` | Long | Count of content rendition changes whose new bitrate was lower than the previous rendition. |
 | `totalTimeSwitchedDown` | Long | Total time spent at a content rendition below the session's all-time max rendition (ms). Includes any open interval at emit time. |
 | `totalPauseTime` | Long | Total content pause duration (ms). Includes any currently-open pause at emit time. |
-| `totalVariantsPlayed` | Long | Count of distinct content rendition bitrates observed during the session. |
+| `totalRenditions` | Long | Count of distinct content renditions observed during the session. |
 | `qoeAggregateVersion` | String | Algorithm version (e.g. "1.0.0") |
 
 ### VideoCustomAction

--- a/NRExoPlayerTracker/src/main/java/com/newrelic/videoagent/exoplayer/tracker/NRTrackerExoPlayer.java
+++ b/NRExoPlayerTracker/src/main/java/com/newrelic/videoagent/exoplayer/tracker/NRTrackerExoPlayer.java
@@ -253,6 +253,16 @@ public class NRTrackerExoPlayer extends NRVideoTracker implements Player.Listene
     }
 
     /**
+     * Expose the latest rendition-change shift (set in onVideoSizeChanged just before
+     * sendRenditionChange). The QoE aggregator reads this directly so it doesn't depend
+     * on the order in which getAttributes overrides decorate the attribute map.
+     */
+    @Override
+    public String getRenditionShift() {
+        return renditionChangeShift;
+    }
+
+    /**
      * Get rendition width.
      *
      * @return Attribute.

--- a/NRExoPlayerTracker/src/main/java/com/newrelic/videoagent/exoplayer/tracker/NRTrackerExoPlayer.java
+++ b/NRExoPlayerTracker/src/main/java/com/newrelic/videoagent/exoplayer/tracker/NRTrackerExoPlayer.java
@@ -252,11 +252,6 @@ public class NRTrackerExoPlayer extends NRVideoTracker implements Player.Listene
         return null;
     }
 
-    /**
-     * Expose the latest rendition-change shift (set in onVideoSizeChanged just before
-     * sendRenditionChange). The QoE aggregator reads this directly so it doesn't depend
-     * on the order in which getAttributes overrides decorate the attribute map.
-     */
     @Override
     public String getRenditionShift() {
         return renditionChangeShift;

--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/tracker/NRVideoTracker.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/tracker/NRVideoTracker.java
@@ -71,35 +71,28 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
     private Long qoeTotalActiveTime;
     private boolean qoeBitrateTimerPaused;
 
-    // QoE — Group A: download rate (network)
-    private long qoeDlSum;
-    private long qoeDlCount;
-    private Long qoeDlMin;
-    private long qoeDlMax;
+    private long qoeDownloadRateSum;
+    private long qoeDownloadRateCount;
+    private Long qoeDownloadRateMin;
+    private long qoeDownloadRateMax;
 
-    // QoE — Group B: rendition switch counters
     private long qoeSwitchUps;
     private long qoeSwitchDowns;
 
-    // QoE — internal anchor for "switched-down" interval; not emitted on the wire.
-    // Holds the highest "rendition signal" observed (pixels when the player reports W/H,
-    // bitrate otherwise — see renditionSignal()). 0 = nothing observed yet.
+    // Highest rendition signal observed; not emitted, anchors the "switched-down" interval.
     private long qoeMaxRendition;
 
-    // QoE — previous rendition bitrate; baseline for the up/down/none shift used by Group B counters
+    // Previous rendition bitrate, used as the baseline when no published shift is available.
     private Long qoePrevRenditionForShift;
 
-    // QoE — Group D: time-weighted "switched down" interval
     private long qoeTimeSwitchedDown;
-    private Long qoeReducedSinceMs;
+    private Long qoeSwitchedDownStartMs;
 
-    // QoE — Group E: pause accumulator (independent of existing pause/playtime)
     private long qoeTotalPauseTime;
     private Long qoePauseStartMs;
 
-    // QoE — Group F: distinct variants played, keyed by the rendition signal (pixels first,
-    // bitrate fallback). Pixel-keyed identity is robust to DASH manifests whose Format.bitrate
-    // is uniform across resolutions — the failure mode this aggregator was hitting.
+    // Keyed by renditionSignal() — pixels when the player reports W/H, bitrate otherwise.
+    // Pixel keying handles DASH manifests with uniform Format.bitrate across resolutions.
     private final Set<Long> qoePlayedRenditions =
             Collections.newSetFromMap(new ConcurrentHashMap<Long, Boolean>());
 
@@ -204,17 +197,16 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
         qoeTotalActiveTime = 0L;
         qoeBitrateTimerPaused = false;
 
-        // QoE additional KPI accumulators (Groups A/B/D/E/F)
-        qoeDlSum = 0L;
-        qoeDlCount = 0L;
-        qoeDlMin = null;
-        qoeDlMax = 0L;
+        qoeDownloadRateSum = 0L;
+        qoeDownloadRateCount = 0L;
+        qoeDownloadRateMin = null;
+        qoeDownloadRateMax = 0L;
         qoeSwitchUps = 0L;
         qoeSwitchDowns = 0L;
         qoeMaxRendition = 0L;
         qoePrevRenditionForShift = null;
         qoeTimeSwitchedDown = 0L;
-        qoeReducedSinceMs = null;
+        qoeSwitchedDownStartMs = null;
         qoeTotalPauseTime = 0L;
         qoePauseStartMs = null;
         qoePlayedRenditions.clear();
@@ -379,7 +371,6 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
         if (!state.isAd && !QOE_AGGREGATE.equals(action)) {
             trackBitrateFromProcessedAttributes(action, attr);
         }
-        // QoE: seed initial rendition into played-variants set / max-rendition anchor (§5.2)
         if (!state.isAd && CONTENT_START.equals(action)) {
             onQoeContentStart();
         }
@@ -482,7 +473,6 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
                 sendVideoEvent(CONTENT_PAUSE);
                 // Pause bitrate timer during pause to exclude paused time from average
                 pauseBitrateTimer();
-                // QoE: open pause interval for totalPauseTime accumulator (§5.5)
                 onQoePause();
             }
             playtimeSinceLastEventTimestamp = 0L;
@@ -522,7 +512,6 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
                 if (!state.isBuffering && !state.isSeeking) {
                     resumeBitrateTimer();
                 }
-                // QoE: close pause interval for totalPauseTime accumulator (§5.5)
                 onQoeResume();
             }
             if (!state.isBuffering && !state.isSeeking) {
@@ -544,7 +533,7 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
                 }
                 totalAdPlaytime = totalAdPlaytime + totalPlaytime;
             } else {
-                // QoE: flush open intervals so the final emit sees closed totals (§5.6 / §5.0 rule 8)
+                // Flush any open pause / reduced-rendition interval before the final emit reads them.
                 onQoeViewEnd();
 
                 // Build final QOE at CONTENT_END and mark for next harvest cycle
@@ -967,27 +956,25 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
         }
         kpiAttributes.put("hadStartupError", qoeHadStartupError);
 
-        // Additional QoE KPIs (Groups A/B/D/E/F) — §5.7 snapshot, never mutates accumulators.
-        // Group A: omit avg/min/max when no download-rate sample arrived (§7 invariant 10).
-        if (qoeDlCount > 0) {
-            long avgDownloadRate = Math.round((double) qoeDlSum / (double) qoeDlCount);
+        // Omit when no download-rate sample arrived; emitting 0 would be misleading.
+        if (qoeDownloadRateCount > 0) {
+            long avgDownloadRate = Math.round((double) qoeDownloadRateSum / (double) qoeDownloadRateCount);
             kpiAttributes.put("avgDownloadRate", avgDownloadRate);
-            kpiAttributes.put("minDownloadRate", qoeDlMin);
-            kpiAttributes.put("maxDownloadRate", qoeDlMax);
+            kpiAttributes.put("minDownloadRate", qoeDownloadRateMin);
+            kpiAttributes.put("maxDownloadRate", qoeDownloadRateMax);
         }
 
-        // Group B: counters (0 is a valid value).
         kpiAttributes.put("totalSwitchUps", qoeSwitchUps);
         kpiAttributes.put("totalSwitchDowns", qoeSwitchDowns);
 
-        // Groups D & E: snapshot any open interval into the emitted total without mutating state.
+        // Snapshot any open interval into the emitted total without closing it; only
+        // onQoeViewEnd() mutates these accumulators.
         long nowMs = SystemClock.elapsedRealtime();
-        long openReducedMs = (qoeReducedSinceMs == null) ? 0L : nowMs - qoeReducedSinceMs;
+        long openReducedMs = (qoeSwitchedDownStartMs == null) ? 0L : nowMs - qoeSwitchedDownStartMs;
         long openPauseMs   = (qoePauseStartMs   == null) ? 0L : nowMs - qoePauseStartMs;
         kpiAttributes.put("totalTimeSwitchedDown", qoeTimeSwitchedDown + openReducedMs);
         kpiAttributes.put("totalPauseTime",        qoeTotalPauseTime   + openPauseMs);
 
-        // Group F: distinct variants played (cast to long for cross-platform parity).
         kpiAttributes.put("totalRenditions", (long) qoePlayedRenditions.size());
 
         return kpiAttributes;
@@ -1290,17 +1277,16 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
         qoeTotalActiveTime = 0L;
         qoeBitrateTimerPaused = false;
 
-        // Reset QoE additional KPI accumulators (Groups A/B/D/E/F)
-        qoeDlSum = 0L;
-        qoeDlCount = 0L;
-        qoeDlMin = null;
-        qoeDlMax = 0L;
+        qoeDownloadRateSum = 0L;
+        qoeDownloadRateCount = 0L;
+        qoeDownloadRateMin = null;
+        qoeDownloadRateMax = 0L;
         qoeSwitchUps = 0L;
         qoeSwitchDowns = 0L;
         qoeMaxRendition = 0L;
         qoePrevRenditionForShift = null;
         qoeTimeSwitchedDown = 0L;
-        qoeReducedSinceMs = null;
+        qoeSwitchedDownStartMs = null;
         qoeTotalPauseTime = 0L;
         qoePauseStartMs = null;
         qoePlayedRenditions.clear();
@@ -1520,10 +1506,9 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
     }
 
     /**
-     * Get the published rendition-change shift ("up" / "down" / "none" / null).
-     * Override hook so the QoE aggregator can read the shift the tracker has chosen for
-     * the current CONTENT_RENDITION_CHANGE without depending on map-decoration order.
-     * Default null = no signal; the QoE algorithm then derives shift from bitrate delta.
+     * Direction of the most recent rendition change ("up" / "down" / "none" / null).
+     * Returning null lets the QoE aggregator fall back to deriving direction from the
+     * bitrate delta — useful for trackers that don't classify shifts directly.
      */
     public String getRenditionShift() {
         return null;
@@ -1841,26 +1826,17 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
      * @param processedAttributes Fully processed attributes including contentBitrate
      */
     void trackBitrateFromProcessedAttributes(String action, Map<String, Object> processedAttributes) {
-        // QoE Group A — every event with contentNetworkDownloadBitrate populated counts as a
-        // sample (§5.3 / DECISIONS D11: plain mean over every sample, not deduped).
         Long downloadRate = extractBitrateValue(processedAttributes.get("contentNetworkDownloadBitrate"));
         if (downloadRate != null) {
             onQoeDownloadRateSample(downloadRate);
         }
 
-        // QoE Groups B/D/F — fire on each rendition change after the event is sent.
-        // Prefer the published "shift" attribute when the tracker provides one (e.g.
-        // NRTrackerExoPlayer derives it from VideoSize, which can flip independently of
-        // contentRenditionBitrate). Width/height are passed through so the §5 algorithm
-        // can use a composite (bitrate, width, height) identity — robust to DASH manifests
-        // whose Format.bitrate is uniform across renditions.
         if (CONTENT_RENDITION_CHANGE.equals(action)) {
             Long newRendition = extractBitrateValue(processedAttributes.get("contentRenditionBitrate"));
             Long newWidth     = extractBitrateValue(processedAttributes.get("contentRenditionWidth"));
             Long newHeight    = extractBitrateValue(processedAttributes.get("contentRenditionHeight"));
-            // Read shift via the override hook, not the map. The "shift" attr is added by
-            // derived getAttributes overrides AFTER super.getAttributes returns — by which
-            // time this QoE hook has already run and would see null. The hook avoids that.
+            // Read shift via getRenditionShift(): derived getAttributes overrides add the
+            // "shift" attr AFTER super.getAttributes returns, so the map doesn't have it yet.
             String shift = selectQoeShift(getRenditionShift(),
                     qoePrevRenditionForShift, newRendition);
             onQoeRenditionChange(shift, newRendition, newWidth, newHeight);
@@ -1918,14 +1894,7 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
             qoeBitrateSum = safeAdd(qoeBitrateSum, bitrate);
             qoeBitrateCount++;
         }
-        // QoE bitrate tracking completed
     }
-
-    // ====================================================================
-    // QoE additional KPI hooks (cross-agent reference algorithm §5).
-    // Content-only: every hook returns early on state.isAd.
-    // Clock: SystemClock.elapsedRealtime() per spec §5.0 rule 1.
-    // ====================================================================
 
     void onQoeContentStart() {
         if (state.isAd) return;
@@ -1939,11 +1908,9 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
     }
 
     /**
-     * Pick the rendition identity for §5 algorithm input. Pixels (width × height) when the
-     * player reports both — the most reliable "this rendition is different" signal across
-     * ABR ladders, and crucially robust to DASH manifests whose Format.bitrate is uniform
-     * across resolutions. Falls back to bitrate when resolution is unavailable so audio-only
-     * or partially-instrumented streams still drive Group B/D/F.
+     * Pixels when the player reports W/H, bitrate otherwise. Pixel keying is robust to DASH
+     * manifests whose Format.bitrate is uniform across resolutions; bitrate fallback covers
+     * audio-only and partially-instrumented streams.
      */
     static long renditionSignal(Long bitrate, Long width, Long height) {
         if (width != null && height != null && width > 0 && height > 0) {
@@ -1953,9 +1920,8 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
     }
 
     /**
-     * Map a previous → new rendition transition to the §5.4 tri-state shift.
-     * Returns null when the previous baseline is unknown so Group B counters stay 0
-     * for that first transition (still increments distinct-variants and updates Group D).
+     * Map a prev → next bitrate transition to "up" / "down" / "none". Returns null when
+     * either side is missing so the first transition doesn't fabricate a direction.
      */
     static String computeQoeRenditionShift(Long prev, Long next) {
         if (next == null || next <= 0 || prev == null || prev <= 0) return null;
@@ -1965,9 +1931,8 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
     }
 
     /**
-     * Pick the shift to feed §5.4. Published shift wins when present (matches what the
-     * platform already considers a switch — videoSize on ExoPlayer); otherwise fall back
-     * to a bitrate-derived shift so non-ExoPlayer trackers still drive Group B counters.
+     * Published shift (e.g. videoSize-derived on ExoPlayer) wins when present; otherwise
+     * fall back to a bitrate-derived direction so non-ExoPlayer trackers still get counters.
      */
     static String selectQoeShift(Object publishedShift, Long prev, Long next) {
         if (publishedShift instanceof String) {
@@ -1980,14 +1945,14 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
     void onQoeDownloadRateSample(Long rate) {
         if (state.isAd || rate == null || rate <= 0) return;
         try {
-            qoeDlSum = safeAdd(qoeDlSum, rate);
-            qoeDlCount++;
+            qoeDownloadRateSum = safeAdd(qoeDownloadRateSum, rate);
+            qoeDownloadRateCount++;
         } catch (ArithmeticException e) {
             NRLog.w("QoE download-rate accumulation overflow");
             return;
         }
-        qoeDlMin = (qoeDlMin == null) ? rate : Math.min(qoeDlMin, rate);
-        if (rate > qoeDlMax) qoeDlMax = rate;
+        qoeDownloadRateMin = (qoeDownloadRateMin == null) ? rate : Math.min(qoeDownloadRateMin, rate);
+        if (rate > qoeDownloadRateMax) qoeDownloadRateMax = rate;
     }
 
     /** Bitrate-only convenience used by existing call sites and tests. */
@@ -2007,19 +1972,19 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
 
         long t = SystemClock.elapsedRealtime();
 
-        if (qoeReducedSinceMs != null && signal >= qoeMaxRendition) {
+        if (qoeSwitchedDownStartMs != null && signal >= qoeMaxRendition) {
             try {
-                qoeTimeSwitchedDown = safeAdd(qoeTimeSwitchedDown, t - qoeReducedSinceMs);
+                qoeTimeSwitchedDown = safeAdd(qoeTimeSwitchedDown, t - qoeSwitchedDownStartMs);
             } catch (ArithmeticException e) {
                 NRLog.w("QoE switched-down accumulation overflow");
             }
-            qoeReducedSinceMs = null;
+            qoeSwitchedDownStartMs = null;
         }
 
         if (signal > qoeMaxRendition) qoeMaxRendition = signal;
 
-        if (signal < qoeMaxRendition && qoeReducedSinceMs == null) {
-            qoeReducedSinceMs = t;
+        if (signal < qoeMaxRendition && qoeSwitchedDownStartMs == null) {
+            qoeSwitchedDownStartMs = t;
         }
     }
 
@@ -2049,35 +2014,32 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
             }
             qoePauseStartMs = null;
         }
-        if (qoeReducedSinceMs != null) {
+        if (qoeSwitchedDownStartMs != null) {
             try {
-                qoeTimeSwitchedDown = safeAdd(qoeTimeSwitchedDown, t - qoeReducedSinceMs);
+                qoeTimeSwitchedDown = safeAdd(qoeTimeSwitchedDown, t - qoeSwitchedDownStartMs);
             } catch (ArithmeticException e) {
                 NRLog.w("QoE switched-down flush overflow");
             }
-            qoeReducedSinceMs = null;
+            qoeSwitchedDownStartMs = null;
         }
     }
 
-    // Package-private accessor for unit tests to assert the emitted KPI payload directly.
     Map<String, Object> qoeKpiAttributesForTest() {
         return calculateQOEKpiAttributes();
     }
 
-    // Package-private snapshot of the QoE accumulator's internal state, used by tests to
-    // assert the §5.8 transition table and §5.0 rule 9 reset coverage.
     Map<String, Object> qoeAccumulatorSnapshotForTest() {
         Map<String, Object> snap = new HashMap<>();
-        snap.put("dlSum", qoeDlSum);
-        snap.put("dlCount", qoeDlCount);
-        snap.put("dlMin", qoeDlMin);
-        snap.put("dlMax", qoeDlMax);
+        snap.put("downloadRateSum", qoeDownloadRateSum);
+        snap.put("downloadRateCount", qoeDownloadRateCount);
+        snap.put("downloadRateMin", qoeDownloadRateMin);
+        snap.put("downloadRateMax", qoeDownloadRateMax);
         snap.put("switchUps", qoeSwitchUps);
         snap.put("switchDowns", qoeSwitchDowns);
         snap.put("maxRendition", qoeMaxRendition);
         snap.put("prevRenditionForShift", qoePrevRenditionForShift);
         snap.put("timeSwitchedDown", qoeTimeSwitchedDown);
-        snap.put("reducedSinceMs", qoeReducedSinceMs);
+        snap.put("switchedDownStartMs", qoeSwitchedDownStartMs);
         snap.put("totalPauseTime", qoeTotalPauseTime);
         snap.put("pauseStartMs", qoePauseStartMs);
         snap.put("playedRenditionsSize", qoePlayedRenditions.size());

--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/tracker/NRVideoTracker.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/tracker/NRVideoTracker.java
@@ -952,7 +952,7 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
         }
 
         // qoeAggregateVersion - Version identifier for QOE calculation algorithm
-        kpiAttributes.put("qoeAggregateVersion", "1.0.0");
+        kpiAttributes.put("qoeAggregateVersion", "1.1.0");
 
         // startupTime - Cached value calculated at CONTENT_START
         if (qoeStartupTime != null && qoeStartupTime >= 0) {
@@ -988,7 +988,7 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
         kpiAttributes.put("totalPauseTime",        qoeTotalPauseTime   + openPauseMs);
 
         // Group F: distinct variants played (cast to long for cross-platform parity).
-        kpiAttributes.put("totalVariantsPlayed", (long) qoePlayedRenditions.size());
+        kpiAttributes.put("totalRenditions", (long) qoePlayedRenditions.size());
 
         return kpiAttributes;
     }

--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/tracker/NRVideoTracker.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/tracker/NRVideoTracker.java
@@ -1,6 +1,7 @@
 package com.newrelic.videoagent.core.tracker;
 
 import android.os.Handler;
+import android.os.SystemClock;
 
 import com.newrelic.videoagent.core.NRVideo;
 import com.newrelic.videoagent.core.NRVideoConfiguration;
@@ -10,11 +11,14 @@ import com.newrelic.videoagent.core.utils.NRLog;
 import com.newrelic.videoagent.core.harvest.QoeProvider;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static com.newrelic.videoagent.core.NRDef.*;
 import com.newrelic.videoagent.core.exception.ErrorExceptionHandler;
@@ -66,6 +70,38 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
     private Long qoeTotalBitrateWeightedTime;
     private Long qoeTotalActiveTime;
     private boolean qoeBitrateTimerPaused;
+
+    // QoE — Group A: download rate (network)
+    private long qoeDlSum;
+    private long qoeDlCount;
+    private Long qoeDlMin;
+    private long qoeDlMax;
+
+    // QoE — Group B: rendition switch counters
+    private long qoeSwitchUps;
+    private long qoeSwitchDowns;
+
+    // QoE — internal anchor for "switched-down" interval; not emitted on the wire.
+    // Holds the highest "rendition signal" observed (pixels when the player reports W/H,
+    // bitrate otherwise — see renditionSignal()). 0 = nothing observed yet.
+    private long qoeMaxRendition;
+
+    // QoE — previous rendition bitrate; baseline for the up/down/none shift used by Group B counters
+    private Long qoePrevRenditionForShift;
+
+    // QoE — Group D: time-weighted "switched down" interval
+    private long qoeTimeSwitchedDown;
+    private Long qoeReducedSinceMs;
+
+    // QoE — Group E: pause accumulator (independent of existing pause/playtime)
+    private long qoeTotalPauseTime;
+    private Long qoePauseStartMs;
+
+    // QoE — Group F: distinct variants played, keyed by the rendition signal (pixels first,
+    // bitrate fallback). Pixel-keyed identity is robust to DASH manifests whose Format.bitrate
+    // is uniform across resolutions — the failure mode this aggregator was hitting.
+    private final Set<Long> qoePlayedRenditions =
+            Collections.newSetFromMap(new ConcurrentHashMap<Long, Boolean>());
 
     // QOE_AGGREGATE provider fields
     private boolean qoeProviderRegistered = false;
@@ -167,6 +203,21 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
         qoeTotalBitrateWeightedTime = 0L;
         qoeTotalActiveTime = 0L;
         qoeBitrateTimerPaused = false;
+
+        // QoE additional KPI accumulators (Groups A/B/D/E/F)
+        qoeDlSum = 0L;
+        qoeDlCount = 0L;
+        qoeDlMin = null;
+        qoeDlMax = 0L;
+        qoeSwitchUps = 0L;
+        qoeSwitchDowns = 0L;
+        qoeMaxRendition = 0L;
+        qoePrevRenditionForShift = null;
+        qoeTimeSwitchedDown = 0L;
+        qoeReducedSinceMs = null;
+        qoeTotalPauseTime = 0L;
+        qoePauseStartMs = null;
+        qoePlayedRenditions.clear();
     }
 
     /**
@@ -328,6 +379,10 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
         if (!state.isAd && !QOE_AGGREGATE.equals(action)) {
             trackBitrateFromProcessedAttributes(action, attr);
         }
+        // QoE: seed initial rendition into played-variants set / max-rendition anchor (§5.2)
+        if (!state.isAd && CONTENT_START.equals(action)) {
+            onQoeContentStart();
+        }
 
         // Cache attributes for non-QOE events (for thread-safe QOE generation)
         // QOE generation runs on harvest background thread but ExoPlayer requires main thread access.
@@ -427,6 +482,8 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
                 sendVideoEvent(CONTENT_PAUSE);
                 // Pause bitrate timer during pause to exclude paused time from average
                 pauseBitrateTimer();
+                // QoE: open pause interval for totalPauseTime accumulator (§5.5)
+                onQoePause();
             }
             playtimeSinceLastEventTimestamp = 0L;
         }
@@ -465,6 +522,8 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
                 if (!state.isBuffering && !state.isSeeking) {
                     resumeBitrateTimer();
                 }
+                // QoE: close pause interval for totalPauseTime accumulator (§5.5)
+                onQoeResume();
             }
             if (!state.isBuffering && !state.isSeeking) {
                 playtimeSinceLastEventTimestamp = System.currentTimeMillis();
@@ -485,6 +544,9 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
                 }
                 totalAdPlaytime = totalAdPlaytime + totalPlaytime;
             } else {
+                // QoE: flush open intervals so the final emit sees closed totals (§5.6 / §5.0 rule 8)
+                onQoeViewEnd();
+
                 // Build final QOE at CONTENT_END and mark for next harvest cycle
                 if (configuration != null && configuration.isQoeAggregateEnabled() && qoeProviderRegistered) {
                     // Build final QOE with complete metrics
@@ -905,6 +967,29 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
         }
         kpiAttributes.put("hadStartupError", qoeHadStartupError);
 
+        // Additional QoE KPIs (Groups A/B/D/E/F) — §5.7 snapshot, never mutates accumulators.
+        // Group A: omit avg/min/max when no download-rate sample arrived (§7 invariant 10).
+        if (qoeDlCount > 0) {
+            long avgDownloadRate = Math.round((double) qoeDlSum / (double) qoeDlCount);
+            kpiAttributes.put("avgDownloadRate", avgDownloadRate);
+            kpiAttributes.put("minDownloadRate", qoeDlMin);
+            kpiAttributes.put("maxDownloadRate", qoeDlMax);
+        }
+
+        // Group B: counters (0 is a valid value).
+        kpiAttributes.put("totalSwitchUps", qoeSwitchUps);
+        kpiAttributes.put("totalSwitchDowns", qoeSwitchDowns);
+
+        // Groups D & E: snapshot any open interval into the emitted total without mutating state.
+        long nowMs = SystemClock.elapsedRealtime();
+        long openReducedMs = (qoeReducedSinceMs == null) ? 0L : nowMs - qoeReducedSinceMs;
+        long openPauseMs   = (qoePauseStartMs   == null) ? 0L : nowMs - qoePauseStartMs;
+        kpiAttributes.put("totalTimeSwitchedDown", qoeTimeSwitchedDown + openReducedMs);
+        kpiAttributes.put("totalPauseTime",        qoeTotalPauseTime   + openPauseMs);
+
+        // Group F: distinct variants played (cast to long for cross-platform parity).
+        kpiAttributes.put("totalVariantsPlayed", (long) qoePlayedRenditions.size());
+
         return kpiAttributes;
     }
 
@@ -1184,7 +1269,7 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
      * Reset QoE metrics when starting a new view session.
      * This ensures that QoE KPIs are isolated per view ID.
      */
-    private void resetQoeMetrics() {
+    void resetQoeMetrics() {
         qoePeakBitrate = null;
         qoeHadPlaybackError = false;
         qoeHadStartupError = false;
@@ -1204,6 +1289,21 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
         qoeTotalBitrateWeightedTime = 0L;
         qoeTotalActiveTime = 0L;
         qoeBitrateTimerPaused = false;
+
+        // Reset QoE additional KPI accumulators (Groups A/B/D/E/F)
+        qoeDlSum = 0L;
+        qoeDlCount = 0L;
+        qoeDlMin = null;
+        qoeDlMax = 0L;
+        qoeSwitchUps = 0L;
+        qoeSwitchDowns = 0L;
+        qoeMaxRendition = 0L;
+        qoePrevRenditionForShift = null;
+        qoeTimeSwitchedDown = 0L;
+        qoeReducedSinceMs = null;
+        qoeTotalPauseTime = 0L;
+        qoePauseStartMs = null;
+        qoePlayedRenditions.clear();
 
         // Reset QOE provider fields for new view session
         // NOTE: Don't reset pendingQoeForNextHarvest here - it needs to persist until next harvest
@@ -1416,6 +1516,16 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
      * @return Attribute.
      */
     public Long getRenditionHeight() {
+        return null;
+    }
+
+    /**
+     * Get the published rendition-change shift ("up" / "down" / "none" / null).
+     * Override hook so the QoE aggregator can read the shift the tracker has chosen for
+     * the current CONTENT_RENDITION_CHANGE without depending on map-decoration order.
+     * Default null = no signal; the QoE algorithm then derives shift from bitrate delta.
+     */
+    public String getRenditionShift() {
         return null;
     }
 
@@ -1730,7 +1840,35 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
      * @param action The action being processed
      * @param processedAttributes Fully processed attributes including contentBitrate
      */
-    private void trackBitrateFromProcessedAttributes(String action, Map<String, Object> processedAttributes) {
+    void trackBitrateFromProcessedAttributes(String action, Map<String, Object> processedAttributes) {
+        // QoE Group A — every event with contentNetworkDownloadBitrate populated counts as a
+        // sample (§5.3 / DECISIONS D11: plain mean over every sample, not deduped).
+        Long downloadRate = extractBitrateValue(processedAttributes.get("contentNetworkDownloadBitrate"));
+        if (downloadRate != null) {
+            onQoeDownloadRateSample(downloadRate);
+        }
+
+        // QoE Groups B/D/F — fire on each rendition change after the event is sent.
+        // Prefer the published "shift" attribute when the tracker provides one (e.g.
+        // NRTrackerExoPlayer derives it from VideoSize, which can flip independently of
+        // contentRenditionBitrate). Width/height are passed through so the §5 algorithm
+        // can use a composite (bitrate, width, height) identity — robust to DASH manifests
+        // whose Format.bitrate is uniform across renditions.
+        if (CONTENT_RENDITION_CHANGE.equals(action)) {
+            Long newRendition = extractBitrateValue(processedAttributes.get("contentRenditionBitrate"));
+            Long newWidth     = extractBitrateValue(processedAttributes.get("contentRenditionWidth"));
+            Long newHeight    = extractBitrateValue(processedAttributes.get("contentRenditionHeight"));
+            // Read shift via the override hook, not the map. The "shift" attr is added by
+            // derived getAttributes overrides AFTER super.getAttributes returns — by which
+            // time this QoE hook has already run and would see null. The hook avoids that.
+            String shift = selectQoeShift(getRenditionShift(),
+                    qoePrevRenditionForShift, newRendition);
+            onQoeRenditionChange(shift, newRendition, newWidth, newHeight);
+            if (newRendition != null && newRendition > 0 && !state.isAd) {
+                qoePrevRenditionForShift = newRendition;
+            }
+        }
+
         Long currentBitrate = extractBitrateValue(processedAttributes.get("contentBitrate"));
         if (currentBitrate == null || currentBitrate <= 0) {
             return;
@@ -1783,6 +1921,168 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
         // QoE bitrate tracking completed
     }
 
+    // ====================================================================
+    // QoE additional KPI hooks (cross-agent reference algorithm §5).
+    // Content-only: every hook returns early on state.isAd.
+    // Clock: SystemClock.elapsedRealtime() per spec §5.0 rule 1.
+    // ====================================================================
+
+    void onQoeContentStart() {
+        if (state.isAd) return;
+        long signal = renditionSignal(getRenditionBitrate(), getRenditionWidth(), getRenditionHeight());
+        if (signal > 0) {
+            qoePlayedRenditions.add(signal);
+            if (signal > qoeMaxRendition) qoeMaxRendition = signal;
+        }
+        Long b = getRenditionBitrate();
+        if (b != null && b > 0) qoePrevRenditionForShift = b;
+    }
+
+    /**
+     * Pick the rendition identity for §5 algorithm input. Pixels (width × height) when the
+     * player reports both — the most reliable "this rendition is different" signal across
+     * ABR ladders, and crucially robust to DASH manifests whose Format.bitrate is uniform
+     * across resolutions. Falls back to bitrate when resolution is unavailable so audio-only
+     * or partially-instrumented streams still drive Group B/D/F.
+     */
+    static long renditionSignal(Long bitrate, Long width, Long height) {
+        if (width != null && height != null && width > 0 && height > 0) {
+            return width * height;
+        }
+        return (bitrate == null || bitrate <= 0) ? 0L : bitrate;
+    }
+
+    /**
+     * Map a previous → new rendition transition to the §5.4 tri-state shift.
+     * Returns null when the previous baseline is unknown so Group B counters stay 0
+     * for that first transition (still increments distinct-variants and updates Group D).
+     */
+    static String computeQoeRenditionShift(Long prev, Long next) {
+        if (next == null || next <= 0 || prev == null || prev <= 0) return null;
+        if (next.longValue() > prev.longValue()) return "up";
+        if (next.longValue() < prev.longValue()) return "down";
+        return "none";
+    }
+
+    /**
+     * Pick the shift to feed §5.4. Published shift wins when present (matches what the
+     * platform already considers a switch — videoSize on ExoPlayer); otherwise fall back
+     * to a bitrate-derived shift so non-ExoPlayer trackers still drive Group B counters.
+     */
+    static String selectQoeShift(Object publishedShift, Long prev, Long next) {
+        if (publishedShift instanceof String) {
+            String s = (String) publishedShift;
+            if ("up".equals(s) || "down".equals(s) || "none".equals(s)) return s;
+        }
+        return computeQoeRenditionShift(prev, next);
+    }
+
+    void onQoeDownloadRateSample(Long rate) {
+        if (state.isAd || rate == null || rate <= 0) return;
+        try {
+            qoeDlSum = safeAdd(qoeDlSum, rate);
+            qoeDlCount++;
+        } catch (ArithmeticException e) {
+            NRLog.w("QoE download-rate accumulation overflow");
+            return;
+        }
+        qoeDlMin = (qoeDlMin == null) ? rate : Math.min(qoeDlMin, rate);
+        if (rate > qoeDlMax) qoeDlMax = rate;
+    }
+
+    /** Bitrate-only convenience used by existing call sites and tests. */
+    void onQoeRenditionChange(String shift, Long newBitrate) {
+        onQoeRenditionChange(shift, newBitrate, null, null);
+    }
+
+    void onQoeRenditionChange(String shift, Long newBitrate, Long newWidth, Long newHeight) {
+        if (state.isAd) return;
+        long signal = renditionSignal(newBitrate, newWidth, newHeight);
+        if (signal <= 0) return;
+
+        if ("up".equals(shift))   qoeSwitchUps++;
+        if ("down".equals(shift)) qoeSwitchDowns++;
+
+        qoePlayedRenditions.add(signal);
+
+        long t = SystemClock.elapsedRealtime();
+
+        if (qoeReducedSinceMs != null && signal >= qoeMaxRendition) {
+            try {
+                qoeTimeSwitchedDown = safeAdd(qoeTimeSwitchedDown, t - qoeReducedSinceMs);
+            } catch (ArithmeticException e) {
+                NRLog.w("QoE switched-down accumulation overflow");
+            }
+            qoeReducedSinceMs = null;
+        }
+
+        if (signal > qoeMaxRendition) qoeMaxRendition = signal;
+
+        if (signal < qoeMaxRendition && qoeReducedSinceMs == null) {
+            qoeReducedSinceMs = t;
+        }
+    }
+
+    void onQoePause() {
+        if (state.isAd) return;
+        qoePauseStartMs = SystemClock.elapsedRealtime();
+    }
+
+    void onQoeResume() {
+        if (state.isAd || qoePauseStartMs == null) return;
+        try {
+            qoeTotalPauseTime = safeAdd(qoeTotalPauseTime,
+                    SystemClock.elapsedRealtime() - qoePauseStartMs);
+        } catch (ArithmeticException e) {
+            NRLog.w("QoE total-pause-time accumulation overflow");
+        }
+        qoePauseStartMs = null;
+    }
+
+    void onQoeViewEnd() {
+        long t = SystemClock.elapsedRealtime();
+        if (qoePauseStartMs != null) {
+            try {
+                qoeTotalPauseTime = safeAdd(qoeTotalPauseTime, t - qoePauseStartMs);
+            } catch (ArithmeticException e) {
+                NRLog.w("QoE total-pause-time flush overflow");
+            }
+            qoePauseStartMs = null;
+        }
+        if (qoeReducedSinceMs != null) {
+            try {
+                qoeTimeSwitchedDown = safeAdd(qoeTimeSwitchedDown, t - qoeReducedSinceMs);
+            } catch (ArithmeticException e) {
+                NRLog.w("QoE switched-down flush overflow");
+            }
+            qoeReducedSinceMs = null;
+        }
+    }
+
+    // Package-private accessor for unit tests to assert the emitted KPI payload directly.
+    Map<String, Object> qoeKpiAttributesForTest() {
+        return calculateQOEKpiAttributes();
+    }
+
+    // Package-private snapshot of the QoE accumulator's internal state, used by tests to
+    // assert the §5.8 transition table and §5.0 rule 9 reset coverage.
+    Map<String, Object> qoeAccumulatorSnapshotForTest() {
+        Map<String, Object> snap = new HashMap<>();
+        snap.put("dlSum", qoeDlSum);
+        snap.put("dlCount", qoeDlCount);
+        snap.put("dlMin", qoeDlMin);
+        snap.put("dlMax", qoeDlMax);
+        snap.put("switchUps", qoeSwitchUps);
+        snap.put("switchDowns", qoeSwitchDowns);
+        snap.put("maxRendition", qoeMaxRendition);
+        snap.put("prevRenditionForShift", qoePrevRenditionForShift);
+        snap.put("timeSwitchedDown", qoeTimeSwitchedDown);
+        snap.put("reducedSinceMs", qoeReducedSinceMs);
+        snap.put("totalPauseTime", qoeTotalPauseTime);
+        snap.put("pauseStartMs", qoePauseStartMs);
+        snap.put("playedRenditionsSize", qoePlayedRenditions.size());
+        return snap;
+    }
 
     public void sendVideoErrorEvent(String action, Map<String, Object> attributes) {
         updatePlaytime();

--- a/NewRelicVideoCore/src/test/java/com/newrelic/videoagent/core/tracker/NRVideoTrackerQoeTest.java
+++ b/NewRelicVideoCore/src/test/java/com/newrelic/videoagent/core/tracker/NRVideoTrackerQoeTest.java
@@ -1,0 +1,613 @@
+package com.newrelic.videoagent.core.tracker;
+
+import android.os.SystemClock;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for the additional QoE KPIs added to {@link NRVideoTracker}.
+ *
+ * Covers the cross-agent reference algorithm from the spec:
+ *   §5.8 Group D transition table (all 6 cells)
+ *   §5.0 rule 5: snapshot-not-mutate on emit
+ *   §5.0 rule 6: pause × rendition interaction
+ *   §5.0 rule 9: exhaustive per-view reset
+ *   §7 invariants 1, 2, 4, 7, 10
+ */
+@RunWith(RobolectricTestRunner.class)
+public class NRVideoTrackerQoeTest {
+
+    /** Subclass that lets the test pin getRenditionBitrate/Shift for the QoE hooks. */
+    private static class TestTracker extends NRVideoTracker {
+        Long pinnedRendition;
+        String pinnedShift;
+        @Override public Long getRenditionBitrate() { return pinnedRendition; }
+        @Override public String getRenditionShift() { return pinnedShift; }
+    }
+
+    private TestTracker tracker;
+
+    @Before
+    public void setUp() {
+        tracker = new TestTracker();
+    }
+
+    @After
+    public void tearDown() {
+        if (tracker != null) tracker.dispose();
+    }
+
+    // ====================================================================
+    // §5.8 Group D transition table — all 6 cells.
+    // ====================================================================
+
+    @Test
+    public void transitionTable_bGreaterThanM_noOpenInterval_setsMaxOnly() {
+        tracker.pinnedRendition = 1_000_000L;
+        tracker.onQoeContentStart();
+        // M = 1_000_000, no open reduced interval
+
+        tracker.onQoeRenditionChange("up", 2_000_000L);
+
+        Map<String, Object> snap = tracker.qoeAccumulatorSnapshotForTest();
+        assertEquals(2_000_000L, snap.get("maxRendition"));
+        assertNull("no reduced interval should be open", snap.get("reducedSinceMs"));
+        assertEquals(0L, snap.get("timeSwitchedDown"));
+        assertEquals(1L, snap.get("switchUps"));
+        assertEquals(0L, snap.get("switchDowns"));
+    }
+
+    @Test
+    public void transitionTable_bGreaterThanM_withOpenInterval_closesAndAdvancesMax() {
+        tracker.pinnedRendition = 5_000_000L;
+        tracker.onQoeContentStart();
+        long t0 = SystemClock.elapsedRealtime();
+
+        tracker.onQoeRenditionChange("down", 1_000_000L); // opens reduced
+        SystemClock.sleep(2_000);
+        tracker.onQoeRenditionChange("up", 6_000_000L); // closes reduced AND advances max
+
+        Map<String, Object> snap = tracker.qoeAccumulatorSnapshotForTest();
+        assertEquals(6_000_000L, snap.get("maxRendition"));
+        assertNull(snap.get("reducedSinceMs"));
+        long elapsed = (Long) snap.get("timeSwitchedDown");
+        assertTrue("expected ~2_000 ms accumulated, got " + elapsed,
+                elapsed >= 2_000 && elapsed < 5_000);
+    }
+
+    @Test
+    public void transitionTable_bEqualToM_noOpenInterval_isNoOp() {
+        tracker.pinnedRendition = 3_000_000L;
+        tracker.onQoeContentStart();
+        Map<String, Object> before = tracker.qoeAccumulatorSnapshotForTest();
+
+        // shift "none" → b == M, no open interval
+        tracker.onQoeRenditionChange("none", 3_000_000L);
+
+        Map<String, Object> after = tracker.qoeAccumulatorSnapshotForTest();
+        assertEquals(before.get("maxRendition"), after.get("maxRendition"));
+        assertEquals(before.get("timeSwitchedDown"), after.get("timeSwitchedDown"));
+        assertNull(after.get("reducedSinceMs"));
+    }
+
+    @Test
+    public void transitionTable_bEqualToM_withOpenInterval_closesIntervalOnly() {
+        tracker.pinnedRendition = 5_000_000L;
+        tracker.onQoeContentStart();
+
+        tracker.onQoeRenditionChange("down", 2_000_000L); // open reduced
+        SystemClock.sleep(1_000);
+        tracker.onQoeRenditionChange("up", 5_000_000L); // b == M, close reduced (no max bump)
+
+        Map<String, Object> snap = tracker.qoeAccumulatorSnapshotForTest();
+        assertEquals(5_000_000L, snap.get("maxRendition"));
+        assertNull(snap.get("reducedSinceMs"));
+        long elapsed = (Long) snap.get("timeSwitchedDown");
+        assertTrue("expected ~1_000 ms accumulated, got " + elapsed,
+                elapsed >= 1_000 && elapsed < 4_000);
+    }
+
+    @Test
+    public void transitionTable_bLessThanM_noOpenInterval_opensInterval() {
+        tracker.pinnedRendition = 5_000_000L;
+        tracker.onQoeContentStart();
+
+        tracker.onQoeRenditionChange("down", 2_000_000L);
+
+        Map<String, Object> snap = tracker.qoeAccumulatorSnapshotForTest();
+        assertEquals(5_000_000L, snap.get("maxRendition"));
+        assertNotNull("a reduced interval should now be open", snap.get("reducedSinceMs"));
+        assertEquals(0L, snap.get("timeSwitchedDown"));
+    }
+
+    @Test
+    public void transitionTable_bLessThanM_withOpenInterval_isNoOp() {
+        tracker.pinnedRendition = 5_000_000L;
+        tracker.onQoeContentStart();
+
+        tracker.onQoeRenditionChange("down", 3_000_000L); // open at t0
+        Object reducedT0 = tracker.qoeAccumulatorSnapshotForTest().get("reducedSinceMs");
+        SystemClock.sleep(500);
+        tracker.onQoeRenditionChange("down", 1_500_000L); // still below max, prev open
+
+        Map<String, Object> snap = tracker.qoeAccumulatorSnapshotForTest();
+        assertEquals("interval start should not be reopened", reducedT0, snap.get("reducedSinceMs"));
+        assertEquals("no time accumulated yet — interval still open", 0L, snap.get("timeSwitchedDown"));
+        assertEquals("max stays at the all-time high", 5_000_000L, snap.get("maxRendition"));
+    }
+
+    // ====================================================================
+    // §5.0 rule 5 — emitQoe() must NOT mutate intervals (heartbeat snapshot).
+    // ====================================================================
+
+    @Test
+    public void emit_doesNotMutateOpenIntervals() {
+        tracker.pinnedRendition = 5_000_000L;
+        tracker.onQoeContentStart();
+        tracker.onQoeRenditionChange("down", 1_000_000L); // open reduced
+        tracker.onQoePause();                              // open pause
+
+        Object reducedBefore = tracker.qoeAccumulatorSnapshotForTest().get("reducedSinceMs");
+        Object pauseBefore   = tracker.qoeAccumulatorSnapshotForTest().get("pauseStartMs");
+
+        SystemClock.sleep(750);
+        Map<String, Object> kpis = tracker.qoeKpiAttributesForTest();
+        long emittedReduced = (Long) kpis.get("totalTimeSwitchedDown");
+        long emittedPause   = (Long) kpis.get("totalPauseTime");
+
+        assertTrue("emit should reflect open reduced interval", emittedReduced >= 750);
+        assertTrue("emit should reflect open pause interval", emittedPause >= 750);
+
+        Map<String, Object> snapAfter = tracker.qoeAccumulatorSnapshotForTest();
+        assertEquals("reducedSinceMs must not move", reducedBefore, snapAfter.get("reducedSinceMs"));
+        assertEquals("pauseStartMs must not move", pauseBefore, snapAfter.get("pauseStartMs"));
+        assertEquals("timeSwitchedDown accumulator must not advance on emit",
+                0L, snapAfter.get("timeSwitchedDown"));
+        assertEquals("totalPauseTime accumulator must not advance on emit",
+                0L, snapAfter.get("totalPauseTime"));
+    }
+
+    @Test
+    public void emit_thenLaterRenditionChange_doesNotDoubleCount() {
+        tracker.pinnedRendition = 5_000_000L;
+        tracker.onQoeContentStart();
+        tracker.onQoeRenditionChange("down", 1_000_000L); // open reduced
+
+        SystemClock.sleep(500);
+        tracker.qoeKpiAttributesForTest(); // mid-session emit
+        SystemClock.sleep(500);
+        tracker.onQoeRenditionChange("up", 5_000_000L); // close reduced — single accumulation
+
+        long total = (Long) tracker.qoeAccumulatorSnapshotForTest().get("timeSwitchedDown");
+        assertTrue("should accumulate ~1000ms total, got " + total,
+                total >= 1_000 && total < 2_500);
+    }
+
+    // ====================================================================
+    // §5.0 rule 6 — switched-down timer continues while paused.
+    // ====================================================================
+
+    @Test
+    public void pauseDuringReducedInterval_doesNotPauseSwitchedDownTimer() {
+        tracker.pinnedRendition = 5_000_000L;
+        tracker.onQoeContentStart();
+        tracker.onQoeRenditionChange("down", 1_000_000L); // open reduced
+
+        SystemClock.sleep(300);
+        tracker.onQoePause();
+        SystemClock.sleep(700);   // 700ms paused
+        tracker.onQoeResume();
+        SystemClock.sleep(200);
+        tracker.onQoeRenditionChange("up", 5_000_000L); // close reduced
+
+        long switchedDown = (Long) tracker.qoeAccumulatorSnapshotForTest().get("timeSwitchedDown");
+        long pauseTotal   = (Long) tracker.qoeAccumulatorSnapshotForTest().get("totalPauseTime");
+
+        assertTrue("switched-down should span paused time too (~1200ms), got " + switchedDown,
+                switchedDown >= 1_200 && switchedDown < 2_000);
+        assertTrue("totalPauseTime should be ~700ms, got " + pauseTotal,
+                pauseTotal >= 700 && pauseTotal < 1_500);
+    }
+
+    // ====================================================================
+    // §5.6 / §7 invariant 4 — view end flushes intervals exactly once.
+    // ====================================================================
+
+    @Test
+    public void viewEnd_flushesPauseAndReduced_exactlyOnce() {
+        tracker.pinnedRendition = 5_000_000L;
+        tracker.onQoeContentStart();
+        tracker.onQoeRenditionChange("down", 1_000_000L);
+        tracker.onQoePause();
+        SystemClock.sleep(400);
+
+        tracker.onQoeViewEnd();
+        long firstReduced = (Long) tracker.qoeAccumulatorSnapshotForTest().get("timeSwitchedDown");
+        long firstPause   = (Long) tracker.qoeAccumulatorSnapshotForTest().get("totalPauseTime");
+        assertTrue("first flush captured the reduced interval", firstReduced >= 400);
+        assertTrue("first flush captured the pause interval", firstPause >= 400);
+        assertNull(tracker.qoeAccumulatorSnapshotForTest().get("reducedSinceMs"));
+        assertNull(tracker.qoeAccumulatorSnapshotForTest().get("pauseStartMs"));
+
+        SystemClock.sleep(400);
+        tracker.onQoeViewEnd(); // second call should be a no-op
+
+        assertEquals("second view-end must not double-count reduced",
+                firstReduced, tracker.qoeAccumulatorSnapshotForTest().get("timeSwitchedDown"));
+        assertEquals("second view-end must not double-count pause",
+                firstPause, tracker.qoeAccumulatorSnapshotForTest().get("totalPauseTime"));
+    }
+
+    // ====================================================================
+    // §7 invariant 1 — ad-scoped events are no-ops.
+    // §7 invariant 2 — null/zero rendition never enters accumulators.
+    // ====================================================================
+
+    @Test
+    public void adScope_renditionChangeIsNoOp() {
+        tracker.getState().isAd = true;
+        tracker.onQoeRenditionChange("up", 4_000_000L);
+        tracker.onQoeRenditionChange("down", 1_000_000L);
+        tracker.onQoeDownloadRateSample(1_000_000L);
+        tracker.onQoePause();
+
+        Map<String, Object> snap = tracker.qoeAccumulatorSnapshotForTest();
+        assertEquals(0L, snap.get("switchUps"));
+        assertEquals(0L, snap.get("switchDowns"));
+        assertEquals(0L, snap.get("dlCount"));
+        assertNull(snap.get("pauseStartMs"));
+        assertEquals(0, snap.get("playedRenditionsSize"));
+    }
+
+    @Test
+    public void nullOrZeroRendition_neverEntersAccumulators() {
+        tracker.pinnedRendition = null;
+        tracker.onQoeContentStart();
+        tracker.onQoeRenditionChange("up", null);
+        tracker.onQoeRenditionChange("up", 0L);
+
+        Map<String, Object> snap = tracker.qoeAccumulatorSnapshotForTest();
+        assertEquals(0, snap.get("playedRenditionsSize"));
+        assertEquals(0L, snap.get("maxRendition"));
+        assertEquals(0L, snap.get("switchUps"));
+    }
+
+    // ====================================================================
+    // Group A — download-rate samples.
+    // ====================================================================
+
+    @Test
+    public void downloadRate_sameValueRepeatedCountsEachSample() {
+        for (int i = 0; i < 10; i++) tracker.onQoeDownloadRateSample(1_500_000L);
+        Map<String, Object> snap = tracker.qoeAccumulatorSnapshotForTest();
+        assertEquals(10L, snap.get("dlCount"));
+        assertEquals(15_000_000L, snap.get("dlSum"));
+        assertEquals(1_500_000L, snap.get("dlMin"));
+        assertEquals(1_500_000L, snap.get("dlMax"));
+    }
+
+    @Test
+    public void downloadRate_alternatingSamples_avgMinMax() {
+        tracker.onQoeDownloadRateSample(1_000_000L);
+        tracker.onQoeDownloadRateSample(5_000_000L);
+        tracker.onQoeDownloadRateSample(1_000_000L);
+        tracker.onQoeDownloadRateSample(5_000_000L);
+
+        Map<String, Object> kpis = tracker.qoeKpiAttributesForTest();
+        assertEquals(3_000_000L, kpis.get("avgDownloadRate"));
+        assertEquals(1_000_000L, kpis.get("minDownloadRate"));
+        assertEquals(5_000_000L, kpis.get("maxDownloadRate"));
+    }
+
+    @Test
+    public void downloadRate_omitsKeysWhenNoSampleArrived() {
+        Map<String, Object> kpis = tracker.qoeKpiAttributesForTest();
+        assertFalse("avgDownloadRate must be absent, not 0/null",
+                kpis.containsKey("avgDownloadRate"));
+        assertFalse(kpis.containsKey("minDownloadRate"));
+        assertFalse(kpis.containsKey("maxDownloadRate"));
+    }
+
+    @Test
+    public void downloadRate_rejectsNullAndNonPositive() {
+        tracker.onQoeDownloadRateSample(null);
+        tracker.onQoeDownloadRateSample(0L);
+        tracker.onQoeDownloadRateSample(-42L);
+        Map<String, Object> snap = tracker.qoeAccumulatorSnapshotForTest();
+        assertEquals(0L, snap.get("dlCount"));
+    }
+
+    // ====================================================================
+    // Group F — distinct variants de-dups.
+    // ====================================================================
+
+    @Test
+    public void variants_dedupRepeatedBitrate() {
+        tracker.pinnedRendition = 1_000_000L;
+        tracker.onQoeContentStart();
+        tracker.onQoeRenditionChange("up", 2_000_000L);
+        tracker.onQoeRenditionChange("down", 1_000_000L); // already in set
+        tracker.onQoeRenditionChange("up", 2_000_000L);   // already in set
+
+        long count = (Long) tracker.qoeKpiAttributesForTest().get("totalVariantsPlayed");
+        assertEquals(2L, count);
+    }
+
+    // ====================================================================
+    // Shift derivation — Android computes shift from previous rendition.
+    // ====================================================================
+
+    @Test
+    public void computeQoeRenditionShift_returnsTriState() {
+        assertEquals("up",   NRVideoTracker.computeQoeRenditionShift(1_000_000L, 2_000_000L));
+        assertEquals("down", NRVideoTracker.computeQoeRenditionShift(2_000_000L, 1_000_000L));
+        assertEquals("none", NRVideoTracker.computeQoeRenditionShift(1_000_000L, 1_000_000L));
+        assertNull(NRVideoTracker.computeQoeRenditionShift(null, 2_000_000L));
+        assertNull(NRVideoTracker.computeQoeRenditionShift(1_000_000L, null));
+        assertNull(NRVideoTracker.computeQoeRenditionShift(1_000_000L, 0L));
+    }
+
+    // ====================================================================
+    // Composite (bitrate, width, height) rendition identity — robust to DASH
+    // streams whose Format.bitrate is uniform across resolutions.
+    // ====================================================================
+
+    // ====================================================================
+    // Pixel-first rendition identity — robust to DASH streams whose
+    // contentRenditionBitrate is uniform across resolutions. When width/height
+    // are reported, the algorithm keys off pixels (W*H); otherwise it falls
+    // back to bitrate. See renditionSignal().
+    // Tests skip onQoeContentStart() because TestTracker doesn't override
+    // getRenditionWidth/Height — its seed would key off bitrate-fallback and
+    // muddy whole-state assertions about the rendition-change path.
+    // ====================================================================
+
+    @Test
+    public void pixelSignal_resolutionFlipWithStuckBitrate_countsAsTwoVariants() {
+        // Reproduces the production case: contentRenditionBitrate=932697 across
+        // 720p → 360p → 720p, with the platform publishing shift up/down.
+        tracker.onQoeRenditionChange("none", 932_697L, 1280L, 720L);
+        tracker.onQoeRenditionChange("down", 932_697L, 640L, 360L);
+        tracker.onQoeRenditionChange("up",   932_697L, 1280L, 720L);
+
+        Map<String, Object> kpis = tracker.qoeKpiAttributesForTest();
+        assertEquals("two distinct resolutions despite stuck bitrate",
+                2L, kpis.get("totalVariantsPlayed"));
+        assertEquals(1L, kpis.get("totalSwitchUps"));
+        assertEquals(1L, kpis.get("totalSwitchDowns"));
+    }
+
+    @Test
+    public void pixelSignal_sameResolutionDifferentBitrate_countsAsOneVariant() {
+        // Pixel-only identity collapses same-resolution renditions. Documented
+        // trade-off — switch counters still increment via published shift.
+        tracker.onQoeRenditionChange("none", 1_000_000L, 1280L, 720L);
+        tracker.onQoeRenditionChange("up",   2_000_000L, 1280L, 720L);
+
+        long count = (Long) tracker.qoeKpiAttributesForTest().get("totalVariantsPlayed");
+        assertEquals(1L, count);
+        assertEquals(1L, tracker.qoeKpiAttributesForTest().get("totalSwitchUps"));
+    }
+
+    @Test
+    public void pixelSignal_sameBitrateAndResolution_countsAsOneVariant() {
+        tracker.onQoeRenditionChange("none", 1_500_000L, 1280L, 720L);
+        tracker.onQoeRenditionChange("none", 1_500_000L, 1280L, 720L);
+        tracker.onQoeRenditionChange("none", 1_500_000L, 1280L, 720L);
+
+        long count = (Long) tracker.qoeKpiAttributesForTest().get("totalVariantsPlayed");
+        assertEquals(1L, count);
+    }
+
+    @Test
+    public void pixelSignal_maxAnchor_isHighestPixelCount() {
+        // 360p (230_400 px) → 720p (921_600 px). Max anchor advances on pixels.
+        tracker.onQoeRenditionChange("none", 5_000_000L, 640L, 360L);
+        tracker.onQoeRenditionChange("up",   1_000_000L, 1280L, 720L);
+
+        Map<String, Object> snap = tracker.qoeAccumulatorSnapshotForTest();
+        assertEquals(1280L * 720L, snap.get("maxRendition"));
+    }
+
+    @Test
+    public void pixelSignal_groupD_drivenByPixelsWhenBitrateIsStuck() {
+        // Production scenario: 720p (max) → 360p (reduced) → 720p (recover).
+        tracker.onQoeRenditionChange("none", 932_697L, 1280L, 720L);
+
+        tracker.onQoeRenditionChange("down", 932_697L, 640L, 360L); // open reduced
+        SystemClock.sleep(1_000);
+        tracker.onQoeRenditionChange("up",   932_697L, 1280L, 720L); // close reduced
+
+        long switchedDown = (Long) tracker.qoeAccumulatorSnapshotForTest().get("timeSwitchedDown");
+        assertTrue("expected ~1_000 ms accumulated, got " + switchedDown,
+                switchedDown >= 1_000 && switchedDown < 3_000);
+    }
+
+    // Production regression: when CONTENT_RENDITION_CHANGE is dispatched, the QoE hook
+    // runs from inside super.getAttributes — which means derived-class additions to the
+    // attribute map (including "shift") have NOT happened yet. The QoE hook must read
+    // shift via the override hook (getRenditionShift), not via processedAttributes.
+    @Test
+    public void renditionChange_publishedShiftReadViaOverride_notViaMap() {
+        tracker.pinnedShift = "down";
+
+        // Simulate the exact map ExoPlayer's super.getAttributes hands us: rendition
+        // info present, but "shift" NOT yet on the map (derived class adds it later).
+        Map<String, Object> attrs = new HashMap<>();
+        attrs.put("contentRenditionBitrate", 932_697L);
+        attrs.put("contentRenditionWidth",   854L);
+        attrs.put("contentRenditionHeight",  480L);
+        // Deliberately no "shift" key.
+
+        tracker.trackBitrateFromProcessedAttributes("CONTENT_RENDITION_CHANGE", attrs);
+
+        Map<String, Object> snap = tracker.qoeAccumulatorSnapshotForTest();
+        assertEquals("down published via override hook should increment switchDowns",
+                1L, snap.get("switchDowns"));
+        assertEquals(0L, snap.get("switchUps"));
+        assertEquals(1, snap.get("playedRenditionsSize"));
+    }
+
+    @Test
+    public void renditionChange_overrideShiftWins_evenWithStaleBitrateBaseline() {
+        // Reproduces the exact failing prod data: contentRenditionBitrate stuck at 932697
+        // across a 720p → 480p flip. Bitrate-derived fallback would say "none";
+        // override-published shift "down" must win.
+        tracker.pinnedRendition = 932_697L; // seeds qoePrevRenditionForShift
+        tracker.onQoeContentStart();
+        tracker.pinnedShift = "down";
+
+        Map<String, Object> attrs = new HashMap<>();
+        attrs.put("contentRenditionBitrate", 932_697L);     // unchanged
+        attrs.put("contentRenditionWidth",   854L);
+        attrs.put("contentRenditionHeight",  480L);
+
+        tracker.trackBitrateFromProcessedAttributes("CONTENT_RENDITION_CHANGE", attrs);
+
+        Map<String, Object> snap = tracker.qoeAccumulatorSnapshotForTest();
+        assertEquals(1L, snap.get("switchDowns"));
+        assertEquals(0L, snap.get("switchUps"));
+    }
+
+    @Test
+    public void renditionSignal_prefersPixelsWhenAvailable_elseBitrate() {
+        assertEquals(1280L * 720L, NRVideoTracker.renditionSignal(1_000_000L, 1280L, 720L));
+        assertEquals(1_000_000L,   NRVideoTracker.renditionSignal(1_000_000L, null, null));
+        assertEquals(1_000_000L,   NRVideoTracker.renditionSignal(1_000_000L, 0L, 0L));
+        assertEquals(1_000_000L,   NRVideoTracker.renditionSignal(1_000_000L, 1280L, null));
+        assertEquals(0L,           NRVideoTracker.renditionSignal(null, null, null));
+        assertEquals(0L,           NRVideoTracker.renditionSignal(0L, 0L, 0L));
+        assertEquals(0L,           NRVideoTracker.renditionSignal(-1L, null, null));
+    }
+
+    // Regression: ExoPlayer publishes "shift" from VideoSize, which can flip
+    // (720p → 360p → 720p) without contentRenditionBitrate changing. The published
+    // value must win so Group B counters track real platform-observed switches.
+    @Test
+    public void selectQoeShift_prefersPublishedOverBitrateDerived() {
+        // Published wins even when bitrate is unchanged.
+        assertEquals("down", NRVideoTracker.selectQoeShift("down", 932_697L, 932_697L));
+        assertEquals("up",   NRVideoTracker.selectQoeShift("up",   932_697L, 932_697L));
+        assertEquals("none", NRVideoTracker.selectQoeShift("none", 932_697L, 932_697L));
+
+        // Falls back to bitrate-derived when published is missing or not a recognized value.
+        assertEquals("up",   NRVideoTracker.selectQoeShift(null, 1_000_000L, 2_000_000L));
+        assertEquals("down", NRVideoTracker.selectQoeShift("",   2_000_000L, 1_000_000L));
+        assertEquals("none", NRVideoTracker.selectQoeShift("garbage", 1_000_000L, 1_000_000L));
+        assertEquals("up",   NRVideoTracker.selectQoeShift(42, 1_000_000L, 2_000_000L));
+    }
+
+    // ====================================================================
+    // §7 invariant 10 — strict key omission, never null.
+    // ====================================================================
+
+    @Test
+    public void emit_alwaysIncludesGroupBDFKeysWithZeroDefault() {
+        Map<String, Object> kpis = tracker.qoeKpiAttributesForTest();
+
+        assertTrue(kpis.containsKey("totalSwitchUps"));
+        assertTrue(kpis.containsKey("totalSwitchDowns"));
+        assertTrue(kpis.containsKey("totalTimeSwitchedDown"));
+        assertTrue(kpis.containsKey("totalPauseTime"));
+        assertTrue(kpis.containsKey("totalVariantsPlayed"));
+
+        assertEquals(0L, kpis.get("totalSwitchUps"));
+        assertEquals(0L, kpis.get("totalSwitchDowns"));
+        assertEquals(0L, kpis.get("totalTimeSwitchedDown"));
+        assertEquals(0L, kpis.get("totalPauseTime"));
+        assertEquals(0L, kpis.get("totalVariantsPlayed"));
+    }
+
+    // ====================================================================
+    // Integration scenario — three-rendition session low → high → low.
+    // ====================================================================
+
+    @Test
+    public void integration_threeRenditionSession() {
+        tracker.pinnedRendition = 1_000_000L;
+        tracker.onQoeContentStart();
+        // up
+        tracker.onQoeRenditionChange("up", 5_000_000L);
+        SystemClock.sleep(100);
+        // down — opens reduced
+        tracker.onQoeRenditionChange("down", 1_000_000L);
+        SystemClock.sleep(2_000);
+        // back up to max — closes reduced
+        tracker.onQoeRenditionChange("up", 5_000_000L);
+
+        tracker.onQoeViewEnd();
+        Map<String, Object> kpis = tracker.qoeKpiAttributesForTest();
+
+        assertEquals(2L, kpis.get("totalSwitchUps"));
+        assertEquals(1L, kpis.get("totalSwitchDowns"));
+        assertEquals(2L, kpis.get("totalVariantsPlayed"));
+        long switchedDown = (Long) kpis.get("totalTimeSwitchedDown");
+        assertTrue("expected ~2_000 ms switched-down, got " + switchedDown,
+                switchedDown >= 2_000 && switchedDown < 4_000);
+    }
+
+    // ====================================================================
+    // §5.0 rule 9 — exhaustive per-view reset (whole-state equality).
+    // ====================================================================
+
+    @Test
+    public void resetForViewSession_zeroesAllNewKpiState() {
+        // Drive into non-trivial state
+        tracker.pinnedRendition = 5_000_000L;
+        tracker.onQoeContentStart();
+        tracker.onQoeRenditionChange("down", 2_000_000L);
+        tracker.onQoeRenditionChange("up", 5_000_000L);
+        tracker.onQoeDownloadRateSample(1_500_000L);
+        tracker.onQoeDownloadRateSample(4_500_000L);
+        tracker.onQoePause();
+        SystemClock.sleep(200);
+        tracker.onQoeResume();
+        // Leave one open interval to make sure reset clears it too.
+        tracker.onQoeRenditionChange("down", 1_000_000L);
+        tracker.onQoePause();
+
+        // Sanity: state is non-trivial before reset
+        Map<String, Object> dirty = tracker.qoeAccumulatorSnapshotForTest();
+        assertTrue((Long) dirty.get("dlCount") > 0);
+        assertTrue((Long) dirty.get("switchDowns") > 0);
+        assertNotNull(dirty.get("reducedSinceMs"));
+        assertNotNull(dirty.get("pauseStartMs"));
+
+        tracker.resetQoeMetrics();
+
+        Map<String, Object> after = tracker.qoeAccumulatorSnapshotForTest();
+        Map<String, Object> expected = freshSnapshot();
+        assertEquals("whole-state equality after reset", expected, after);
+    }
+
+    private Map<String, Object> freshSnapshot() {
+        Map<String, Object> e = new HashMap<>();
+        e.put("dlSum", 0L);
+        e.put("dlCount", 0L);
+        e.put("dlMin", null);
+        e.put("dlMax", 0L);
+        e.put("switchUps", 0L);
+        e.put("switchDowns", 0L);
+        e.put("maxRendition", 0L);
+        e.put("prevRenditionForShift", null);
+        e.put("timeSwitchedDown", 0L);
+        e.put("reducedSinceMs", null);
+        e.put("totalPauseTime", 0L);
+        e.put("pauseStartMs", null);
+        e.put("playedRenditionsSize", 0);
+        return e;
+    }
+}

--- a/NewRelicVideoCore/src/test/java/com/newrelic/videoagent/core/tracker/NRVideoTrackerQoeTest.java
+++ b/NewRelicVideoCore/src/test/java/com/newrelic/videoagent/core/tracker/NRVideoTrackerQoeTest.java
@@ -64,7 +64,7 @@ public class NRVideoTrackerQoeTest {
 
         Map<String, Object> snap = tracker.qoeAccumulatorSnapshotForTest();
         assertEquals(2_000_000L, snap.get("maxRendition"));
-        assertNull("no reduced interval should be open", snap.get("reducedSinceMs"));
+        assertNull("no switched-down interval should be open", snap.get("switchedDownStartMs"));
         assertEquals(0L, snap.get("timeSwitchedDown"));
         assertEquals(1L, snap.get("switchUps"));
         assertEquals(0L, snap.get("switchDowns"));
@@ -82,7 +82,7 @@ public class NRVideoTrackerQoeTest {
 
         Map<String, Object> snap = tracker.qoeAccumulatorSnapshotForTest();
         assertEquals(6_000_000L, snap.get("maxRendition"));
-        assertNull(snap.get("reducedSinceMs"));
+        assertNull(snap.get("switchedDownStartMs"));
         long elapsed = (Long) snap.get("timeSwitchedDown");
         assertTrue("expected ~2_000 ms accumulated, got " + elapsed,
                 elapsed >= 2_000 && elapsed < 5_000);
@@ -100,7 +100,7 @@ public class NRVideoTrackerQoeTest {
         Map<String, Object> after = tracker.qoeAccumulatorSnapshotForTest();
         assertEquals(before.get("maxRendition"), after.get("maxRendition"));
         assertEquals(before.get("timeSwitchedDown"), after.get("timeSwitchedDown"));
-        assertNull(after.get("reducedSinceMs"));
+        assertNull(after.get("switchedDownStartMs"));
     }
 
     @Test
@@ -114,7 +114,7 @@ public class NRVideoTrackerQoeTest {
 
         Map<String, Object> snap = tracker.qoeAccumulatorSnapshotForTest();
         assertEquals(5_000_000L, snap.get("maxRendition"));
-        assertNull(snap.get("reducedSinceMs"));
+        assertNull(snap.get("switchedDownStartMs"));
         long elapsed = (Long) snap.get("timeSwitchedDown");
         assertTrue("expected ~1_000 ms accumulated, got " + elapsed,
                 elapsed >= 1_000 && elapsed < 4_000);
@@ -129,7 +129,7 @@ public class NRVideoTrackerQoeTest {
 
         Map<String, Object> snap = tracker.qoeAccumulatorSnapshotForTest();
         assertEquals(5_000_000L, snap.get("maxRendition"));
-        assertNotNull("a reduced interval should now be open", snap.get("reducedSinceMs"));
+        assertNotNull("a switched-down interval should now be open", snap.get("switchedDownStartMs"));
         assertEquals(0L, snap.get("timeSwitchedDown"));
     }
 
@@ -139,12 +139,12 @@ public class NRVideoTrackerQoeTest {
         tracker.onQoeContentStart();
 
         tracker.onQoeRenditionChange("down", 3_000_000L); // open at t0
-        Object reducedT0 = tracker.qoeAccumulatorSnapshotForTest().get("reducedSinceMs");
+        Object reducedT0 = tracker.qoeAccumulatorSnapshotForTest().get("switchedDownStartMs");
         SystemClock.sleep(500);
         tracker.onQoeRenditionChange("down", 1_500_000L); // still below max, prev open
 
         Map<String, Object> snap = tracker.qoeAccumulatorSnapshotForTest();
-        assertEquals("interval start should not be reopened", reducedT0, snap.get("reducedSinceMs"));
+        assertEquals("interval start should not be reopened", reducedT0, snap.get("switchedDownStartMs"));
         assertEquals("no time accumulated yet — interval still open", 0L, snap.get("timeSwitchedDown"));
         assertEquals("max stays at the all-time high", 5_000_000L, snap.get("maxRendition"));
     }
@@ -160,7 +160,7 @@ public class NRVideoTrackerQoeTest {
         tracker.onQoeRenditionChange("down", 1_000_000L); // open reduced
         tracker.onQoePause();                              // open pause
 
-        Object reducedBefore = tracker.qoeAccumulatorSnapshotForTest().get("reducedSinceMs");
+        Object reducedBefore = tracker.qoeAccumulatorSnapshotForTest().get("switchedDownStartMs");
         Object pauseBefore   = tracker.qoeAccumulatorSnapshotForTest().get("pauseStartMs");
 
         SystemClock.sleep(750);
@@ -172,7 +172,7 @@ public class NRVideoTrackerQoeTest {
         assertTrue("emit should reflect open pause interval", emittedPause >= 750);
 
         Map<String, Object> snapAfter = tracker.qoeAccumulatorSnapshotForTest();
-        assertEquals("reducedSinceMs must not move", reducedBefore, snapAfter.get("reducedSinceMs"));
+        assertEquals("switchedDownStartMs must not move", reducedBefore, snapAfter.get("switchedDownStartMs"));
         assertEquals("pauseStartMs must not move", pauseBefore, snapAfter.get("pauseStartMs"));
         assertEquals("timeSwitchedDown accumulator must not advance on emit",
                 0L, snapAfter.get("timeSwitchedDown"));
@@ -239,7 +239,7 @@ public class NRVideoTrackerQoeTest {
         long firstPause   = (Long) tracker.qoeAccumulatorSnapshotForTest().get("totalPauseTime");
         assertTrue("first flush captured the reduced interval", firstReduced >= 400);
         assertTrue("first flush captured the pause interval", firstPause >= 400);
-        assertNull(tracker.qoeAccumulatorSnapshotForTest().get("reducedSinceMs"));
+        assertNull(tracker.qoeAccumulatorSnapshotForTest().get("switchedDownStartMs"));
         assertNull(tracker.qoeAccumulatorSnapshotForTest().get("pauseStartMs"));
 
         SystemClock.sleep(400);
@@ -267,7 +267,7 @@ public class NRVideoTrackerQoeTest {
         Map<String, Object> snap = tracker.qoeAccumulatorSnapshotForTest();
         assertEquals(0L, snap.get("switchUps"));
         assertEquals(0L, snap.get("switchDowns"));
-        assertEquals(0L, snap.get("dlCount"));
+        assertEquals(0L, snap.get("downloadRateCount"));
         assertNull(snap.get("pauseStartMs"));
         assertEquals(0, snap.get("playedRenditionsSize"));
     }
@@ -293,10 +293,10 @@ public class NRVideoTrackerQoeTest {
     public void downloadRate_sameValueRepeatedCountsEachSample() {
         for (int i = 0; i < 10; i++) tracker.onQoeDownloadRateSample(1_500_000L);
         Map<String, Object> snap = tracker.qoeAccumulatorSnapshotForTest();
-        assertEquals(10L, snap.get("dlCount"));
-        assertEquals(15_000_000L, snap.get("dlSum"));
-        assertEquals(1_500_000L, snap.get("dlMin"));
-        assertEquals(1_500_000L, snap.get("dlMax"));
+        assertEquals(10L, snap.get("downloadRateCount"));
+        assertEquals(15_000_000L, snap.get("downloadRateSum"));
+        assertEquals(1_500_000L, snap.get("downloadRateMin"));
+        assertEquals(1_500_000L, snap.get("downloadRateMax"));
     }
 
     @Test
@@ -327,7 +327,7 @@ public class NRVideoTrackerQoeTest {
         tracker.onQoeDownloadRateSample(0L);
         tracker.onQoeDownloadRateSample(-42L);
         Map<String, Object> snap = tracker.qoeAccumulatorSnapshotForTest();
-        assertEquals(0L, snap.get("dlCount"));
+        assertEquals(0L, snap.get("downloadRateCount"));
     }
 
     // ====================================================================
@@ -581,9 +581,9 @@ public class NRVideoTrackerQoeTest {
 
         // Sanity: state is non-trivial before reset
         Map<String, Object> dirty = tracker.qoeAccumulatorSnapshotForTest();
-        assertTrue((Long) dirty.get("dlCount") > 0);
+        assertTrue((Long) dirty.get("downloadRateCount") > 0);
         assertTrue((Long) dirty.get("switchDowns") > 0);
-        assertNotNull(dirty.get("reducedSinceMs"));
+        assertNotNull(dirty.get("switchedDownStartMs"));
         assertNotNull(dirty.get("pauseStartMs"));
 
         tracker.resetQoeMetrics();
@@ -595,16 +595,16 @@ public class NRVideoTrackerQoeTest {
 
     private Map<String, Object> freshSnapshot() {
         Map<String, Object> e = new HashMap<>();
-        e.put("dlSum", 0L);
-        e.put("dlCount", 0L);
-        e.put("dlMin", null);
-        e.put("dlMax", 0L);
+        e.put("downloadRateSum", 0L);
+        e.put("downloadRateCount", 0L);
+        e.put("downloadRateMin", null);
+        e.put("downloadRateMax", 0L);
         e.put("switchUps", 0L);
         e.put("switchDowns", 0L);
         e.put("maxRendition", 0L);
         e.put("prevRenditionForShift", null);
         e.put("timeSwitchedDown", 0L);
-        e.put("reducedSinceMs", null);
+        e.put("switchedDownStartMs", null);
         e.put("totalPauseTime", 0L);
         e.put("pauseStartMs", null);
         e.put("playedRenditionsSize", 0);

--- a/NewRelicVideoCore/src/test/java/com/newrelic/videoagent/core/tracker/NRVideoTrackerQoeTest.java
+++ b/NewRelicVideoCore/src/test/java/com/newrelic/videoagent/core/tracker/NRVideoTrackerQoeTest.java
@@ -342,7 +342,7 @@ public class NRVideoTrackerQoeTest {
         tracker.onQoeRenditionChange("down", 1_000_000L); // already in set
         tracker.onQoeRenditionChange("up", 2_000_000L);   // already in set
 
-        long count = (Long) tracker.qoeKpiAttributesForTest().get("totalVariantsPlayed");
+        long count = (Long) tracker.qoeKpiAttributesForTest().get("totalRenditions");
         assertEquals(2L, count);
     }
 
@@ -385,7 +385,7 @@ public class NRVideoTrackerQoeTest {
 
         Map<String, Object> kpis = tracker.qoeKpiAttributesForTest();
         assertEquals("two distinct resolutions despite stuck bitrate",
-                2L, kpis.get("totalVariantsPlayed"));
+                2L, kpis.get("totalRenditions"));
         assertEquals(1L, kpis.get("totalSwitchUps"));
         assertEquals(1L, kpis.get("totalSwitchDowns"));
     }
@@ -397,7 +397,7 @@ public class NRVideoTrackerQoeTest {
         tracker.onQoeRenditionChange("none", 1_000_000L, 1280L, 720L);
         tracker.onQoeRenditionChange("up",   2_000_000L, 1280L, 720L);
 
-        long count = (Long) tracker.qoeKpiAttributesForTest().get("totalVariantsPlayed");
+        long count = (Long) tracker.qoeKpiAttributesForTest().get("totalRenditions");
         assertEquals(1L, count);
         assertEquals(1L, tracker.qoeKpiAttributesForTest().get("totalSwitchUps"));
     }
@@ -408,7 +408,7 @@ public class NRVideoTrackerQoeTest {
         tracker.onQoeRenditionChange("none", 1_500_000L, 1280L, 720L);
         tracker.onQoeRenditionChange("none", 1_500_000L, 1280L, 720L);
 
-        long count = (Long) tracker.qoeKpiAttributesForTest().get("totalVariantsPlayed");
+        long count = (Long) tracker.qoeKpiAttributesForTest().get("totalRenditions");
         assertEquals(1L, count);
     }
 
@@ -522,13 +522,13 @@ public class NRVideoTrackerQoeTest {
         assertTrue(kpis.containsKey("totalSwitchDowns"));
         assertTrue(kpis.containsKey("totalTimeSwitchedDown"));
         assertTrue(kpis.containsKey("totalPauseTime"));
-        assertTrue(kpis.containsKey("totalVariantsPlayed"));
+        assertTrue(kpis.containsKey("totalRenditions"));
 
         assertEquals(0L, kpis.get("totalSwitchUps"));
         assertEquals(0L, kpis.get("totalSwitchDowns"));
         assertEquals(0L, kpis.get("totalTimeSwitchedDown"));
         assertEquals(0L, kpis.get("totalPauseTime"));
-        assertEquals(0L, kpis.get("totalVariantsPlayed"));
+        assertEquals(0L, kpis.get("totalRenditions"));
     }
 
     // ====================================================================
@@ -553,7 +553,7 @@ public class NRVideoTrackerQoeTest {
 
         assertEquals(2L, kpis.get("totalSwitchUps"));
         assertEquals(1L, kpis.get("totalSwitchDowns"));
-        assertEquals(2L, kpis.get("totalVariantsPlayed"));
+        assertEquals(2L, kpis.get("totalRenditions"));
         long switchedDown = (Long) kpis.get("totalTimeSwitchedDown");
         assertTrue("expected ~2_000 ms switched-down, got " + switchedDown,
                 switchedDown >= 2_000 && switchedDown < 4_000);

--- a/NewRelicVideoCore/src/test/java/com/newrelic/videoagent/core/tracker/NRVideoTrackerQoeTest.java
+++ b/NewRelicVideoCore/src/test/java/com/newrelic/videoagent/core/tracker/NRVideoTrackerQoeTest.java
@@ -17,16 +17,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-/**
- * Unit tests for the additional QoE KPIs added to {@link NRVideoTracker}.
- *
- * Covers the cross-agent reference algorithm from the spec:
- *   §5.8 Group D transition table (all 6 cells)
- *   §5.0 rule 5: snapshot-not-mutate on emit
- *   §5.0 rule 6: pause × rendition interaction
- *   §5.0 rule 9: exhaustive per-view reset
- *   §7 invariants 1, 2, 4, 7, 10
- */
 @RunWith(RobolectricTestRunner.class)
 public class NRVideoTrackerQoeTest {
 
@@ -51,7 +41,7 @@ public class NRVideoTrackerQoeTest {
     }
 
     // ====================================================================
-    // §5.8 Group D transition table — all 6 cells.
+    // transition table — all 6 cells.
     // ====================================================================
 
     @Test
@@ -150,7 +140,7 @@ public class NRVideoTrackerQoeTest {
     }
 
     // ====================================================================
-    // §5.0 rule 5 — emitQoe() must NOT mutate intervals (heartbeat snapshot).
+    // emitQoe() must NOT mutate intervals (heartbeat snapshot).
     // ====================================================================
 
     @Test
@@ -197,7 +187,7 @@ public class NRVideoTrackerQoeTest {
     }
 
     // ====================================================================
-    // §5.0 rule 6 — switched-down timer continues while paused.
+    // switched-down timer continues while paused.
     // ====================================================================
 
     @Test
@@ -223,7 +213,7 @@ public class NRVideoTrackerQoeTest {
     }
 
     // ====================================================================
-    // §5.6 / §7 invariant 4 — view end flushes intervals exactly once.
+    // invariant 4 — view end flushes intervals exactly once.
     // ====================================================================
 
     @Test
@@ -252,8 +242,8 @@ public class NRVideoTrackerQoeTest {
     }
 
     // ====================================================================
-    // §7 invariant 1 — ad-scoped events are no-ops.
-    // §7 invariant 2 — null/zero rendition never enters accumulators.
+    // ad-scoped events are no-ops.
+    // null/zero rendition never enters accumulators.
     // ====================================================================
 
     @Test
@@ -560,7 +550,7 @@ public class NRVideoTrackerQoeTest {
     }
 
     // ====================================================================
-    // §5.0 rule 9 — exhaustive per-view reset (whole-state equality).
+    // exhaustive per-view reset (whole-state equality).
     // ====================================================================
 
     @Test


### PR DESCRIPTION
<html><head></head><body><p data-path-to-node="3" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">Adds <b data-path-to-node="3" data-index-in-node="5" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">8 new content-only KPIs</b> to the <code data-path-to-node="3" data-index-in-node="36" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">QOE_AGGREGATE</code> event</p><h3 data-path-to-node="4" style="font-family: &quot;Google Sans&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">New QoE Metrics</h3>

- avgDownloadRate
- minDownloadRate
- maxDownloadRate
- totalSwitchUps
- totalSwitchDowns
- totalTimeSwitchedDown
- totalPauseTime
- totalRenditions

<h2 data-path-to-node="7" style="font-family: &quot;Google Sans&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">🛠️ Design Notes</h2><ul data-path-to-node="8" style="padding-inline-start: 32px; font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><li style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><p data-path-to-node="8,0,0" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><b data-path-to-node="8,0,0" data-index-in-node="0" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">Pixel-First Rendition Identity (<code data-path-to-node="8,0,0" data-index-in-node="32" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">NRVideoTracker.java#renditionSignal</code>)</b></p><ul data-path-to-node="8,0,1" style="padding-inline-start: 32px; font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><li style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><p data-path-to-node="8,0,1,0,0" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><b data-path-to-node="8,0,1,0,0" data-index-in-node="0" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">Problem:</b> Some DASH manifests declare uniform <code data-path-to-node="8,0,1,0,0" data-index-in-node="45" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">Format.bitrate</code> across representations, causing <code data-path-to-node="8,0,1,0,0" data-index-in-node="92" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">contentRenditionBitrate</code> to stay constant during resolution switches.</p></li><li style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><p data-path-to-node="8,0,1,1,0" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><b data-path-to-node="8,0,1,1,0" data-index-in-node="0" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">Solution:</b> Group D/F algorithms now key off <code data-path-to-node="8,0,1,1,0" data-index-in-node="43" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">width × height</code> when available, falling back to bitrate only when W/H is missing. Keeps lightweight <code data-path-to-node="8,0,1,1,0" data-index-in-node="142" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">Set&lt;Long&gt;</code> / <code data-path-to-node="8,0,1,1,0" data-index-in-node="154" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">long</code> state.</p></li></ul></li><li style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><p data-path-to-node="8,1,0" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><b data-path-to-node="8,1,0" data-index-in-node="0" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">Decoupled Override Hook for Shift Attribute</b></p><ul data-path-to-node="8,1,1" style="padding-inline-start: 32px; font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><li style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><p data-path-to-node="8,1,1,0,0" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><b data-path-to-node="8,1,1,0,0" data-index-in-node="0" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">Problem:</b> The <code data-path-to-node="8,1,1,0,0" data-index-in-node="13" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">shift</code> attribute was added to the event map <i data-path-to-node="8,1,1,0,0" data-index-in-node="56" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">after</i> <code data-path-to-node="8,1,1,0,0" data-index-in-node="62" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">super.getAttributes</code> returned. Reading it via the map inside the QoE hook resulted in <code data-path-to-node="8,1,1,0,0" data-index-in-node="147" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">null</code>, breaking switch counters on stuck-bitrate streams.</p></li><li style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><p data-path-to-node="8,1,1,1,0" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><b data-path-to-node="8,1,1,1,0" data-index-in-node="0" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">Solution:</b> Introduced a new <code data-path-to-node="8,1,1,1,0" data-index-in-node="27" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">getRenditionShift()</code> override hook in <code data-path-to-node="8,1,1,1,0" data-index-in-node="64" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">NRVideoTracker.java</code> and <code data-path-to-node="8,1,1,1,0" data-index-in-node="88" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">NRTrackerExoPlayer.java</code> to eliminate this lifecycle ordering dependency.</p></li></ul></li><li style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><p data-path-to-node="8,2,0" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><b data-path-to-node="8,2,0" data-index-in-node="0" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">Snapshot-Not-Mutate on Emit (§5.0 Rule 5)</b></p><ul data-path-to-node="8,2,1" style="padding-inline-start: 32px; font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><li style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><p data-path-to-node="8,2,1,0,0" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><code data-path-to-node="8,2,1,0,0" data-index-in-node="0" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">calculateQOEKpiAttributes()</code> adds open-interval values to <code data-path-to-node="8,2,1,0,0" data-index-in-node="57" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">totalTimeSwitchedDown</code> and <code data-path-to-node="8,2,1,0,0" data-index-in-node="83" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">totalPauseTime</code> without closing/mutating the intervals.</p></li><li style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><p data-path-to-node="8,2,1,1,0" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">Mutation is strictly isolated to <code data-path-to-node="8,2,1,1,0" data-index-in-node="33" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">onQoeViewEnd()</code>. Verified bit-exact via production mid-pause emit data.</p></li></ul></li><li style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><p data-path-to-node="8,3,0" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><b data-path-to-node="8,3,0" data-index-in-node="0" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">Per-View Reset Coverage (§5.0 Rule 9)</b></p><ul data-path-to-node="8,3,1" style="padding-inline-start: 32px; font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><li style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><p data-path-to-node="8,3,1,0,0" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">All 13 new state fields are safely zeroed out in both <code data-path-to-node="8,3,1,0,0" data-index-in-node="54" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">resetForViewSession()</code> and <code data-path-to-node="8,3,1,0,0" data-index-in-node="80" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">resetQoeMetrics()</code>. Covered by a whole-state-equality test.</p></li></ul></li><li style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><p data-path-to-node="8,4,0" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><b data-path-to-node="8,4,0" data-index-in-node="0" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">Thread Safety</b></p><ul data-path-to-node="8,4,1" style="padding-inline-start: 32px; font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><li style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><p data-path-to-node="8,4,1,0,0" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><code data-path-to-node="8,4,1,0,0" data-index-in-node="0" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">qoePlayedRenditions</code> leverages a <code data-path-to-node="8,4,1,0,0" data-index-in-node="32" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">ConcurrentHashMap</code>-backed <code data-path-to-node="8,4,1,0,0" data-index-in-node="57" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">Set</code>.</p></li><li style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><p data-path-to-node="8,4,1,1,0" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">Scalar fields run on the same event-processing thread as existing trackers (<code data-path-to-node="8,4,1,1,0" data-index-in-node="76" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">qoeBitrateSum</code>).</p></li><li style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><p data-path-to-node="8,4,1,2,0" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">All 64-bit accumulators use <code data-path-to-node="8,4,1,2,0" data-index-in-node="28" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">safeAdd</code> for overflow protection.</p></li></ul></li></ul></body></html>