### PR TITLE
feat: enable QoE by default with interval multiplier 2

### DIFF
--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/NRVideoConfiguration.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/NRVideoConfiguration.java
@@ -53,7 +53,7 @@ public final class NRVideoConfiguration {
     private final List<ObfuscationRule> obfuscationRules;
 
     // Runtime configuration fields (mutable, thread-safe) - Using AtomicBoolean for better performance
-    private final AtomicBoolean qoeAggregateEnabled = new AtomicBoolean(false);
+    private final AtomicBoolean qoeAggregateEnabled = new AtomicBoolean(true);
     private final AtomicBoolean runtimeConfigInitialized = new AtomicBoolean(false);
 
 
@@ -246,8 +246,8 @@ public final class NRVideoConfiguration {
         private boolean debugLoggingEnabled = false;
         private boolean isTV = false;
         private String collectorAddress = null;
-        private boolean qoeAggregateEnabled = false; // Default disabled
-        private int qoeAggregateIntervalMultiplier = 1; // Default 1 (send every harvest cycle)
+        private boolean qoeAggregateEnabled = true; // Default enabled
+        private int qoeAggregateIntervalMultiplier = 2; // Default 2 (send every other harvest cycle)
         // React analogy: this starts as an empty array [] — no rules by default.
         private List<ObfuscationRule> obfuscationRules = new ArrayList<>();
 

--- a/README.md
+++ b/README.md
@@ -297,7 +297,8 @@ if (shouldEnable) {
 | `.autoDetectPlatform(context)` | `Context` | Mobile | Auto-detect Mobile vs. Android TV platform. |
 | `.withHarvestCycle(seconds)` | `int` | 300 (Mobile) / 180 (TV) | Interval in seconds between data harvests. For on-demand video, use a minimum of 300 seconds. |
 | `.enableLogging()` | — | Disabled | Enable debug logging for development. |
-| `.enableQoeAggregate(enabled)` | `boolean` | `false` | Enable Quality of Experience event aggregation (`QOE_AGGREGATE` events). |
+| `.enableQoeAggregate(enabled)` | `boolean` | `true` | Enable or disable Quality of Experience event aggregation (`QOE_AGGREGATE` events). QoE is **enabled by default** — call `.enableQoeAggregate(false)` to opt out. |
+| `.withQoeAggregateIntervalMultiplier(multiplier)` | `int` | `2` | Controls how often `QOE_AGGREGATE` events are emitted relative to the harvest cycle. `1` = every harvest cycle, `2` = every other cycle, `3` = every third, etc. The first and last harvest cycles always emit a `QOE_AGGREGATE` event regardless of this value. Call `.withQoeAggregateIntervalMultiplier(n)` to change the frequency. |
 | `.withMemoryOptimization()` | — | Disabled | Optimize for low-memory devices. |
 
 ### NRVideoPlayerConfiguration
@@ -400,7 +401,7 @@ NRVideoConfiguration config = new NRVideoConfiguration.Builder("YOUR_APPLICATION
         .autoDetectPlatform(getApplicationContext())
         .withHarvestCycle(5 * 60)
         .enableLogging()           // Enable for development
-        .enableQoeAggregate(true)  // Enable QoE metrics
+        // QoE is enabled by default; call .enableQoeAggregate(false) to disable
         .build();
 
 NRVideo.newBuilder(getApplicationContext())


### PR DESCRIPTION
Enables QoE tracking by default and sets the interval multiplier default to 2. Part of NR-573376.