### PR TITLE
feat: Add new QOE attributes

### DIFF
--- a/DATAMODEL.md
+++ b/DATAMODEL.md
@@ -225,7 +225,15 @@ Quality of Experience aggregate attributes sent with `CONTENT_END` events.
 | `averageBitrate` | Long | Time-weighted average bitrate (bps) |
 | `hadPlaybackError` | Boolean | Error occurred during playback |
 | `totalPlaytime` | Long | Actual viewing time (ms) |
-| `qoeAggregateVersion` | String | Algorithm version (e.g. "1.0.0") |
+| `avgDownloadRate` | Long | Mean of observed network download throughput samples during content (bps). Omitted when no sample was observed. |
+| `minDownloadRate` | Long | Minimum observed network download throughput sample during content (bps). Omitted when no sample was observed. |
+| `maxDownloadRate` | Long | Maximum observed network download throughput sample during content (bps). Omitted when no sample was observed. |
+| `totalSwitchUps` | Long | Count of upward rendition (resolution) changes during content |
+| `totalSwitchDowns` | Long | Count of downward rendition (resolution) changes during content |
+| `totalTimeSwitchedDown` | Long | Cumulative time (ms) spent at a rendition below the highest rendition bitrate seen so far in the view; includes any open interval at emit time |
+| `totalPauseTime` | Long | Total content pause duration (ms); includes any open pause at emit time |
+| `totalRenditions` | Long | Count of distinct renditions (width × height) played during content |
+| `qoeAggregateVersion` | String | Algorithm version (e.g. "1.1.0") |
 
 ### VideoCustomAction
 

--- a/NRExoPlayerTracker/src/main/java/com/newrelic/videoagent/exoplayer/tracker/NRTrackerExoPlayer.java
+++ b/NRExoPlayerTracker/src/main/java/com/newrelic/videoagent/exoplayer/tracker/NRTrackerExoPlayer.java
@@ -816,6 +816,11 @@ public class NRTrackerExoPlayer extends NRVideoTracker implements Player.Listene
         NRLog.d("onVideoSizeChanged analytics, H = " + height + " W = " + width);
 
         if (player.isPlayingAd() || isLinkedAdBreakActive()) return;
+        // Media3 fires (0,0) when the renderer clears output between resolution
+        // transitions. Treat as non-event: otherwise prevSize→0 emits a false
+        // DOWN and the subsequent 0→newSize is silenced by the first-observation
+        // guard (lastMul == 0), eating every real shift.
+        if (width <= 0 || height <= 0) return;
 
         long currMul = (long) width * height;
         long lastMul = (long) lastWidth * lastHeight;

--- a/NRExoPlayerTracker/src/main/java/com/newrelic/videoagent/exoplayer/tracker/NRTrackerExoPlayer.java
+++ b/NRExoPlayerTracker/src/main/java/com/newrelic/videoagent/exoplayer/tracker/NRTrackerExoPlayer.java
@@ -710,7 +710,7 @@ public class NRTrackerExoPlayer extends NRVideoTracker implements Player.Listene
         } else {
             NRLog.d("\tVideo Paused");
 
-            if (getState().isPlaying && !inAd) {
+            if (getState().isStarted && !getState().isPaused && !player.isPlayingAd()) {
                 sendPause();
             }
         }

--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/model/NRTrackerState.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/model/NRTrackerState.java
@@ -190,7 +190,7 @@ public class NRTrackerState {
     public boolean goBufferEnd() {
         if (isRequested && isBuffering) {
             isBuffering = false;
-            isPlaying = true;
+            isPlaying = !isPaused;
             return true;
         } else {
             return false;
@@ -220,7 +220,7 @@ public class NRTrackerState {
     public boolean goSeekEnd() {
         if (isStarted && isSeeking) {
             isSeeking = false;
-            isPlaying = true;
+            isPlaying = !isPaused;
             return true;
         }
         else {

--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/tracker/NRTracker.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/tracker/NRTracker.java
@@ -292,6 +292,12 @@ public class NRTracker {
                 // Process CONTENT_BUFFER_END events for rebuffering time calculation
                 videoTracker.calculateRebufferingTime(attributes);
             }
+            else if (CONTENT_RENDITION_CHANGE.equals(action)) {
+                videoTracker.processQoeRenditionChange(attributes);
+            }
+            else if (CONTENT_PAUSE.equals(action) || CONTENT_RESUME.equals(action)) {
+                videoTracker.processQoePauseTime(action);
+            }
         }
     }
 }

--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/tracker/NRVideoTracker.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/tracker/NRVideoTracker.java
@@ -15,6 +15,10 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
+import java.util.Collections;
+import java.util.concurrent.ConcurrentHashMap;
+
 
 import static com.newrelic.videoagent.core.NRDef.*;
 import com.newrelic.videoagent.core.exception.ErrorExceptionHandler;
@@ -59,6 +63,27 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
     private Long startupPeriodPauseTime; // Pause time that occurred during startup period
     private boolean hasContentStarted; // Tracks whether content has successfully started (for buffer classification)
     private boolean initialBufferingHappened; // Tracks if initial buffering completed
+
+    // QoE network download-rate tracking (samples of contentNetworkDownloadBitrate)
+    private Long qoeDownloadRateSum;
+    private Long qoeDownloadRateCount;
+    private Long qoeMinDownloadRate;
+    private Long qoeMaxDownloadRate;
+
+    // QOE switch ups and downs
+    private long qoeTotalSwitchUps;
+    private long qoeTotalSwitchDowns;
+    private long qoeTotalTimeSwitchedDown;
+    private long qoeMaxRenditionBitrate;  // highest rendition bitrate seen this view
+    private Long qoeSwitchedDownSinceMs;
+
+    // QOE total pause time
+    private long qoeTotalPauseTime;
+    private Long qoePauseStartMs; // start of open pause; null = not paused
+
+    // QOE distinct renditions (keyed by width*height)
+    private final Set<Long> qoePlayedRenditions =
+            Collections.newSetFromMap(new ConcurrentHashMap<Long, Boolean>());
 
     // Time-weighted bitrate calculation fields
     private Long qoeCurrentBitrate;
@@ -167,6 +192,20 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
         qoeTotalBitrateWeightedTime = 0L;
         qoeTotalActiveTime = 0L;
         qoeBitrateTimerPaused = false;
+
+        qoeDownloadRateSum = 0L;
+        qoeDownloadRateCount = 0L;
+        qoeMinDownloadRate = null;
+        qoeMaxDownloadRate = null;
+
+        qoeTotalSwitchUps = 0L;
+        qoeTotalSwitchDowns = 0L;
+        qoeTotalTimeSwitchedDown = 0L;
+        qoeMaxRenditionBitrate = 0L;
+        qoeSwitchedDownSinceMs = null;
+
+        qoeTotalPauseTime = 0L;
+        qoePauseStartMs = null;
     }
 
     /**
@@ -327,6 +366,8 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
         // QoE: Track bitrate after all attributes are processed (including contentBitrate)
         if (!state.isAd && !QOE_AGGREGATE.equals(action)) {
             trackBitrateFromProcessedAttributes(action, attr);
+            trackDownloadRateMetrics(attr);
+            trackPlayedRenditions(attr);
         }
 
         // Cache attributes for non-QOE events (for thread-safe QOE generation)
@@ -890,7 +931,7 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
         }
 
         // qoeAggregateVersion - Version identifier for QOE calculation algorithm
-        kpiAttributes.put("qoeAggregateVersion", "1.0.0");
+        kpiAttributes.put("qoeAggregateVersion", "1.1.0");
 
         // startupTime - Cached value calculated at CONTENT_START
         if (qoeStartupTime != null && qoeStartupTime >= 0) {
@@ -904,6 +945,30 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
             qoeHadStartupError = false;
         }
         kpiAttributes.put("hadStartupError", qoeHadStartupError);
+
+        // Download-rate KPIs (from contentNetworkDownloadBitrate samples)
+        if (qoeDownloadRateCount != null && qoeDownloadRateCount > 0) {
+            long avgDownloadRate = Math.round((double) qoeDownloadRateSum / qoeDownloadRateCount);
+            kpiAttributes.put("avgDownloadRate", avgDownloadRate);
+        }
+        if (qoeMinDownloadRate != null) {
+            kpiAttributes.put("minDownloadRate", qoeMinDownloadRate);
+        }
+        if (qoeMaxDownloadRate != null) {
+            kpiAttributes.put("maxDownloadRate", qoeMaxDownloadRate);
+        }
+
+        // rendition switch ups and downs
+        kpiAttributes.put("totalSwitchUps", qoeTotalSwitchUps);
+        kpiAttributes.put("totalSwitchDowns", qoeTotalSwitchDowns);
+        long openMs = (qoeSwitchedDownSinceMs == null) ? 0L : System.currentTimeMillis() - qoeSwitchedDownSinceMs;
+        kpiAttributes.put("totalTimeSwitchedDown", safeAdd(qoeTotalTimeSwitchedDown, openMs));
+
+        // totalPauseTime — bank + currently-open pause, without closing it
+        long openPauseMs = (qoePauseStartMs == null) ? 0L : System.currentTimeMillis() - qoePauseStartMs;
+        kpiAttributes.put("totalPauseTime", safeAdd(qoeTotalPauseTime, openPauseMs));
+
+        kpiAttributes.put("totalRenditions", (long) qoePlayedRenditions.size());
 
         return kpiAttributes;
     }
@@ -933,6 +998,50 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
         // Set initialBufferingHappened flag after processing this buffer event
         if (!initialBufferingHappened) {
             initialBufferingHappened = true;
+        }
+    }
+
+    // Update rendition-switch QoE metrics from a CONTENT_RENDITION_CHANGE event.
+    void processQoeRenditionChange(Map<String, Object> attributes) {
+        if (state.isAd) return;
+
+        // Switch up/down counters — driven by the player-published shift (unchanged).
+        Object shift = attributes.get("shift");
+        if ("up".equals(shift))   qoeTotalSwitchUps++;
+        if ("down".equals(shift)) qoeTotalSwitchDowns++;
+
+        // totalTimeSwitchedDown: cumulative time below the highest rendition bitrate
+        // seen so far in this view.
+        Long bitrate = extractBitrateValue(attributes.get("contentRenditionBitrate"));
+        if (bitrate == null || bitrate <= 0) return;
+        long now = System.currentTimeMillis();
+
+        // Recovered to/above the session peak → close the open below-max interval.
+        if (qoeSwitchedDownSinceMs != null && bitrate >= qoeMaxRenditionBitrate) {
+            qoeTotalTimeSwitchedDown = safeAdd(qoeTotalTimeSwitchedDown, now - qoeSwitchedDownSinceMs);
+            qoeSwitchedDownSinceMs = null;
+        }
+        // New session peak.
+        if (bitrate > qoeMaxRenditionBitrate) {
+            qoeMaxRenditionBitrate = bitrate;
+        }
+        // Dropped below the peak with no interval open → start one.
+        if (bitrate < qoeMaxRenditionBitrate && qoeSwitchedDownSinceMs == null) {
+            qoeSwitchedDownSinceMs = now;
+        }
+    }
+
+    /**
+     * Update total pause time. Opens an interval on CONTENT_PAUSE, banks it on CONTENT_RESUME.
+     * An interval still open at emit is added by the snapshot in calculateQOEKpiAttributes().
+     */
+    void processQoePauseTime(String action) {
+        if (state.isAd) return;
+        if (CONTENT_PAUSE.equals(action)) {
+            qoePauseStartMs = System.currentTimeMillis();
+        } else if (CONTENT_RESUME.equals(action) && qoePauseStartMs != null) {
+            qoeTotalPauseTime = safeAdd(qoeTotalPauseTime, System.currentTimeMillis() - qoePauseStartMs);
+            qoePauseStartMs = null;
         }
     }
 
@@ -1204,6 +1313,22 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
         qoeTotalBitrateWeightedTime = 0L;
         qoeTotalActiveTime = 0L;
         qoeBitrateTimerPaused = false;
+
+        qoeDownloadRateSum = 0L;
+        qoeDownloadRateCount = 0L;
+        qoeMinDownloadRate = null;
+        qoeMaxDownloadRate = null;
+
+        qoeTotalSwitchUps = 0L;
+        qoeTotalSwitchDowns = 0L;
+        qoeTotalTimeSwitchedDown = 0L;
+        qoeMaxRenditionBitrate = 0L;
+        qoeSwitchedDownSinceMs = null;
+
+        qoeTotalPauseTime = 0L;
+        qoePauseStartMs = null;
+        
+        qoePlayedRenditions.clear();
 
         // Reset QOE provider fields for new view session
         // NOTE: Don't reset pendingQoeForNextHarvest here - it needs to persist until next harvest
@@ -1743,6 +1868,33 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
         qoeLastTrackedBitrate = currentBitrate;
         // Update QoE metrics efficiently
         updateQoeBitrateMetrics(currentBitrate, action);
+    }
+
+     // Sample contentNetworkDownloadBitrate for QoE download-rate KPIs
+    private void trackDownloadRateMetrics(Map<String, Object> processedAttributes) {
+        Long sample = extractBitrateValue(processedAttributes.get("contentNetworkDownloadBitrate"));
+        if (sample == null || sample <= 0) {
+            return;   // getNetworkDownloadBitrate() returns null/<=0 when unavailable
+        }
+
+        // Accumulate for average (overflow-safe, mirrors updateQoeBitrateMetrics)
+        if (qoeDownloadRateCount < Long.MAX_VALUE - 1) {
+            qoeDownloadRateSum = safeAdd(qoeDownloadRateSum, sample);
+            qoeDownloadRateCount++;
+        }
+
+        // Running min / max with null sentinel for first sample
+        qoeMinDownloadRate = (qoeMinDownloadRate == null) ? sample : Math.min(qoeMinDownloadRate, sample);
+        qoeMaxDownloadRate = (qoeMaxDownloadRate == null) ? sample : Math.max(qoeMaxDownloadRate, sample);
+    }
+
+    // Record distinct renditions played, keyed by width*height
+    private void trackPlayedRenditions(Map<String, Object> processedAttributes) {
+        Long w = extractBitrateValue(processedAttributes.get("contentRenditionWidth"));
+        Long h = extractBitrateValue(processedAttributes.get("contentRenditionHeight"));
+        if (w != null && w > 0 && h != null && h > 0) {
+            qoePlayedRenditions.add(w * h);
+        }
     }
 
     /**

--- a/NewRelicVideoCore/src/test/java/com/newrelic/videoagent/core/model/NRTrackerStateTest.java
+++ b/NewRelicVideoCore/src/test/java/com/newrelic/videoagent/core/model/NRTrackerStateTest.java
@@ -469,4 +469,109 @@ public class NRTrackerStateTest {
         assertFalse(state.isStarted);
         assertFalse(state.isPlaying);
     }
+
+    // --- Bug fix tests: pause state preserved across buffer/seek end ---
+
+    @Test
+    public void testGoBufferEndWhilePausedKeepsIsPlayingFalse() {
+        // Scenario: user pauses before network stalls, buffer fills while paused.
+        // goBufferEnd() must not flip isPlaying to true.
+        state.goRequest();
+        state.goStart();
+        state.goPause();        // user pauses
+        state.goBufferStart();  // network stalls
+
+        assertTrue(state.goBufferEnd());
+        assertFalse(state.isBuffering);
+        assertTrue(state.isPaused);
+        assertFalse(state.isPlaying);  // must stay false — player is still paused
+    }
+
+    @Test
+    public void testGoBufferEndWhileNotPausedSetsIsPlayingTrue() {
+        // Regression guard: normal rebuffer (no pause) must still resume playing.
+        state.goRequest();
+        state.goStart();
+        state.goBufferStart();
+
+        assertTrue(state.goBufferEnd());
+        assertFalse(state.isBuffering);
+        assertFalse(state.isPaused);
+        assertTrue(state.isPlaying);  // must be true — normal playback resumes
+    }
+
+    @Test
+    public void testGoSeekEndWhilePausedKeepsIsPlayingFalse() {
+        // Scenario: user pauses, then seeks to an unbuffered position.
+        // goSeekEnd() must not flip isPlaying to true.
+        state.goRequest();
+        state.goStart();
+        state.goPause();       // user pauses
+        state.goSeekStart();   // user drags progress bar
+
+        assertTrue(state.goSeekEnd());
+        assertFalse(state.isSeeking);
+        assertTrue(state.isPaused);
+        assertFalse(state.isPlaying);  // must stay false — player is still paused
+    }
+
+    @Test
+    public void testGoSeekEndWhileNotPausedSetsIsPlayingTrue() {
+        // Regression guard: normal seek (no pause) must still resume playing.
+        state.goRequest();
+        state.goStart();
+        state.goSeekStart();
+
+        assertTrue(state.goSeekEnd());
+        assertFalse(state.isSeeking);
+        assertFalse(state.isPaused);
+        assertTrue(state.isPlaying);  // must be true — normal playback resumes
+    }
+
+    @Test
+    public void testFullRebufferWhilePausedFlow() {
+        // Full scenario: stall → pause during buffer → buffer fills → resume.
+        // isPaused must survive buffer start/end and clear on resume.
+        state.goRequest();
+        state.goStart();
+        state.goBufferStart();  // network stalls while playing
+        state.goPause();        // user pauses during buffer
+
+        assertTrue(state.isPaused);
+        assertFalse(state.isPlaying);
+
+        state.goBufferEnd();    // buffer fills while still paused
+
+        assertTrue(state.isPaused);
+        assertFalse(state.isPlaying);
+        assertFalse(state.isBuffering);
+
+        state.goResume();       // user taps play
+
+        assertFalse(state.isPaused);
+        assertTrue(state.isPlaying);
+    }
+
+    @Test
+    public void testFullSeekWhilePausedFlow() {
+        // Full scenario: pause → seek → seek ends → resume.
+        state.goRequest();
+        state.goStart();
+        state.goPause();
+        state.goSeekStart();
+
+        assertTrue(state.isPaused);
+        assertFalse(state.isPlaying);
+
+        state.goSeekEnd();      // seek finishes while paused
+
+        assertTrue(state.isPaused);
+        assertFalse(state.isPlaying);
+        assertFalse(state.isSeeking);
+
+        state.goResume();
+
+        assertFalse(state.isPaused);
+        assertTrue(state.isPlaying);
+    }
 }

--- a/NewRelicVideoCore/src/test/java/com/newrelic/videoagent/core/tracker/NRVideoTrackerQoeTest.java
+++ b/NewRelicVideoCore/src/test/java/com/newrelic/videoagent/core/tracker/NRVideoTrackerQoeTest.java
@@ -1,0 +1,403 @@
+package com.newrelic.videoagent.core.tracker;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.newrelic.videoagent.core.NRDef.*;
+import static org.junit.Assert.*;
+
+/**
+ * Unit tests for the QoE attributes added in qoeAggregateVersion 1.1.0:
+ *   - avgDownloadRate / minDownloadRate / maxDownloadRate
+ *   - totalSwitchUps / totalSwitchDowns / totalTimeSwitchedDown
+ *   - totalPauseTime
+ *   - totalRenditions
+ *
+ * Strategy:
+ *   - A test subclass overrides the player-data getters so getAttributes() populates
+ *     real rendition / download values (the base getters return null).
+ *   - Download-rate and rendition capture are driven through the real getAttributes()
+ *     path. Switch and pause metrics are driven through the real event pipeline
+ *     (sendVideoEvent / sendPause / sendResume) so the NRTracker.processQoeEvents()
+ *     wiring is exercised too.
+ *   - KPI values are read back from the private calculateQOEKpiAttributes() via reflection.
+ *
+ * Time-based assertions use small real sleeps with generous tolerance (the production
+ * code uses System.currentTimeMillis()); this mirrors the existing playtime tests.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class NRVideoTrackerQoeTest {
+
+    /** Lower bound applied to duration assertions to absorb scheduling jitter. */
+    private static final long SLEEP_MS = 60L;
+    private static final long MIN_ELAPSED = 25L;
+
+    private QoeTestTracker tracker;
+
+    @Before
+    public void setUp() {
+        tracker = new QoeTestTracker();
+    }
+
+    @After
+    public void tearDown() {
+        if (tracker != null) {
+            tracker.dispose();
+        }
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    /** Test tracker exposing settable values for the data getters QoE reads. */
+    static class QoeTestTracker extends NRVideoTracker {
+        Long renditionWidth;
+        Long renditionHeight;
+        Long renditionBitrate;
+        Long networkDownloadBitrate;
+
+        @Override public Long getRenditionWidth()        { return renditionWidth; }
+        @Override public Long getRenditionHeight()       { return renditionHeight; }
+        @Override public Long getRenditionBitrate()      { return renditionBitrate; }
+        @Override public Long getNetworkDownloadBitrate(){ return networkDownloadBitrate; }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> kpis() {
+        try {
+            Method m = NRVideoTracker.class.getDeclaredMethod("calculateQOEKpiAttributes");
+            m.setAccessible(true);
+            return (Map<String, Object>) m.invoke(tracker);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static long lng(Map<String, Object> m, String key) {
+        Object v = m.get(key);
+        assertNotNull("KPI '" + key + "' should be present", v);
+        return ((Number) v).longValue();
+    }
+
+    private void startContent() {
+        tracker.setPlayer(new Object());
+        tracker.sendRequest();
+        tracker.sendStart();
+    }
+
+    /** Drive one content event so the getAttributes() capture hooks run. */
+    private void emitContentEvent() {
+        tracker.getAttributes(CONTENT_HEARTBEAT, null);
+    }
+
+    private void sendShift(String shift) {
+        Map<String, Object> attrs = new HashMap<>();
+        if (shift != null) {
+            attrs.put("shift", shift);
+        }
+        tracker.sendVideoEvent(CONTENT_RENDITION_CHANGE, attrs);
+    }
+
+    /**
+     * Drive a CONTENT_RENDITION_CHANGE carrying a rendition bitrate. The bitrate is what
+     * totalTimeSwitchedDown is anchored on (session-max); requires the tracker to be started
+     * so getAttributes() populates contentRenditionBitrate.
+     */
+    private void renditionChange(String shift, long bitrate) {
+        tracker.renditionBitrate = bitrate;
+        Map<String, Object> attrs = new HashMap<>();
+        if (shift != null) {
+            attrs.put("shift", shift);
+        }
+        tracker.sendVideoEvent(CONTENT_RENDITION_CHANGE, attrs);
+    }
+
+    private static void sleep(long ms) {
+        try { Thread.sleep(ms); } catch (InterruptedException ignored) { }
+    }
+
+    // =========================================================================
+    // Defaults — counters/time present at zero, download omitted with no sample
+    // =========================================================================
+
+    @Test
+    public void defaults_countersZero_downloadOmitted() {
+        Map<String, Object> k = kpis();
+
+        assertEquals(0L, lng(k, "totalSwitchUps"));
+        assertEquals(0L, lng(k, "totalSwitchDowns"));
+        assertEquals(0L, lng(k, "totalTimeSwitchedDown"));
+        assertEquals(0L, lng(k, "totalPauseTime"));
+        assertEquals(0L, lng(k, "totalRenditions"));
+
+        assertFalse("avgDownloadRate omitted with no sample", k.containsKey("avgDownloadRate"));
+        assertFalse("minDownloadRate omitted with no sample", k.containsKey("minDownloadRate"));
+        assertFalse("maxDownloadRate omitted with no sample", k.containsKey("maxDownloadRate"));
+    }
+
+    // =========================================================================
+    // Download rate: avg / min / max
+    // =========================================================================
+
+    @Test
+    public void downloadRate_avgMinMax() {
+        startContent();
+
+        tracker.networkDownloadBitrate = 1000L; emitContentEvent();
+        tracker.networkDownloadBitrate = 3000L; emitContentEvent();
+        tracker.networkDownloadBitrate = 2000L; emitContentEvent();
+
+        Map<String, Object> k = kpis();
+        assertEquals("avg = (1000+3000+2000)/3", 2000L, lng(k, "avgDownloadRate"));
+        assertEquals(1000L, lng(k, "minDownloadRate"));
+        assertEquals(3000L, lng(k, "maxDownloadRate"));
+    }
+
+    @Test
+    public void downloadRate_avgRoundsHalfUp() {
+        startContent();
+
+        tracker.networkDownloadBitrate = 1000L; emitContentEvent();
+        tracker.networkDownloadBitrate = 1001L; emitContentEvent();
+
+        // 2001 / 2 = 1000.5 -> Math.round -> 1001
+        assertEquals(1001L, lng(kpis(), "avgDownloadRate"));
+    }
+
+    @Test
+    public void downloadRate_ignoresNonPositiveSamples() {
+        startContent();
+
+        tracker.networkDownloadBitrate = 0L;    emitContentEvent();   // skipped (<= 0)
+        tracker.networkDownloadBitrate = -5L;   emitContentEvent();   // skipped (<= 0)
+        tracker.networkDownloadBitrate = 4000L; emitContentEvent();   // counted
+
+        Map<String, Object> k = kpis();
+        assertEquals("only the positive sample counts", 4000L, lng(k, "avgDownloadRate"));
+        assertEquals(4000L, lng(k, "minDownloadRate"));
+        assertEquals(4000L, lng(k, "maxDownloadRate"));
+    }
+
+    @Test
+    public void downloadRate_omittedWhenStartedButNoSample() {
+        startContent();
+        // networkDownloadBitrate stays null -> no samples
+        emitContentEvent();
+
+        Map<String, Object> k = kpis();
+        assertFalse(k.containsKey("avgDownloadRate"));
+        assertFalse(k.containsKey("minDownloadRate"));
+        assertFalse(k.containsKey("maxDownloadRate"));
+    }
+
+    // =========================================================================
+    // Rendition switch up / down counts
+    // =========================================================================
+
+    @Test
+    public void switches_countUpsAndDowns() {
+        sendShift("down");
+        sendShift("down");
+        sendShift("up");
+        sendShift("up");
+
+        Map<String, Object> k = kpis();
+        assertEquals(2L, lng(k, "totalSwitchUps"));
+        assertEquals(2L, lng(k, "totalSwitchDowns"));
+    }
+
+    @Test
+    public void switches_missingOrUnknownShiftIgnored() {
+        sendShift(null);          // no "shift" attribute
+        sendShift("sideways");    // unrecognised value
+
+        Map<String, Object> k = kpis();
+        assertEquals(0L, lng(k, "totalSwitchUps"));
+        assertEquals(0L, lng(k, "totalSwitchDowns"));
+        assertEquals(0L, lng(k, "totalTimeSwitchedDown"));
+    }
+
+    // =========================================================================
+    // totalTimeSwitchedDown
+    // =========================================================================
+
+    @Test
+    public void timeSwitchedDown_banksWhenRecoveringToPeak() {
+        startContent();
+
+        renditionChange("down", 5_000_000L);   // establishes session peak = 5M, no interval
+        renditionChange("down", 3_000_000L);   // below peak -> open interval
+        sleep(SLEEP_MS);
+        renditionChange("up",   5_000_000L);   // back to peak -> close, bank elapsed
+
+        long t = lng(kpis(), "totalTimeSwitchedDown");
+        assertTrue("below-peak time banked (was " + t + ")", t >= MIN_ELAPSED);
+    }
+
+    @Test
+    public void timeSwitchedDown_partialRecoveryStaysBelowPeak() {
+        // The defining session-max behavior: an upswitch that is still below the session
+        // peak must NOT close the interval (unlike the previous-rendition semantic).
+        startContent();
+
+        renditionChange("down", 5_000_000L);   // peak = 5M
+        renditionChange("down", 2_000_000L);   // open interval
+        sleep(SLEEP_MS);
+        renditionChange("up",   3_000_000L);   // 3M < 5M -> still below peak, interval stays OPEN
+
+        long v1 = lng(kpis(), "totalTimeSwitchedDown");
+        sleep(SLEEP_MS);
+        long v2 = lng(kpis(), "totalTimeSwitchedDown");
+        assertTrue("still counting below the session peak (" + v1 + " -> " + v2 + ")", v2 > v1);
+    }
+
+    @Test
+    public void timeSwitchedDown_consecutiveDownsKeepOneInterval() {
+        startContent();
+
+        renditionChange("down", 5_000_000L);   // peak = 5M
+        renditionChange("down", 3_000_000L);   // open interval
+        sleep(SLEEP_MS);
+        renditionChange("down", 2_000_000L);   // still below peak — interval start must NOT reset
+        sleep(SLEEP_MS);
+        renditionChange("up",   5_000_000L);   // recover to peak -> close
+
+        long t = lng(kpis(), "totalTimeSwitchedDown");
+        // One continuous interval spanning both sleeps.
+        assertTrue("continuous interval (was " + t + ")", t >= (2 * MIN_ELAPSED));
+    }
+
+    @Test
+    public void timeSwitchedDown_openIntervalSnapshotIsNonMutating() {
+        startContent();
+
+        renditionChange("down", 5_000_000L);   // peak = 5M
+        renditionChange("down", 3_000_000L);   // open, never recovered
+        sleep(SLEEP_MS);
+
+        long first = lng(kpis(), "totalTimeSwitchedDown");
+        assertTrue("open interval reflected at emit (was " + first + ")", first >= MIN_ELAPSED);
+
+        sleep(SLEEP_MS);
+        long second = lng(kpis(), "totalTimeSwitchedDown");
+        // Non-mutating snapshot: the interval is still open, so it keeps growing.
+        assertTrue("snapshot keeps growing (" + first + " -> " + second + ")", second > first);
+    }
+
+    // =========================================================================
+    // totalPauseTime
+    // =========================================================================
+
+    @Test
+    public void pauseTime_banksOnResume() {
+        startContent();
+
+        tracker.sendPause();
+        sleep(SLEEP_MS);
+        tracker.sendResume();
+
+        long t = lng(kpis(), "totalPauseTime");
+        assertTrue("pause time banked (was " + t + ")", t >= MIN_ELAPSED);
+    }
+
+    @Test
+    public void pauseTime_accumulatesAcrossMultiplePauses() {
+        startContent();
+
+        tracker.sendPause(); sleep(SLEEP_MS); tracker.sendResume();
+        long afterFirst = lng(kpis(), "totalPauseTime");
+
+        tracker.sendPause(); sleep(SLEEP_MS); tracker.sendResume();
+        long afterSecond = lng(kpis(), "totalPauseTime");
+
+        assertTrue(afterFirst >= MIN_ELAPSED);
+        assertTrue("second pause adds on top (" + afterFirst + " -> " + afterSecond + ")",
+                afterSecond >= afterFirst + MIN_ELAPSED);
+    }
+
+    @Test
+    public void pauseTime_openPauseSnapshotIsNonMutating() {
+        startContent();
+
+        tracker.sendPause();        // open pause, never resumed
+        sleep(SLEEP_MS);
+
+        long first = lng(kpis(), "totalPauseTime");
+        assertTrue("open pause reflected at emit (was " + first + ")", first >= MIN_ELAPSED);
+
+        sleep(SLEEP_MS);
+        long second = lng(kpis(), "totalPauseTime");
+        assertTrue("open pause keeps growing (" + first + " -> " + second + ")", second > first);
+    }
+
+    // =========================================================================
+    // totalRenditions (distinct width*height)
+    // =========================================================================
+
+    @Test
+    public void renditions_countsDistinctResolutions() {
+        startContent();
+
+        tracker.renditionWidth = 1920L; tracker.renditionHeight = 1080L; emitContentEvent();
+        tracker.renditionWidth = 1280L; tracker.renditionHeight = 720L;  emitContentEvent();
+        tracker.renditionWidth = 1920L; tracker.renditionHeight = 1080L; emitContentEvent(); // duplicate
+
+        assertEquals("two distinct resolutions", 2L, lng(kpis(), "totalRenditions"));
+    }
+
+    @Test
+    public void renditions_ignoresNullOrZeroDimensions() {
+        startContent();
+
+        tracker.renditionWidth = null;  tracker.renditionHeight = 1080L; emitContentEvent(); // skipped
+        tracker.renditionWidth = 1280L; tracker.renditionHeight = 0L;    emitContentEvent(); // skipped
+        tracker.renditionWidth = 1280L; tracker.renditionHeight = 720L;  emitContentEvent(); // counted
+
+        assertEquals(1L, lng(kpis(), "totalRenditions"));
+    }
+
+    // =========================================================================
+    // Reset per view (sendEnd -> resetQoeMetrics)
+    // =========================================================================
+
+    @Test
+    public void reset_clearsAllQoeStateOnNewView() {
+        startContent();
+
+        // Accumulate every metric.
+        tracker.networkDownloadBitrate = 5000L; emitContentEvent();
+        tracker.renditionWidth = 1920L; tracker.renditionHeight = 1080L; emitContentEvent();
+        renditionChange("up",   6_000_000L);   // peak = 6M, switchUps=1
+        renditionChange("down", 4_000_000L);   // below peak -> open interval, switchDowns=1
+        tracker.sendPause(); sleep(SLEEP_MS); tracker.sendResume();
+        sleep(SLEEP_MS);
+
+        // Sanity: state accumulated (incl. an OPEN switched-down interval).
+        Map<String, Object> before = kpis();
+        assertEquals(1L, lng(before, "totalSwitchUps"));
+        assertEquals(1L, lng(before, "totalSwitchDowns"));
+        assertTrue(lng(before, "totalTimeSwitchedDown") > 0);
+        assertTrue(lng(before, "totalPauseTime") > 0);
+        assertTrue(lng(before, "totalRenditions") >= 1);
+        assertTrue(before.containsKey("avgDownloadRate"));
+
+        // End the view -> resetQoeMetrics().
+        tracker.sendEnd();
+
+        Map<String, Object> after = kpis();
+        assertEquals(0L, lng(after, "totalSwitchUps"));
+        assertEquals(0L, lng(after, "totalSwitchDowns"));
+        assertEquals(0L, lng(after, "totalTimeSwitchedDown"));
+        assertEquals(0L, lng(after, "totalPauseTime"));
+        assertEquals(0L, lng(after, "totalRenditions"));
+        assertFalse("download rate cleared", after.containsKey("avgDownloadRate"));
+    }
+}

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The New Relic Video Agent for Android provides comprehensive video analytics for
 ## Features
 
 - **Automatic Event Detection** — Captures ExoPlayer lifecycle events automatically without manual instrumentation
-- **QoE Metrics** — Quality of Experience aggregation for startup time, buffering ratio, bitrate, and playback errors
+- **QoE Metrics** — Quality of Experience aggregation for startup time, buffering ratio, bitrate, download throughput, rendition switches, pause time, and playback errors
 - **Event Segregation** — Organized event types: `VideoAction`, `VideoAdAction`, `VideoErrorAction`, `VideoCustomAction`
 - **IMA Ads Support** — Built-in Google IMA SDK ad tracking via dedicated ad tracker
 - **Android TV Support** — Auto-detection of Android TV with optimized harvest cycles


### PR DESCRIPTION
<h2 style="color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Summary</h2><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Extends the QoE aggregate (sent with <code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">CONTENT_END</code>) with eight new attributes covering network throughput, rendition stability, and pause behavior. Bumps <code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">qoeAggregateVersion</code> to <code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">1.1.0</code>. Also fixes a Media3 <code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">(0,0)</code> video-size glitch that was corrupting switch up/down counts.</p><h2 style="color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">New attributes</h2>
Attribute | Type | Meaning
-- | -- | --
avgDownloadRate / minDownloadRate / maxDownloadRate | Long | Network download throughput samples (bps); omitted when no sample observed
totalSwitchUps / totalSwitchDowns | Long | Upward / downward rendition changes
totalTimeSwitchedDown | Long | Cumulative ms spent below the session-peak rendition bitrate (includes any open interval at emit)
totalPauseTime | Long | Total content pause duration in ms (includes any open pause at emit)
totalRenditions | Long | Distinct renditions played (keyed by width × height)

<h2 style="color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Changes</h2><ul style="padding-inline-start: 2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li><strong>NRVideoTracker</strong><span> </span>— accumulators + reset logic for the new metrics; download-rate sampled per processed event, distinct renditions tracked by<span> </span><code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">w*h</code>, time-below-peak and pause time tracked as open/closed intervals (open intervals snapshotted, not closed, at emit). Overflow-safe via<span> </span><code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">safeAdd</code>.</li><li><strong>NRTracker</strong><span> </span>— routes<span> </span><code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">CONTENT_RENDITION_CHANGE</code><span> </span>→<span> </span><code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">processQoeRenditionChange</code><span> </span>and<span> </span><code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">CONTENT_PAUSE</code>/<code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">CONTENT_RESUME</code><span> </span>→<span> </span><code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">processQoePauseTime</code>.</li><li><strong>NRTrackerExoPlayer</strong><span> </span>— ignore<span> </span><code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">onVideoSizeChanged(0,0)</code>; Media3 fires it when the renderer clears output between transitions, which otherwise emitted a false DOWN and then silenced the real shift.</li><li><strong>Tests</strong><span> </span>—<span> </span><code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">NRVideoTrackerQoeTest</code><span> </span>(403 lines) covering the new metrics;<span> </span><code style="font-family: var(--app-monospace-font-family); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">DATAMODEL.md</code><span> </span>updated.</li></ul><h2 style="color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Notes</h2><ul style="padding-inline-start: 2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li>Download-rate KPIs are omitted entirely when no sample is available (vs. emitting 0).</li></ul>