### PR TITLE
feat: nr ad config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,35 @@
 
 ### Features
 
-* **NRMediaTailorTracker** — new optional AAR module for AWS Elemental MediaTailor SSAI.
+* **NRAdConfig** — unified ad configuration object, the single place for all ad options per player session.
+  * `NRAdConfig.csai()` — Google IMA / any CSAI framework.
+  * `NRAdConfig.mediaTailor()` — AWS MediaTailor SSAI with default AWS domain detection.
+  * `NRAdConfig.mediaTailor(segmentPrefix)` — custom CDN with a non-`/tm/` ad-segment path.
+  * `NRAdConfig.mediaTailor(segmentPrefix, trackingUrl)` — custom CDN + explicit tracking URL (POST session-init flow).
+  * Pass `null` as the `adConfig` argument to `NRVideoPlayerConfiguration` to disable ad tracking.
+
+* **Backward compatibility** — existing integrations built against v4.2.0 compile without changes:
+  * `new NRVideoPlayerConfiguration(name, player, true, attrs)` → `NRAdConfig.csai()`
+  * `new NRVideoPlayerConfiguration(name, player, false, attrs)` → no ad tracking
+  * `AdTrackerType.IMA` → `NRAdConfig.csai()`
+  * `AdTrackerType.MEDIA_TAILOR` → `NRAdConfig.mediaTailor()`
+  * `AdTrackerType.NONE` → no ad tracking
+  * `isAdEnabled()` and `getAdTrackerType()` kept as deprecated methods.
+  All deprecated; migrate to `NRAdConfig` factory methods at your own pace.
+
+* **Custom CDN support for MediaTailor** — ad segments served from customer-owned CDN domains are now detected automatically:
+  * `/tm/` (AWS-recommended CDN prefix) is checked for all customers without any configuration.
+  * `segmentPrefix` in `NRAdConfig` overrides this for CDN paths that differ from `/tm/`.
+  * When `NRAdConfig.mediaTailor()` is passed, the tracker activates unconditionally — no `mediatailor` substring required in the manifest URL, enabling fully custom CDN manifest domains.
+
+* **NRMediaTailorTracker** — AWS Elemental MediaTailor SSAI tracker module.
   * Supports **DASH** (multi-period BaseURL detection + single-period SCTE‑35 EventStream) and **HLS** (segment URL + discontinuity-driven pod splitting).
   * Implicit and explicit session-init flows (POST `/v1/session/…`); recovers `sessionId` from DASH `<Location>` when the client-side URI doesn't carry it.
   * VOD and Live — tracking API polled once for VOD, on every manifest refresh for Live.
   * Rich VAST metadata on `VideoAdAction` events emitted by `NRTrackerMediaTailor` (identified by `trackerName = "NRMTracker"`): `adSystem`, `vastAdId`, `creativeSequence`, `skipOffset`, `adProgramDateTime`, `availProgramDateTime`, `isBumper`, `nonLinearAvailsCount`. These attributes are **not** populated by `NRTrackerIMA`.
+  * Structured log tags — `[MT][CONFIG]`, `[MT][DETECT]`, `[MT][HLS]`, `[MT][DASH]`, `[MT][TRACK]`, `[MT][EVENT]` — for targeted filtering in Logcat.
   * `notifyAdSkipped()` API for skippable-ad UX integrations.
-* **NRVideoPlayerConfiguration.AdTrackerType** — `NONE` / `IMA` / `MEDIA_TAILOR` replaces the boolean `isAdEnabled` (legacy ctor preserved). `NRVideo.addPlayer` switches the ad-tracker slot accordingly.
+
 * **NRTrackerExoPlayer** — new `isLinkedAdBreakActive()` gate suppresses stray `CONTENT_PAUSE` / `CONTENT_RESUME` / `CONTENT_BUFFER_*` / `CONTENT_START` / `CONTENT_RENDITION_CHANGE` / `CONTENT_SEEK_START` events during SSAI ad breaks, and routes error callbacks (`onPlayerError`, `onLoadError`) to the ad tracker as `AD_ERROR` when one is active.
 
 ## [4.1.1](https://github.com/newrelic/video-agent-android/compare/v4.1.0...v4.1.1) (2026-04-22)

--- a/NRMediaTailorTracker/src/main/java/com/newrelic/videoagent/mediatailor/MTConstants.java
+++ b/NRMediaTailorTracker/src/main/java/com/newrelic/videoagent/mediatailor/MTConstants.java
@@ -32,11 +32,20 @@ public final class MTConstants {
     private MTConstants() {}
 
     public static final String MT_URL_MARKER = "mediatailor";
-    public static final String MT_SEGMENT_PATTERN = "segments.mediatailor";
-    // Alternative MediaTailor ad-period markers — used when responses are served
-    // through MediaTailor's own/CDN rewrite host (see user guide p.183 for DASH).
+
+    // ── Ad-segment detection markers ───────────────────────────────────────
+    // Checked in this order for every segment URL / DASH base URL:
+    //   1. MT_SEGMENT_PATTERN       — default AWS ad-segment hostname
+    //   2. MT_HLSSEGMENT_PATH_PATTERN / MT_DASHSEGMENT_PATH_PATTERN
+    //                               — MediaTailor CDN rewrite paths
+    //   3. MT_DEFAULT_AD_SEGMENT_PATH — AWS-recommended custom CDN prefix,
+    //                                   always checked for all customers
+    //   4. customer segmentPrefix   — override for non-/tm/ CDN paths (optional)
+    public static final String MT_SEGMENT_PATTERN          = "segments.mediatailor";
     public static final String MT_DASHSEGMENT_PATH_PATTERN = "/v1/dashsegment/";
-    public static final String MT_HLSSEGMENT_PATH_PATTERN = "/v1/hlssegment/";
+    public static final String MT_HLSSEGMENT_PATH_PATTERN  = "/v1/hlssegment/";
+    /** AWS-recommended CDN ad-segment path prefix (parity with VideoJS PR #106). */
+    public static final String MT_DEFAULT_AD_SEGMENT_PATH  = "/tm/";
 
     public static final String SCTE35_SCHEME_MARKER = "scte35";
 
@@ -64,4 +73,15 @@ public final class MTConstants {
     public static final double QUARTILE_Q1 = 0.25;
     public static final double QUARTILE_Q2 = 0.50;
     public static final double QUARTILE_Q3 = 0.75;
+
+    // ── Log tag prefixes ───────────────────────────────────────────────────
+    // All MediaTailor log lines start with [MT] followed by a subsystem tag.
+    // Grep for "[MT]" to see everything, or narrow with e.g. "[MT][DETECT]".
+    public static final String LOG_TAG         = "[MT]";
+    public static final String LOG_CONFIG      = "[MT][CONFIG]";
+    public static final String LOG_DETECT      = "[MT][DETECT]";
+    public static final String LOG_PARSE_HLS   = "[MT][HLS]";
+    public static final String LOG_PARSE_DASH  = "[MT][DASH]";
+    public static final String LOG_TRACK       = "[MT][TRACK]";
+    public static final String LOG_EVENT       = "[MT][EVENT]";
 }

--- a/NRMediaTailorTracker/src/main/java/com/newrelic/videoagent/mediatailor/detection/MTDashParser.java
+++ b/NRMediaTailorTracker/src/main/java/com/newrelic/videoagent/mediatailor/detection/MTDashParser.java
@@ -1,5 +1,6 @@
 package com.newrelic.videoagent.mediatailor.detection;
 
+import androidx.annotation.Nullable;
 import androidx.annotation.OptIn;
 import androidx.media3.common.util.UnstableApi;
 import androidx.media3.exoplayer.dash.manifest.AdaptationSet;
@@ -10,6 +11,7 @@ import androidx.media3.exoplayer.dash.manifest.Period;
 import androidx.media3.exoplayer.dash.manifest.Representation;
 import androidx.media3.extractor.metadata.emsg.EventMessage;
 
+import com.newrelic.videoagent.core.utils.NRLog;
 import com.newrelic.videoagent.mediatailor.MTConstants;
 import com.newrelic.videoagent.mediatailor.model.MTAdBreak;
 
@@ -22,46 +24,81 @@ import java.util.List;
  * <p>Two shapes are recognised:</p>
  * <ul>
  *   <li><b>Multi-period:</b> a period whose representations point at a base URL
- *       containing {@code segments.mediatailor} is treated as an ad period.
- *       Media3 1.2 exposes {@code BaseUrl}s on {@link Representation}, not on
- *       {@link Period} directly — we walk down.</li>
+ *       that matches any of the four detection candidates is treated as an ad
+ *       period. Media3 1.2+ exposes {@link BaseUrl}s on {@link Representation},
+ *       not on {@link Period} directly — we walk down through adaptation sets.</li>
  *   <li><b>Single-period:</b> SCTE-35 {@link EventStream}s inside the period.</li>
  * </ul>
+ *
+ * <p>Detection candidates (checked in order for every base URL):</p>
+ * <ol>
+ *   <li>{@code segments.mediatailor} — default AWS ad-segment hostname.</li>
+ *   <li>{@code /v1/dashsegment/} — MediaTailor CDN rewrite path.</li>
+ *   <li>{@code /tm/} — AWS-recommended custom CDN prefix; always active.</li>
+ *   <li>{@code segmentPrefix} — customer override; only checked when non-null.</li>
+ * </ol>
  */
 @OptIn(markerClass = UnstableApi.class)
 public final class MTDashParser {
 
     private MTDashParser() {}
 
-    public static List<MTAdBreak> parse(DashManifest manifest) {
+    /**
+     * Parse the DASH manifest into ad breaks.
+     *
+     * @param manifest      Manifest from {@code ExoPlayer.getCurrentManifest()}.
+     * @param segmentPrefix Optional customer CDN prefix override. Pass {@code null}
+     *                      to rely on default detection ({@code segments.mediatailor},
+     *                      {@code /v1/dashsegment/}, and {@code /tm/}).
+     */
+    public static List<MTAdBreak> parse(DashManifest manifest, @Nullable String segmentPrefix) {
         List<MTAdBreak> breaks = new ArrayList<>();
         if (manifest == null) return breaks;
 
         int periodCount = manifest.getPeriodCount();
         if (periodCount <= 0) return breaks;
 
+        logDetectionMode(segmentPrefix);
+
+        // ── Parse ──────────────────────────────────────────────────────────
+        NRLog.d(MTConstants.LOG_PARSE_DASH + " parsing " + periodCount + " period(s), type="
+                + (periodCount > 1 ? "multi-period" : "single-period"));
+
         if (periodCount > 1) {
-            parseMultiPeriod(manifest, breaks);
+            parseMultiPeriod(manifest, segmentPrefix, breaks);
         } else {
             parseSinglePeriod(manifest.getPeriod(0), breaks);
         }
+
+        logResult(breaks);
         return breaks;
     }
 
-    private static void parseMultiPeriod(DashManifest manifest, List<MTAdBreak> out) {
+    // ── Multi-period ───────────────────────────────────────────────────────
+
+    private static void parseMultiPeriod(DashManifest manifest,
+                                          @Nullable String segmentPrefix,
+                                          List<MTAdBreak> out) {
         int count = manifest.getPeriodCount();
         for (int i = 0; i < count; i++) {
             Period period = manifest.getPeriod(i);
-            if (!isMediaTailorAdPeriod(period)) continue;
+            String adMarker = whichMarkerMatchedPeriod(period, segmentPrefix);
+            if (adMarker == null) continue;
 
-            long startMs = period.startMs;
+            long startMs    = period.startMs;
             long durationMs = manifest.getPeriodDurationMs(i);
             if (durationMs < MTConstants.MIN_AD_DURATION_MS) continue;
 
             String id = period.id != null ? period.id : ("mt-period-" + startMs);
+            NRLog.d(MTConstants.LOG_PARSE_DASH + "   ad period id=" + id
+                    + " startMs=" + startMs
+                    + " durationMs=" + durationMs
+                    + " via=" + adMarker);
             out.add(new MTAdBreak(id, startMs, durationMs));
         }
     }
+
+    // ── Single-period (SCTE-35) ────────────────────────────────────────────
 
     private static void parseSinglePeriod(Period period, List<MTAdBreak> out) {
         if (period == null || period.eventStreams == null) return;
@@ -70,37 +107,86 @@ public final class MTDashParser {
             String scheme = stream.schemeIdUri != null ? stream.schemeIdUri : "";
             if (!scheme.toLowerCase().contains(MTConstants.SCTE35_SCHEME_MARKER)) continue;
 
-            long[] times = stream.presentationTimesUs;
+            long[]         times  = stream.presentationTimesUs;
             EventMessage[] events = stream.events;
             if (times == null || events == null) continue;
             int n = Math.min(times.length, events.length);
 
             for (int i = 0; i < n; i++) {
-                long startMs = times[i] / 1000L;
+                long startMs    = times[i] / 1000L;
                 long durationMs = events[i] != null ? events[i].durationMs : 0L;
                 if (durationMs < MTConstants.MIN_AD_DURATION_MS) continue;
 
                 String id = events[i] != null && events[i].id != 0
                         ? "scte35-" + events[i].id
                         : "scte35-" + startMs;
+                NRLog.d(MTConstants.LOG_PARSE_DASH + "   SCTE-35 cue id=" + id
+                        + " startMs=" + startMs + " durationMs=" + durationMs);
                 out.add(new MTAdBreak(id, startMs, durationMs));
             }
         }
     }
 
-    private static boolean isMediaTailorAdPeriod(Period period) {
-        if (period == null || period.adaptationSets == null) return false;
+    // ── Detection helpers ──────────────────────────────────────────────────
+
+    /**
+     * Returns the detection marker label that identified this period as an ad
+     * period, or {@code null} if the period is content.
+     */
+    @Nullable
+    private static String whichMarkerMatchedPeriod(Period period,
+                                                    @Nullable String segmentPrefix) {
+        if (period == null || period.adaptationSets == null) return null;
         for (AdaptationSet set : period.adaptationSets) {
             if (set == null || set.representations == null) continue;
             for (Representation rep : set.representations) {
                 if (rep == null || rep.baseUrls == null) continue;
                 for (BaseUrl b : rep.baseUrls) {
                     if (b == null || b.url == null) continue;
-                    if (b.url.contains(MTConstants.MT_SEGMENT_PATTERN)) return true;
-                    if (b.url.contains(MTConstants.MT_DASHSEGMENT_PATH_PATTERN)) return true;
+                    String marker = whichMarkerMatched(b.url, segmentPrefix);
+                    if (marker != null) return marker;
                 }
             }
         }
-        return false;
+        return null;
+    }
+
+    /**
+     * Returns the name of the first detection marker that matched the URL,
+     * or {@code null} if no marker matched.
+     */
+    @Nullable
+    static String whichMarkerMatched(@Nullable String url, @Nullable String segmentPrefix) {
+        if (url == null) return null;
+        if (url.contains(MTConstants.MT_SEGMENT_PATTERN))          return "aws-hostname";
+        if (url.contains(MTConstants.MT_DASHSEGMENT_PATH_PATTERN)) return "dashsegment-path";
+        if (url.contains(MTConstants.MT_DEFAULT_AD_SEGMENT_PATH))  return "/tm/";
+        if (segmentPrefix != null && url.contains(segmentPrefix))  return "custom:'" + segmentPrefix + "'";
+        return null;
+    }
+
+    // ── Logging ────────────────────────────────────────────────────────────
+
+    private static void logDetectionMode(@Nullable String segmentPrefix) {
+        if (segmentPrefix != null) {
+            NRLog.d(MTConstants.LOG_PARSE_DASH + " detection: aws-hostname | /tm/ | custom='"
+                    + segmentPrefix + "'");
+        } else {
+            NRLog.d(MTConstants.LOG_PARSE_DASH + " detection: aws-hostname | /tm/ (no custom prefix)");
+        }
+    }
+
+    private static void logResult(List<MTAdBreak> breaks) {
+        if (breaks.isEmpty()) {
+            NRLog.d(MTConstants.LOG_PARSE_DASH + " no ad breaks detected");
+            return;
+        }
+        NRLog.d(MTConstants.LOG_PARSE_DASH + " " + breaks.size() + " ad break(s) detected:");
+        for (int i = 0; i < breaks.size(); i++) {
+            MTAdBreak b = breaks.get(i);
+            NRLog.d(MTConstants.LOG_PARSE_DASH + "   break[" + i + "] id=" + b.id
+                    + " start=" + b.startTimeMs + "ms"
+                    + " duration=" + b.durationMs + "ms");
+        }
     }
 }

--- a/NRMediaTailorTracker/src/main/java/com/newrelic/videoagent/mediatailor/detection/MTHlsParser.java
+++ b/NRMediaTailorTracker/src/main/java/com/newrelic/videoagent/mediatailor/detection/MTHlsParser.java
@@ -1,10 +1,12 @@
 package com.newrelic.videoagent.mediatailor.detection;
 
+import androidx.annotation.Nullable;
 import androidx.annotation.OptIn;
 import androidx.media3.common.util.UnstableApi;
 import androidx.media3.exoplayer.hls.HlsManifest;
 import androidx.media3.exoplayer.hls.playlist.HlsMediaPlaylist;
 
+import com.newrelic.videoagent.core.utils.NRLog;
 import com.newrelic.videoagent.mediatailor.MTConstants;
 import com.newrelic.videoagent.mediatailor.model.MTAdBreak;
 import com.newrelic.videoagent.mediatailor.model.MTAdPod;
@@ -16,10 +18,16 @@ import java.util.List;
  * Turns a Media3 {@link HlsManifest} into a list of {@link MTAdBreak}s.
  *
  * <p>Media3 strips {@code #EXT-X-CUE-OUT} / {@code #EXT-X-CUE-IN} from the
- * typed model, so we detect ad segments by URL pattern:
- * either {@code segments.mediatailor} (hostname) or {@code /v1/hlssegment/}
- * (path, used when responses are served through MediaTailor's own/CDN rewrite host).
- * Pod boundaries inside a break are detected via
+ * typed model, so ad segments are identified by URL pattern. Detection checks
+ * four candidates in order:</p>
+ * <ol>
+ *   <li>{@code segments.mediatailor} — default AWS ad-segment hostname.</li>
+ *   <li>{@code /v1/hlssegment/} — MediaTailor CDN rewrite path.</li>
+ *   <li>{@code /tm/} — AWS-recommended custom CDN prefix; always active.</li>
+ *   <li>{@code segmentPrefix} — customer override; only checked when non-null.</li>
+ * </ol>
+ *
+ * <p>Pod boundaries inside a break are detected via
  * {@link HlsMediaPlaylist.Segment#relativeDiscontinuitySequence} changes.</p>
  */
 @OptIn(markerClass = UnstableApi.class)
@@ -27,51 +35,109 @@ public final class MTHlsParser {
 
     private MTHlsParser() {}
 
-    public static List<MTAdBreak> parse(HlsManifest manifest) {
+    /**
+     * Parse the HLS manifest into ad breaks.
+     *
+     * @param manifest      Manifest from {@code ExoPlayer.getCurrentManifest()}.
+     * @param segmentPrefix Optional customer CDN prefix override. Pass {@code null}
+     *                      to rely on default detection ({@code segments.mediatailor},
+     *                      {@code /v1/hlssegment/}, and {@code /tm/}).
+     */
+    public static List<MTAdBreak> parse(HlsManifest manifest, @Nullable String segmentPrefix) {
         List<MTAdBreak> breaks = new ArrayList<>();
         if (manifest == null || manifest.mediaPlaylist == null) return breaks;
         HlsMediaPlaylist playlist = manifest.mediaPlaylist;
         if (playlist.segments == null || playlist.segments.isEmpty()) return breaks;
 
+        logDetectionMode(segmentPrefix);
+
+        // ── Parse ad breaks ────────────────────────────────────────────────
         MTAdBreak currentBreak = null;
-        MTAdPod currentPod = null;
-        int lastDiscontinuity = Integer.MIN_VALUE;
+        MTAdPod   currentPod   = null;
+        int lastDiscontinuity  = Integer.MIN_VALUE;
+        String firstMatchVia   = null;
 
         for (HlsMediaPlaylist.Segment seg : playlist.segments) {
             if (seg == null) continue;
             long startMs = seg.relativeStartTimeUs / 1000L;
-            long durMs = Math.max(seg.durationUs / 1000L, 0L);
+            long durMs   = Math.max(seg.durationUs / 1000L, 0L);
 
-            if (isMediaTailorSegment(seg)) {
+            String matchedVia = whichMarkerMatched(seg.url, segmentPrefix);
+            if (matchedVia != null) {
                 if (currentBreak == null) {
-                    currentBreak = new MTAdBreak("hls-break-" + startMs, startMs, 0L);
-                    currentPod = new MTAdPod(startMs, 0L);
+                    currentBreak      = new MTAdBreak("hls-break-" + startMs, startMs, 0L);
+                    currentPod        = new MTAdPod(startMs, 0L);
                     lastDiscontinuity = seg.relativeDiscontinuitySequence;
+                    firstMatchVia     = matchedVia;
                 } else if (seg.relativeDiscontinuitySequence != lastDiscontinuity) {
                     closePod(currentBreak, currentPod);
-                    currentPod = new MTAdPod(startMs, 0L);
+                    currentPod        = new MTAdPod(startMs, 0L);
                     lastDiscontinuity = seg.relativeDiscontinuitySequence;
                 }
                 currentBreak.durationMs += durMs;
                 if (currentPod != null) currentPod.durationMs += durMs;
             } else if (currentBreak != null) {
                 closeBreak(breaks, currentBreak, currentPod);
-                currentBreak = null;
-                currentPod = null;
+                currentBreak      = null;
+                currentPod        = null;
                 lastDiscontinuity = Integer.MIN_VALUE;
             }
         }
         if (currentBreak != null) {
             closeBreak(breaks, currentBreak, currentPod);
         }
+
+        logResult(breaks, firstMatchVia);
         return breaks;
     }
 
-    private static boolean isMediaTailorSegment(HlsMediaPlaylist.Segment seg) {
-        if (seg.url == null) return false;
-        return seg.url.contains(MTConstants.MT_SEGMENT_PATTERN)
-                || seg.url.contains(MTConstants.MT_HLSSEGMENT_PATH_PATTERN);
+    // ── Detection ──────────────────────────────────────────────────────────
+
+    /**
+     * Returns the name of the first detection marker that matched the URL,
+     * or {@code null} if the URL is not an ad segment.
+     *
+     * <p>The label is used in log output to show which path triggered detection
+     * (inspired by VideoJS PR #108's {@code whichAdSegmentMarker} helper).</p>
+     */
+    @Nullable
+    static String whichMarkerMatched(@Nullable String url, @Nullable String segmentPrefix) {
+        if (url == null) return null;
+        if (url.contains(MTConstants.MT_SEGMENT_PATTERN))         return "aws-hostname";
+        if (url.contains(MTConstants.MT_HLSSEGMENT_PATH_PATTERN)) return "hlssegment-path";
+        if (url.contains(MTConstants.MT_DEFAULT_AD_SEGMENT_PATH)) return "/tm/";
+        if (segmentPrefix != null && url.contains(segmentPrefix)) return "custom:'" + segmentPrefix + "'";
+        return null;
     }
+
+    // ── Logging ────────────────────────────────────────────────────────────
+
+    private static void logDetectionMode(@Nullable String segmentPrefix) {
+        if (segmentPrefix != null) {
+            NRLog.d(MTConstants.LOG_PARSE_HLS + " detection: aws-hostname | /tm/ | custom='"
+                    + segmentPrefix + "'");
+        } else {
+            NRLog.d(MTConstants.LOG_PARSE_HLS + " detection: aws-hostname | /tm/ (no custom prefix)");
+        }
+    }
+
+    private static void logResult(List<MTAdBreak> breaks, @Nullable String firstMatchVia) {
+        if (breaks.isEmpty()) {
+            NRLog.d(MTConstants.LOG_PARSE_HLS + " no ad breaks detected");
+            return;
+        }
+        NRLog.d(MTConstants.LOG_PARSE_HLS + " " + breaks.size() + " ad break(s) detected"
+                + (firstMatchVia != null ? " — first match via=" + firstMatchVia : "") + ":");
+        for (int i = 0; i < breaks.size(); i++) {
+            MTAdBreak b = breaks.get(i);
+            NRLog.d(MTConstants.LOG_PARSE_HLS + "   break[" + i + "]"
+                    + " start=" + b.startTimeMs + "ms"
+                    + " duration=" + b.durationMs + "ms"
+                    + " pods=" + b.pods.size());
+        }
+    }
+
+    // ── Break / pod builders ───────────────────────────────────────────────
 
     private static void closePod(MTAdBreak br, MTAdPod pod) {
         if (pod == null) return;

--- a/NRMediaTailorTracker/src/main/java/com/newrelic/videoagent/mediatailor/tracker/NRTrackerMediaTailor.java
+++ b/NRMediaTailorTracker/src/main/java/com/newrelic/videoagent/mediatailor/tracker/NRTrackerMediaTailor.java
@@ -18,6 +18,7 @@ import androidx.media3.exoplayer.dash.manifest.DashManifest;
 import androidx.media3.exoplayer.hls.HlsManifest;
 import androidx.media3.extractor.metadata.emsg.EventMessage;
 
+import com.newrelic.videoagent.core.NRAdConfig;
 import com.newrelic.videoagent.core.NRVideoConfiguration;
 import com.newrelic.videoagent.core.tracker.NRVideoTracker;
 import com.newrelic.videoagent.core.utils.NRLog;
@@ -70,8 +71,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * <ul>
  *   <li>{@link #setTrackingUrl(String)} — plug in a tracking URL obtained
  *       from an external session-init flow.</li>
- *   <li>{@link #setClientSideBeacons(boolean)} — enable when the session was
- *       initialised with {@code reportingMode=client}.</li>
  *   <li>{@link #notifyAdSkipped()} — call from the app's "Skip ad" button.</li>
  * </ul>
  */
@@ -79,6 +78,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class NRTrackerMediaTailor extends NRVideoTracker implements Player.Listener {
 
     private ExoPlayer player;
+
+    // Set at construction time from NRAdConfig; null means no custom prefix.
+    private final String segmentPrefix;
+    // True when the customer explicitly passed NRAdConfig.mediaTailor() —
+    // activation is unconditional (no URL substring check required).
+    private final boolean explicitlyConfigured;
 
     private boolean activated;
     private String manifestType;
@@ -101,18 +106,38 @@ public class NRTrackerMediaTailor extends NRVideoTracker implements Player.Liste
 
     private int nonLinearAvailsCount = 0;
 
+    /**
+     * Primary constructor — called by {@link com.newrelic.videoagent.core.NRVideo#addPlayer}
+     * when the customer passes {@link NRAdConfig#mediaTailor()}.
+     *
+     * <p>Reads {@code segmentPrefix} and {@code trackingUrl} from the config so
+     * both are available before the first manifest parse.</p>
+     */
+    public NRTrackerMediaTailor(NRVideoConfiguration configuration, NRAdConfig adConfig) {
+        super(configuration);
+        this.segmentPrefix        = adConfig != null ? adConfig.segmentPrefix : null;
+        this.explicitlyConfigured = adConfig != null;
+        if (adConfig != null && adConfig.trackingUrl != null) {
+            this.trackingUrl = adConfig.trackingUrl;
+        }
+        NRLog.d(MTConstants.LOG_CONFIG + " tracker created — " + adConfig
+                + " explicitActivation=true"
+                + (segmentPrefix != null ? " segmentPrefix='" + segmentPrefix + "'" : " segmentPrefix=none (aws-hostname + /tm/ active)"));
+    }
+
+    /** Fallback constructor used when no {@link NRAdConfig} is available. */
     public NRTrackerMediaTailor(NRVideoConfiguration configuration) {
         super(configuration);
+        this.segmentPrefix        = null;
+        this.explicitlyConfigured = false;
+        NRLog.d(MTConstants.LOG_CONFIG + " tracker created — no NRAdConfig (URL auto-detect mode)");
     }
 
     @Deprecated
     public NRTrackerMediaTailor() {
         super();
-    }
-
-    public NRTrackerMediaTailor(NRVideoConfiguration configuration, ExoPlayer player) {
-        super(configuration);
-        setPlayer(player);
+        this.segmentPrefix        = null;
+        this.explicitlyConfigured = false;
     }
 
     @Override
@@ -173,7 +198,7 @@ public class NRTrackerMediaTailor extends NRVideoTracker implements Player.Liste
      */
     public void notifyAdSkipped() {
         if (isDisposed.get() || currentAdBreak == null) return;
-        NRLog.d("MT AD_SKIP (user skipped)");
+        NRLog.d(MTConstants.LOG_EVENT + " AD_SKIP (user skipped)");
         sendVideoAdEvent("AD_SKIP");
     }
 
@@ -217,15 +242,15 @@ public class NRTrackerMediaTailor extends NRVideoTracker implements Player.Liste
         // During an ad break, translate buffering + seek state into AD_*
         // events rather than letting the content tracker emit CONTENT_*.
         if (playbackState == Player.STATE_BUFFERING) {
-            NRLog.d("MT AD_BUFFER_START (buffering inside ad break)");
+            NRLog.d(MTConstants.LOG_EVENT + " AD_BUFFER_START (inside ad break)");
             sendBufferStart();
         } else if (playbackState == Player.STATE_READY) {
             if (getState().isBuffering) {
-                NRLog.d("MT AD_BUFFER_END (buffering resolved inside ad break)");
+                NRLog.d(MTConstants.LOG_EVENT + " AD_BUFFER_END (inside ad break)");
                 sendBufferEnd();
             }
             if (getState().isSeeking) {
-                NRLog.d("MT AD_SEEK_END (seek resolved inside ad break)");
+                NRLog.d(MTConstants.LOG_EVENT + " AD_SEEK_END (inside ad break)");
                 sendSeekEnd();
             }
         }
@@ -238,7 +263,7 @@ public class NRTrackerMediaTailor extends NRVideoTracker implements Player.Liste
         if (isDisposed.get() || !activated) return;
         if (currentAdBreak == null) return;
         if (reason == Player.DISCONTINUITY_REASON_SEEK && !getState().isSeeking) {
-            NRLog.d("MT AD_SEEK_START (user seek during ad break)");
+            NRLog.d(MTConstants.LOG_EVENT + " AD_SEEK_START (user seek during ad break)");
             sendSeekStart();
         }
     }
@@ -248,11 +273,11 @@ public class NRTrackerMediaTailor extends NRVideoTracker implements Player.Liste
         if (isDisposed.get() || !activated) return;
         if (currentAdBreak == null) return;
         if (!playWhenReady) {
-            NRLog.d("MT AD_PAUSE (user pause during ad break)");
+            NRLog.d(MTConstants.LOG_EVENT + " AD_PAUSE (user pause during ad break)");
             sendPause();
         } else {
             if (getState().isPaused) {
-                NRLog.d("MT AD_RESUME (user resume during ad break)");
+                NRLog.d(MTConstants.LOG_EVENT + " AD_RESUME (user resume during ad break)");
                 sendResume();
             }
         }
@@ -261,35 +286,55 @@ public class NRTrackerMediaTailor extends NRVideoTracker implements Player.Liste
     // ── detection & activation ────────────────────────────────────────────
 
     private void detectSource(Uri uri) {
-        if (!MTDetector.isMediaTailorUri(uri)) {
-            NRLog.d("MT detectSource: not a MediaTailor URI, staying inert. uri="
-                    + (uri != null ? uri : "null"));
+        // When the customer explicitly passed NRAdConfig.mediaTailor(), we trust
+        // their intent and activate unconditionally — no URL substring check.
+        // This is the only way to support custom CDN manifest domains that have
+        // no "mediatailor" in the URL (mirrors VideoJS PR #106 explicit opt-in).
+        if (!explicitlyConfigured && !MTDetector.isMediaTailorUri(uri)) {
+            NRLog.d(MTConstants.LOG_DETECT + " not a MediaTailor URI and no explicit config"
+                    + " — tracker stays inert. uri=" + (uri != null ? uri : "null"));
             if (activated) {
-                // Source swapped to non-MT content; quiesce.
                 deactivate();
             }
             return;
         }
-        if (activated && uri != null && uri.toString().equals(mediaTailorEndpoint)) {
+        if (uri == null) {
+            NRLog.d(MTConstants.LOG_DETECT + " uri is null — skipping activation");
             return;
+        }
+        if (activated && uri.toString().equals(mediaTailorEndpoint)) {
+            return;
+        }
+        if (explicitlyConfigured && !MTDetector.isMediaTailorUri(uri)) {
+            NRLog.d(MTConstants.LOG_DETECT + " activating on custom CDN domain (no 'mediatailor' in URL)"
+                    + " — explicit NRAdConfig.mediaTailor() opt-in. uri=" + uri);
         }
         activate(uri);
     }
 
     private void activate(Uri uri) {
-        activated = true;
+        activated           = true;
         mediaTailorEndpoint = uri.toString();
-        manifestType = MTDetector.manifestType(uri);
+        manifestType        = MTDetector.manifestType(uri);
+
         if (trackingUrl == null) {
             trackingUrl = MTDetector.extractTrackingUrl(uri);
         }
+
         hasAttemptedTrackingFetch.set(false);
         synchronized (adSchedule) { adSchedule.clear(); }
         currentAdBreak = null;
-        currentAdPod = null;
-        NRLog.d("MT activated: type=" + manifestType
-                + " trackingUrl=" + trackingUrl
+        currentAdPod   = null;
+
+        String detectionDesc = segmentPrefix != null
+                ? "aws-hostname | /tm/ | custom='" + segmentPrefix + "'"
+                : "aws-hostname | /tm/";
+        NRLog.d(MTConstants.LOG_DETECT + " activated"
+                + " format=" + manifestType
+                + " detection=[" + detectionDesc + "]"
+                + " trackingUrl=" + (trackingUrl != null ? trackingUrl : "pending")
                 + " endpoint=" + mediaTailorEndpoint);
+
         startPolling();
     }
 
@@ -311,7 +356,7 @@ public class NRTrackerMediaTailor extends NRVideoTracker implements Player.Liste
         // mediaPresentationDuration — VOD does, live does not.
         boolean live = duration == C.TIME_UNSET || duration <= 0;
         streamType = live ? MTConstants.STREAM_TYPE_LIVE : MTConstants.STREAM_TYPE_VOD;
-        NRLog.d("MT stream type: " + streamType
+        NRLog.d(MTConstants.LOG_DETECT + " stream type: " + streamType
                 + " (duration=" + duration + "ms, isCurrentMediaItemLive="
                 + player.isCurrentMediaItemLive() + ")");
     }
@@ -332,11 +377,11 @@ public class NRTrackerMediaTailor extends NRVideoTracker implements Player.Liste
                 String derived = MTDetector.extractTrackingUrl(dash.location);
                 if (derived != null) {
                     trackingUrl = derived;
-                    NRLog.d("MT trackingUrl recovered from <Location>: " + trackingUrl);
+                    NRLog.d(MTConstants.LOG_TRACK + " trackingUrl recovered from DASH <Location>: " + trackingUrl);
                 }
             }
-            List<MTAdBreak> parsed = MTDashParser.parse(dash);
-            NRLog.d("MT DashManifest parsed: periods=" + dash.getPeriodCount()
+            List<MTAdBreak> parsed = MTDashParser.parse(dash, segmentPrefix);
+            NRLog.d(MTConstants.LOG_PARSE_DASH + " manifest parsed: periods=" + dash.getPeriodCount()
                     + " adBreaks=" + parsed.size()
                     + " location=" + (dash.location != null ? dash.location : "null"));
             if (!parsed.isEmpty()) {
@@ -346,17 +391,17 @@ public class NRTrackerMediaTailor extends NRVideoTracker implements Player.Liste
             HlsManifest hls = (HlsManifest) manifest;
             int segCount = hls.mediaPlaylist != null && hls.mediaPlaylist.segments != null
                     ? hls.mediaPlaylist.segments.size() : 0;
-            List<MTAdBreak> parsed = MTHlsParser.parse(hls);
-            NRLog.d("MT HlsManifest parsed: segments=" + segCount
+            List<MTAdBreak> parsed = MTHlsParser.parse(hls, segmentPrefix);
+            NRLog.d(MTConstants.LOG_PARSE_HLS + " manifest parsed: segments=" + segCount
                     + " adBreaks=" + parsed.size());
             if (!parsed.isEmpty()) {
                 applyNewBreaks(parsed);
             }
         } else if (manifest != null) {
-            NRLog.d("MT getCurrentManifest is neither DASH nor HLS: "
+            NRLog.d(MTConstants.LOG_TAG + " getCurrentManifest is neither DASH nor HLS: "
                     + manifest.getClass().getName());
         } else {
-            NRLog.d("MT getCurrentManifest() returned null — manifest not loaded yet");
+            NRLog.d(MTConstants.LOG_TAG + " getCurrentManifest() returned null — not loaded yet");
         }
         maybeFetchTracking();
     }
@@ -373,7 +418,7 @@ public class NRTrackerMediaTailor extends NRVideoTracker implements Player.Liste
             long positionMs = player != null ? player.getCurrentPosition() : 0L;
             long startMs = Math.max(positionMs, 0L);
             long durationMs = em.durationMs;
-            NRLog.d("MT emsg SCTE-35: scheme=" + em.schemeIdUri
+            NRLog.d(MTConstants.LOG_PARSE_DASH + " emsg SCTE-35: scheme=" + em.schemeIdUri
                     + " id=" + em.id + " startMs=" + startMs + " durationMs=" + durationMs);
             if (durationMs < MTConstants.MIN_AD_DURATION_MS) continue;
             String id = em.id != 0 ? "emsg-" + em.id : "emsg-" + startMs;
@@ -393,7 +438,7 @@ public class NRTrackerMediaTailor extends NRVideoTracker implements Player.Liste
             adSchedule.addAll(merged);
             after = adSchedule.size();
             StringBuilder sb = new StringBuilder();
-            sb.append("MT schedule (").append(after).append(" breaks, was ").append(before).append("): ");
+            sb.append(MTConstants.LOG_TAG).append(" schedule (").append(after).append(" breaks, was ").append(before).append("): ");
             for (int i = 0; i < adSchedule.size(); i++) {
                 MTAdBreak b = adSchedule.get(i);
                 if (i > 0) sb.append(", ");
@@ -426,14 +471,14 @@ public class NRTrackerMediaTailor extends NRVideoTracker implements Player.Liste
         cancelTrackingFetch();
         trackingClient = new MTTrackingClient();
         final String url = trackingUrl;
-        NRLog.d("MT tracking fetch: " + url);
+        NRLog.d(MTConstants.LOG_TRACK + " fetching: " + url);
         trackingWorker = new Thread(new Runnable() {
             @Override
             public void run() {
                 MTTrackingResponse resp = trackingClient.fetch(url);
                 if (isDisposed.get()) return;
                 if (resp == null) {
-                    NRLog.w("MT tracking fetch returned null (failed or cancelled)");
+                    NRLog.w(MTConstants.LOG_TRACK + " fetch returned null (failed or cancelled)");
                     return;
                 }
                 applyTrackingResponse(resp);
@@ -455,7 +500,7 @@ public class NRTrackerMediaTailor extends NRVideoTracker implements Player.Liste
     }
 
     private void applyTrackingResponse(final MTTrackingResponse resp) {
-        NRLog.d("MT tracking API returned " + resp.avails.size() + " avail(s), "
+        NRLog.d(MTConstants.LOG_TRACK + " response: " + resp.avails.size() + " avail(s), "
                 + resp.nonLinearAvails.size() + " non-linear avail(s)");
         Handler main = pollHandler;
         if (main == null) main = new Handler(Looper.getMainLooper());
@@ -469,9 +514,8 @@ public class NRTrackerMediaTailor extends NRVideoTracker implements Player.Liste
                             new ArrayList<>(adSchedule), resp);
                     adSchedule.clear();
                     adSchedule.addAll(enriched);
-                    NRLog.d("MT schedule enriched: " + adSchedule.size()
-                            + " breaks, confirmed="
-                            + countConfirmed(adSchedule));
+                    NRLog.d(MTConstants.LOG_TRACK + " schedule enriched: " + adSchedule.size()
+                            + " breaks, confirmed=" + countConfirmed(adSchedule));
                 }
             }
         });
@@ -539,7 +583,7 @@ public class NRTrackerMediaTailor extends NRVideoTracker implements Player.Liste
         if (!active.hasFiredStart) {
             currentAdBreak = active;
             active.adPosition = computeAdPosition(active);
-            NRLog.d("MT AD_BREAK_START at " + active.startTimeMs + "ms pos=" + active.adPosition);
+            NRLog.d(MTConstants.LOG_EVENT + " AD_BREAK_START startMs=" + active.startTimeMs + " pos=" + active.adPosition);
             sendAdBreakStart();
             active.hasFiredStart = true;
         }
@@ -548,11 +592,11 @@ public class NRTrackerMediaTailor extends NRVideoTracker implements Player.Liste
             MTAdPod pod = active.findActivePod(position);
             if (pod != null && pod != currentAdPod) {
                 if (currentAdPod != null) {
-                    NRLog.d("MT AD_END (pod transition)");
+                    NRLog.d(MTConstants.LOG_EVENT + " AD_END (pod transition)");
                     sendEnd();
                 }
                 currentAdPod = pod;
-                NRLog.d("MT AD_START (new pod)");
+                NRLog.d(MTConstants.LOG_EVENT + " AD_START (new pod)");
                 sendRequest();
                 sendStart();
                 pod.hasFiredStart = true;
@@ -561,7 +605,7 @@ public class NRTrackerMediaTailor extends NRVideoTracker implements Player.Liste
                 trackQuartiles(pod, position - pod.startTimeMs);
             }
         } else if (!active.hasFiredAdStart) {
-            NRLog.d("MT AD_START (no pods)");
+            NRLog.d(MTConstants.LOG_EVENT + " AD_START (no pods)");
             sendRequest();
             sendStart();
             active.hasFiredAdStart = true;
@@ -574,15 +618,15 @@ public class NRTrackerMediaTailor extends NRVideoTracker implements Player.Liste
 
     private void handleExitingBreak() {
         if (currentAdPod != null) {
-            NRLog.d("MT AD_END (final pod)");
+            NRLog.d(MTConstants.LOG_EVENT + " AD_END (final pod)");
             sendEnd();
             currentAdPod = null;
         } else if (currentAdBreak != null && currentAdBreak.hasFiredAdStart) {
-            NRLog.d("MT AD_END (no-pods break)");
+            NRLog.d(MTConstants.LOG_EVENT + " AD_END (no-pods break)");
             sendEnd();
         }
         if (currentAdBreak != null && !currentAdBreak.hasFiredEnd) {
-            NRLog.d("MT AD_BREAK_END");
+            NRLog.d(MTConstants.LOG_EVENT + " AD_BREAK_END");
             sendAdBreakEnd();
             currentAdBreak.hasFiredEnd = true;
         }
@@ -619,7 +663,7 @@ public class NRTrackerMediaTailor extends NRVideoTracker implements Player.Liste
 
     private void fireQuartile(Object target, long quartile) {
         currentQuartile = quartile;
-        NRLog.d("MT AD_QUARTILE " + (quartile * 25) + "%");
+        NRLog.d(MTConstants.LOG_EVENT + " AD_QUARTILE " + (quartile * 25) + "%");
         sendAdQuartile();
         if (target instanceof MTAdPod) {
             MTAdPod p = (MTAdPod) target;

--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/NRAdConfig.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/NRAdConfig.java
@@ -1,0 +1,170 @@
+package com.newrelic.videoagent.core;
+
+import androidx.annotation.Nullable;
+
+/**
+ * Ad configuration for a single player session — the one place for all ad options.
+ *
+ * <p>Construct via static factory methods and pass to
+ * {@link NRVideoPlayerConfiguration}. Pass {@code null} for no ad tracking.</p>
+ *
+ * <pre>
+ *   // Google IMA / any CSAI framework
+ *   NRAdConfig.csai()
+ *
+ *   // AWS MediaTailor — standard AWS hostnames
+ *   NRAdConfig.mediaTailor()
+ *
+ *   // AWS MediaTailor — custom CDN (AWS-recommended /tm/ path is auto-detected;
+ *   // only set segmentPrefix if your CDN uses a different path)
+ *   NRAdConfig.mediaTailor("/my-ads/")
+ *
+ *   // AWS MediaTailor — explicit tracking URL (POST /v1/session/ flow,
+ *   // or when CDN strips aws.sessionId from the manifest URL)
+ *   NRAdConfig.mediaTailor(null, "https://...mediatailor.../v1/tracking/...")
+ *
+ *   // AWS MediaTailor — both overrides
+ *   NRAdConfig.mediaTailor("/my-ads/", "https://...mediatailor.../v1/tracking/...")
+ * </pre>
+ *
+ * <h3>Ad segment detection order (MediaTailor only)</h3>
+ * <ol>
+ *   <li>{@code segments.mediatailor} — default AWS ad-segment hostname.</li>
+ *   <li>{@code /v1/hlssegment/} / {@code /v1/dashsegment/} — MediaTailor CDN
+ *       rewrite paths.</li>
+ *   <li>{@code /tm/} — AWS-recommended CDN ad-segment prefix; detected
+ *       automatically for all customers, no configuration needed.</li>
+ *   <li>{@link #segmentPrefix} — custom override; only checked when non-null.
+ *       Use only if your CDN prefix differs from {@code /tm/}.</li>
+ * </ol>
+ */
+public final class NRAdConfig {
+
+    /**
+     * Ad framework type — identifies which tracker is created by
+     * {@link NRVideo#addPlayer}. Set internally by the factory methods;
+     * read-only for callers.
+     */
+    public enum Type {
+        /** Client-side ad insertion — Google IMA, Freewheel, generic CSAI. */
+        CSAI,
+        /** Server-side ad insertion — AWS Elemental MediaTailor. */
+        SSAI_MT
+    }
+
+    /** Internal tracker type — set by the factory method, not by the customer. */
+    public final Type type;
+
+    /**
+     * Custom CDN ad-segment path prefix override. {@code null} = no override.
+     *
+     * <p>Set only when your CDN rewrites ad-segment URLs to a path that is
+     * not {@code segments.mediatailor} and not {@code /tm/} (both are detected
+     * automatically). Example: {@code "/ads/"} for
+     * {@code https://cdn.example.com/ads/segment_001.ts}.</p>
+     */
+    @Nullable
+    public final String segmentPrefix;
+
+    /**
+     * Explicit MediaTailor tracking URL. {@code null} = auto-derived from
+     * the manifest URI (covers the common implicit-session case).
+     *
+     * <p>Supply this when using the POST {@code /v1/session/} flow (the
+     * tracking URL is in the response body), or when your CDN strips
+     * {@code aws.sessionId} from the manifest URL so auto-derivation fails.
+     * You can also set this after {@code addPlayer()} via
+     * {@code NRTrackerMediaTailor.setTrackingUrl()} for async session flows.</p>
+     */
+    @Nullable
+    public final String trackingUrl;
+
+    // ── Static factory methods ─────────────────────────────────────────────
+
+    /**
+     * Client-side ad insertion.
+     *
+     * <p>Covers Google IMA, Brightcove IMA, Freewheel, and any other CSAI
+     * framework — they all share the same activation path and are
+     * auto-detected by the tracker.</p>
+     */
+    public static NRAdConfig csai() {
+        return new NRAdConfig(Type.CSAI, null, null);
+    }
+
+    /**
+     * AWS Elemental MediaTailor SSAI — standard AWS domain detection.
+     *
+     * <p>Segments at {@code *.mediatailor.*} and {@code /tm/} paths are
+     * detected automatically. Use this for the common case.</p>
+     */
+    public static NRAdConfig mediaTailor() {
+        return new NRAdConfig(Type.SSAI_MT, null, null);
+    }
+
+    /**
+     * AWS Elemental MediaTailor SSAI — with custom CDN segment prefix override.
+     *
+     * <p>Use this only when your CDN ad-segment path is not the default
+     * {@code segments.mediatailor} hostname and not the AWS-recommended
+     * {@code /tm/} path (which is checked automatically).</p>
+     *
+     * @param segmentPrefix Substring matched against each segment URL to
+     *                      classify it as an ad segment. Pass {@code null}
+     *                      to rely on default detection only.
+     */
+    public static NRAdConfig mediaTailor(@Nullable String segmentPrefix) {
+        return new NRAdConfig(Type.SSAI_MT, segmentPrefix, null);
+    }
+
+    /**
+     * AWS Elemental MediaTailor SSAI — custom segment prefix and explicit
+     * tracking URL.
+     *
+     * @param segmentPrefix Substring matched against segment URLs to identify
+     *                      ad segments. Pass {@code null} for default detection.
+     * @param trackingUrl   Full MediaTailor tracking URL. Pass {@code null}
+     *                      to let the tracker derive it from the manifest URI.
+     */
+    public static NRAdConfig mediaTailor(@Nullable String segmentPrefix,
+                                         @Nullable String trackingUrl) {
+        return new NRAdConfig(Type.SSAI_MT, segmentPrefix, trackingUrl);
+    }
+
+    // ── Private constructor ────────────────────────────────────────────────
+
+    private NRAdConfig(Type type, @Nullable String segmentPrefix, @Nullable String trackingUrl) {
+        this.type          = type;
+        this.segmentPrefix = segmentPrefix;
+        this.trackingUrl   = trackingUrl;
+    }
+
+    // ── Object overrides ───────────────────────────────────────────────────
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof NRAdConfig)) return false;
+        NRAdConfig that = (NRAdConfig) o;
+        return type == that.type
+                && java.util.Objects.equals(segmentPrefix, that.segmentPrefix)
+                && java.util.Objects.equals(trackingUrl,   that.trackingUrl);
+    }
+
+    @Override
+    public int hashCode() {
+        return java.util.Objects.hash(type, segmentPrefix, trackingUrl);
+    }
+
+    @Override
+    public String toString() {
+        if (type == Type.CSAI) {
+            return "NRAdConfig{csai}";
+        }
+        StringBuilder sb = new StringBuilder("NRAdConfig{mediaTailor");
+        if (segmentPrefix != null) sb.append(", segmentPrefix='").append(segmentPrefix).append("'");
+        if (trackingUrl   != null) sb.append(", trackingUrl set");
+        sb.append("}");
+        return sb.toString();
+    }
+}

--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/NRVideo.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/NRVideo.java
@@ -71,19 +71,23 @@ public final class NRVideo {
         // Create content tracker with ExoPlayer instance
         NRTracker contentTracker = createContentTracker(instance.configuration);
         NRTracker adsTracker = null;
-        NRVideoPlayerConfiguration.AdTrackerType adType = config.getAdTrackerType();
-        if (adType != NRVideoPlayerConfiguration.AdTrackerType.NONE) {
-            adsTracker = createAdTracker(instance.configuration, adType);
-            NRLog.d("ad tracker created: " + adType);
+        NRAdConfig adConfig = config.getAdConfig();
+        if (adConfig != null) {
+            adsTracker = createAdTracker(instance.configuration, adConfig);
+            NRLog.d("[NRVideo] ad tracker created for " + adConfig);
+        } else {
+            NRLog.d("[NRVideo] no adConfig supplied — ad tracking disabled for player '"
+                    + config.getPlayerName() + "'");
         }
 
         // Now start the tracker system
         Integer trackerId = NewRelicVideoAgent.getInstance().start(contentTracker, adsTracker);
         ((NRVideoTracker) contentTracker).setPlayer(config.getPlayer());
-        // MediaTailor needs the ExoPlayer reference to register Player.Listener;
-        // IMA does not (it wires via AdEventListener externally).
+        // MediaTailor registers a Player.Listener so it needs the ExoPlayer reference.
+        // IMA wires via AdEventListener externally and does not need setPlayer here.
         if (adsTracker instanceof NRVideoTracker
-                && adType == NRVideoPlayerConfiguration.AdTrackerType.MEDIA_TAILOR) {
+                && adConfig != null
+                && adConfig.type == NRAdConfig.Type.SSAI_MT) {
             ((NRVideoTracker) adsTracker).setPlayer(config.getPlayer());
         }
         NRLog.i("NRVideo initialization completed successfully with tracker ID: " + trackerId + " and player name:" + config.getPlayerName());
@@ -291,39 +295,37 @@ public final class NRVideo {
         }
     }
 
-    private static NRTracker createAdTracker(NRVideoConfiguration config,
-                                              NRVideoPlayerConfiguration.AdTrackerType type) {
+    private static NRTracker createAdTracker(NRVideoConfiguration config, NRAdConfig adConfig) {
         String className;
-        switch (type) {
-            case MEDIA_TAILOR:
+        switch (adConfig.type) {
+            case SSAI_MT:
                 className = "com.newrelic.videoagent.mediatailor.tracker.NRTrackerMediaTailor";
                 break;
-            case IMA:
+            case CSAI:
             default:
                 className = "com.newrelic.videoagent.ima.tracker.NRTrackerIMA";
                 break;
         }
+        NRLog.d("[NRVideo] loading ad tracker class: " + className);
         try {
             Class<?> clazz = Class.forName(className);
-            return (NRTracker) clazz.getConstructor(NRVideoConfiguration.class).newInstance(config);
-        } catch (Exception e) {
-            // Fallback to no-arg ctor for backward compatibility
+            // Prefer the two-arg constructor (NRVideoConfiguration, NRAdConfig) so the
+            // tracker receives its full configuration (segmentPrefix, trackingUrl) at
+            // construction time. Fall back to the one-arg constructor for trackers
+            // (e.g. NRTrackerIMA) that do not need NRAdConfig.
             try {
-                Class<?> clazz = Class.forName(className);
-                return (NRTracker) clazz.newInstance();
-            } catch (Exception fallbackException) {
-                NRLog.w("Failed to load ad tracker " + className + ": " + fallbackException);
-                return null;
+                return (NRTracker) clazz
+                        .getConstructor(NRVideoConfiguration.class, NRAdConfig.class)
+                        .newInstance(config, adConfig);
+            } catch (NoSuchMethodException ignored) {
+                return (NRTracker) clazz
+                        .getConstructor(NRVideoConfiguration.class)
+                        .newInstance(config);
             }
+        } catch (Exception e) {
+            NRLog.w("[NRVideo] failed to load ad tracker " + className + ": " + e);
+            return null;
         }
-    }
-
-    /**
-     * @deprecated Kept for source compatibility — routes to IMA.
-     */
-    @Deprecated
-    private static NRTracker createAdTracker(NRVideoConfiguration config) {
-        return createAdTracker(config, NRVideoPlayerConfiguration.AdTrackerType.IMA);
     }
 
     /**

--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/NRVideoPlayerConfiguration.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/NRVideoPlayerConfiguration.java
@@ -1,36 +1,109 @@
 package com.newrelic.videoagent.core;
 
+import androidx.annotation.Nullable;
 import androidx.media3.exoplayer.ExoPlayer;
 
 import java.util.Map;
 
+/**
+ * Per-player configuration passed to {@link NRVideo#addPlayer}.
+ *
+ * <p>Combines the player instance, an optional ad configuration, and optional
+ * custom attributes into a single object.</p>
+ *
+ * <pre>
+ *   // No ads
+ *   new NRVideoPlayerConfiguration("player", exoPlayer, null, null);
+ *
+ *   // Google IMA
+ *   new NRVideoPlayerConfiguration("player", exoPlayer, NRAdConfig.csai(), null);
+ *
+ *   // AWS MediaTailor — default detection
+ *   new NRVideoPlayerConfiguration("player", exoPlayer, NRAdConfig.mediaTailor(), null);
+ *
+ *   // AWS MediaTailor — custom CDN
+ *   new NRVideoPlayerConfiguration("player", exoPlayer, NRAdConfig.mediaTailor("/tm/"), null);
+ * </pre>
+ */
 public class NRVideoPlayerConfiguration {
 
     /**
-     * Selects which ad tracker implementation is paired with the content
-     * tracker. Mutually exclusive per player — only one ad tracker slot
-     * exists in {@code NRTrackerPair}.
+     * Ad tracker selector — kept for source compatibility with integrations
+     * built against v4.2.0 and earlier.
+     *
+     * @deprecated Construct an {@link NRAdConfig} via its factory methods and
+     * pass it to {@link #NRVideoPlayerConfiguration(String, ExoPlayer, NRAdConfig, Map)}.
+     * <pre>
+     *   AdTrackerType.NONE          →  null
+     *   AdTrackerType.IMA           →  NRAdConfig.csai()
+     *   AdTrackerType.MEDIA_TAILOR  →  NRAdConfig.mediaTailor()
+     * </pre>
      */
+    @Deprecated
     public enum AdTrackerType {
         NONE,
+        /** @deprecated Use {@link NRAdConfig#csai()} */
         IMA,
+        /** @deprecated Use {@link NRAdConfig#mediaTailor()} */
         MEDIA_TAILOR
     }
 
     private final String playerName;
     private final ExoPlayer player;
+    private final NRAdConfig adConfig;
     private final Map<String, Object> customAttributes;
-    private final AdTrackerType adTrackerType;
 
-    public NRVideoPlayerConfiguration(String playerName, ExoPlayer player, boolean isAdEnabled, Map<String, Object> customAttributes) {
-        this(playerName, player, isAdEnabled ? AdTrackerType.IMA : AdTrackerType.NONE, customAttributes);
+    /**
+     * @param playerName       Display name for this player — used as a key in
+     *                         tracker ID lookups.
+     * @param player           ExoPlayer instance to track.
+     * @param adConfig         Ad framework configuration. Use {@link NRAdConfig#csai()}
+     *                         for IMA or {@link NRAdConfig#mediaTailor()} for MediaTailor.
+     *                         Pass {@code (NRAdConfig) null} to disable ad tracking
+     *                         (the cast is required to resolve overload ambiguity).
+     * @param customAttributes Optional key-value pairs attached to every event
+     *                         emitted by this player's tracker. Pass {@code null}
+     *                         if not needed.
+     */
+    public NRVideoPlayerConfiguration(String playerName,
+                                       ExoPlayer player,
+                                       @Nullable NRAdConfig adConfig,
+                                       @Nullable Map<String, Object> customAttributes) {
+        this.playerName       = playerName;
+        this.player           = player;
+        this.adConfig         = adConfig;
+        this.customAttributes = customAttributes;
     }
 
-    public NRVideoPlayerConfiguration(String playerName, ExoPlayer player, AdTrackerType adTrackerType, Map<String, Object> customAttributes) {
-        this.playerName = playerName;
-        this.player = player;
-        this.adTrackerType = adTrackerType != null ? adTrackerType : AdTrackerType.NONE;
-        this.customAttributes = customAttributes;
+    /**
+     * @deprecated Use {@link #NRVideoPlayerConfiguration(String, ExoPlayer, NRAdConfig, Map)}
+     * with {@link NRAdConfig#csai()} for ads or {@code null} for no ads.
+     */
+    @Deprecated
+    public NRVideoPlayerConfiguration(String playerName,
+                                       ExoPlayer player,
+                                       boolean isAdEnabled,
+                                       @Nullable Map<String, Object> customAttributes) {
+        this(playerName, player, isAdEnabled ? NRAdConfig.csai() : null, customAttributes);
+    }
+
+    /**
+     * @deprecated Use {@link #NRVideoPlayerConfiguration(String, ExoPlayer, NRAdConfig, Map)}.
+     * Map values: {@code NONE} → {@code null}, {@code IMA} → {@link NRAdConfig#csai()},
+     * {@code MEDIA_TAILOR} → {@link NRAdConfig#mediaTailor()}.
+     */
+    @Deprecated
+    public NRVideoPlayerConfiguration(String playerName,
+                                       ExoPlayer player,
+                                       AdTrackerType adTrackerType,
+                                       @Nullable Map<String, Object> customAttributes) {
+        this(playerName, player, toAdConfig(adTrackerType), customAttributes);
+    }
+
+    private static NRAdConfig toAdConfig(AdTrackerType type) {
+        if (type == null || type == AdTrackerType.NONE) return null;
+        if (type == AdTrackerType.MEDIA_TAILOR) return NRAdConfig.mediaTailor();
+        return NRAdConfig.csai(); // IMA and any future values default to CSAI
     }
 
     public String getPlayerName() {
@@ -41,20 +114,32 @@ public class NRVideoPlayerConfiguration {
         return player;
     }
 
+    /** Returns the ad configuration, or {@code null} if ad tracking is disabled. */
+    @Nullable
+    public NRAdConfig getAdConfig() {
+        return adConfig;
+    }
+
+    @Nullable
     public Map<String, Object> getCustomAttributes() {
         return customAttributes;
     }
 
+    /**
+     * @deprecated Use {@link #getAdConfig()} instead.
+     */
+    @Deprecated
     public AdTrackerType getAdTrackerType() {
-        return adTrackerType;
+        if (adConfig == null) return AdTrackerType.NONE;
+        if (adConfig.type == NRAdConfig.Type.SSAI_MT) return AdTrackerType.MEDIA_TAILOR;
+        return AdTrackerType.IMA;
     }
 
     /**
-     * @deprecated Use {@link #getAdTrackerType()}. Kept for backward compat —
-     * returns {@code true} when any ad tracker is selected.
+     * @deprecated Use {@code getAdConfig() != null} instead.
      */
     @Deprecated
     public boolean isAdEnabled() {
-        return adTrackerType != AdTrackerType.NONE;
+        return adConfig != null;
     }
 }

--- a/NewRelicVideoCore/src/test/java/com/newrelic/videoagent/core/NRVideoPlayerConfigurationTest.java
+++ b/NewRelicVideoCore/src/test/java/com/newrelic/videoagent/core/NRVideoPlayerConfigurationTest.java
@@ -25,60 +25,63 @@ public class NRVideoPlayerConfigurationTest {
         MockitoAnnotations.openMocks(this);
     }
 
+    // ── Current API ───────────────────────────────────────────────────────────
+
     @Test
-    public void testConstructorWithAllParameters() {
+    public void testConstructorWithAdConfig() {
         Map<String, Object> customAttrs = new HashMap<>();
         customAttrs.put("key1", "value1");
 
         NRVideoPlayerConfiguration config = new NRVideoPlayerConfiguration(
-            "TestPlayer",
-            mockPlayer,
-            true,
-            customAttrs
-        );
+            "TestPlayer", mockPlayer, NRAdConfig.csai(), customAttrs);
 
         assertNotNull(config);
         assertEquals("TestPlayer", config.getPlayerName());
         assertEquals(mockPlayer, config.getPlayer());
-        assertTrue(config.isAdEnabled());
+        assertNotNull(config.getAdConfig());
+        assertEquals(NRAdConfig.Type.CSAI, config.getAdConfig().type);
         assertEquals(customAttrs, config.getCustomAttributes());
     }
 
     @Test
-    public void testConstructorWithAdDisabled() {
+    public void testConstructorWithNoAds() {
         NRVideoPlayerConfiguration config = new NRVideoPlayerConfiguration(
-            "TestPlayer",
-            mockPlayer,
-            false,
-            null
-        );
+            "TestPlayer", mockPlayer, (NRAdConfig) null, null);
 
         assertNotNull(config);
-        assertFalse(config.isAdEnabled());
+        assertNull(config.getAdConfig());
     }
 
     @Test
-    public void testGetPlayerName() {
+    public void testMediaTailorAdConfig() {
         NRVideoPlayerConfiguration config = new NRVideoPlayerConfiguration(
-            "MyPlayer",
-            mockPlayer,
-            false,
-            null
-        );
+            "TestPlayer", mockPlayer, NRAdConfig.mediaTailor(), null);
 
-        assertEquals("MyPlayer", config.getPlayerName());
+        assertNotNull(config.getAdConfig());
+        assertEquals(NRAdConfig.Type.SSAI_MT, config.getAdConfig().type);
+        assertNull(config.getAdConfig().segmentPrefix);
+        assertNull(config.getAdConfig().trackingUrl);
     }
 
     @Test
-    public void testGetPlayer() {
+    public void testMediaTailorAdConfigWithSegmentPrefix() {
         NRVideoPlayerConfiguration config = new NRVideoPlayerConfiguration(
-            "TestPlayer",
-            mockPlayer,
-            false,
-            null
-        );
+            "TestPlayer", mockPlayer, NRAdConfig.mediaTailor("/tm/"), null);
 
-        assertSame(mockPlayer, config.getPlayer());
+        assertEquals(NRAdConfig.Type.SSAI_MT, config.getAdConfig().type);
+        assertEquals("/tm/", config.getAdConfig().segmentPrefix);
+        assertNull(config.getAdConfig().trackingUrl);
+    }
+
+    @Test
+    public void testMediaTailorAdConfigWithTrackingUrl() {
+        String url = "https://mediatailor.us-east-1.amazonaws.com/v1/tracking/abc/123";
+        NRVideoPlayerConfiguration config = new NRVideoPlayerConfiguration(
+            "TestPlayer", mockPlayer, NRAdConfig.mediaTailor(null, url), null);
+
+        assertEquals(NRAdConfig.Type.SSAI_MT, config.getAdConfig().type);
+        assertNull(config.getAdConfig().segmentPrefix);
+        assertEquals(url, config.getAdConfig().trackingUrl);
     }
 
     @Test
@@ -88,172 +91,18 @@ public class NRVideoPlayerConfigurationTest {
         customAttrs.put("attr2", 42);
 
         NRVideoPlayerConfiguration config = new NRVideoPlayerConfiguration(
-            "TestPlayer",
-            mockPlayer,
-            false,
-            customAttrs
-        );
+            "TestPlayer", mockPlayer, (NRAdConfig) null, customAttrs);
 
-        Map<String, Object> result = config.getCustomAttributes();
-        assertEquals(customAttrs, result);
-        assertEquals("value1", result.get("attr1"));
-        assertEquals(42, result.get("attr2"));
+        assertEquals("value1", config.getCustomAttributes().get("attr1"));
+        assertEquals(42, config.getCustomAttributes().get("attr2"));
     }
 
     @Test
-    public void testIsAdEnabled() {
-        NRVideoPlayerConfiguration configWithAds = new NRVideoPlayerConfiguration(
-            "TestPlayer",
-            mockPlayer,
-            true,
-            null
-        );
-
-        NRVideoPlayerConfiguration configWithoutAds = new NRVideoPlayerConfiguration(
-            "TestPlayer",
-            mockPlayer,
-            false,
-            null
-        );
-
-        assertTrue(configWithAds.isAdEnabled());
-        assertFalse(configWithoutAds.isAdEnabled());
-    }
-
-    @Test
-    public void testConstructorWithNullPlayerName() {
+    public void testNullCustomAttributes() {
         NRVideoPlayerConfiguration config = new NRVideoPlayerConfiguration(
-            null,
-            mockPlayer,
-            false,
-            null
-        );
-
-        assertNull(config.getPlayerName());
-    }
-
-    @Test
-    public void testConstructorWithNullPlayer() {
-        NRVideoPlayerConfiguration config = new NRVideoPlayerConfiguration(
-            "TestPlayer",
-            null,
-            false,
-            null
-        );
-
-        assertNull(config.getPlayer());
-    }
-
-    @Test
-    public void testConstructorWithNullCustomAttributes() {
-        NRVideoPlayerConfiguration config = new NRVideoPlayerConfiguration(
-            "TestPlayer",
-            mockPlayer,
-            false,
-            null
-        );
+            "TestPlayer", mockPlayer, (NRAdConfig) null, null);
 
         assertNull(config.getCustomAttributes());
-    }
-
-    @Test
-    public void testConstructorWithEmptyCustomAttributes() {
-        Map<String, Object> emptyAttrs = new HashMap<>();
-
-        NRVideoPlayerConfiguration config = new NRVideoPlayerConfiguration(
-            "TestPlayer",
-            mockPlayer,
-            false,
-            emptyAttrs
-        );
-
-        assertNotNull(config.getCustomAttributes());
-        assertTrue(config.getCustomAttributes().isEmpty());
-    }
-
-    @Test
-    public void testConstructorWithMultipleCustomAttributes() {
-        Map<String, Object> customAttrs = new HashMap<>();
-        customAttrs.put("stringAttr", "test");
-        customAttrs.put("intAttr", 123);
-        customAttrs.put("boolAttr", true);
-        customAttrs.put("doubleAttr", 3.14);
-
-        NRVideoPlayerConfiguration config = new NRVideoPlayerConfiguration(
-            "TestPlayer",
-            mockPlayer,
-            true,
-            customAttrs
-        );
-
-        Map<String, Object> result = config.getCustomAttributes();
-        assertEquals(4, result.size());
-        assertEquals("test", result.get("stringAttr"));
-        assertEquals(123, result.get("intAttr"));
-        assertEquals(true, result.get("boolAttr"));
-        assertEquals(3.14, result.get("doubleAttr"));
-    }
-
-    @Test
-    public void testPlayerNameWithSpecialCharacters() {
-        String specialName = "Player@#$%^&*()_+-=[]{}|;':\",./<>?";
-
-        NRVideoPlayerConfiguration config = new NRVideoPlayerConfiguration(
-            specialName,
-            mockPlayer,
-            false,
-            null
-        );
-
-        assertEquals(specialName, config.getPlayerName());
-    }
-
-    @Test
-    public void testPlayerNameWithEmptyString() {
-        NRVideoPlayerConfiguration config = new NRVideoPlayerConfiguration(
-            "",
-            mockPlayer,
-            false,
-            null
-        );
-
-        assertEquals("", config.getPlayerName());
-    }
-
-    @Test
-    public void testMultipleInstancesWithSamePlayer() {
-        NRVideoPlayerConfiguration config1 = new NRVideoPlayerConfiguration(
-            "Player1",
-            mockPlayer,
-            true,
-            null
-        );
-
-        NRVideoPlayerConfiguration config2 = new NRVideoPlayerConfiguration(
-            "Player2",
-            mockPlayer,
-            false,
-            null
-        );
-
-        assertSame(config1.getPlayer(), config2.getPlayer());
-        assertNotEquals(config1.getPlayerName(), config2.getPlayerName());
-    }
-
-    @Test
-    public void testCustomAttributesImmutability() {
-        Map<String, Object> originalAttrs = new HashMap<>();
-        originalAttrs.put("key", "value");
-
-        NRVideoPlayerConfiguration config = new NRVideoPlayerConfiguration(
-            "TestPlayer",
-            mockPlayer,
-            false,
-            originalAttrs
-        );
-
-        Map<String, Object> retrievedAttrs = config.getCustomAttributes();
-        assertSame(originalAttrs, retrievedAttrs);
     }
 
     @Test
@@ -262,15 +111,74 @@ public class NRVideoPlayerConfigurationTest {
         customAttrs.put("test", "value");
 
         NRVideoPlayerConfiguration config = new NRVideoPlayerConfiguration(
-            "CompletePlayer",
-            mockPlayer,
-            true,
-            customAttrs
-        );
+            "CompletePlayer", mockPlayer,
+            NRAdConfig.mediaTailor("/ads/", "https://tracking.example.com"),
+            customAttrs);
 
         assertNotNull(config.getPlayerName());
         assertNotNull(config.getPlayer());
         assertNotNull(config.getCustomAttributes());
+        assertEquals(NRAdConfig.Type.SSAI_MT, config.getAdConfig().type);
+        assertEquals("/ads/", config.getAdConfig().segmentPrefix);
+        assertEquals("https://tracking.example.com", config.getAdConfig().trackingUrl);
+    }
+
+    // ── Backward compatibility (deprecated API) ───────────────────────────────
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void testDeprecatedBooleanConstructorTrue() {
+        NRVideoPlayerConfiguration config = new NRVideoPlayerConfiguration(
+            "TestPlayer", mockPlayer, true, null);
+
+        assertNotNull(config.getAdConfig());
+        assertEquals(NRAdConfig.Type.CSAI, config.getAdConfig().type);
         assertTrue(config.isAdEnabled());
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void testDeprecatedBooleanConstructorFalse() {
+        NRVideoPlayerConfiguration config = new NRVideoPlayerConfiguration(
+            "TestPlayer", mockPlayer, false, null);
+
+        assertNull(config.getAdConfig());
+        assertFalse(config.isAdEnabled());
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void testDeprecatedAdTrackerTypeIma() {
+        NRVideoPlayerConfiguration config = new NRVideoPlayerConfiguration(
+            "TestPlayer", mockPlayer,
+            NRVideoPlayerConfiguration.AdTrackerType.IMA, null);
+
+        assertNotNull(config.getAdConfig());
+        assertEquals(NRAdConfig.Type.CSAI, config.getAdConfig().type);
+        assertEquals(NRVideoPlayerConfiguration.AdTrackerType.IMA, config.getAdTrackerType());
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void testDeprecatedAdTrackerTypeMediaTailor() {
+        NRVideoPlayerConfiguration config = new NRVideoPlayerConfiguration(
+            "TestPlayer", mockPlayer,
+            NRVideoPlayerConfiguration.AdTrackerType.MEDIA_TAILOR, null);
+
+        assertNotNull(config.getAdConfig());
+        assertEquals(NRAdConfig.Type.SSAI_MT, config.getAdConfig().type);
+        assertEquals(NRVideoPlayerConfiguration.AdTrackerType.MEDIA_TAILOR, config.getAdTrackerType());
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void testDeprecatedAdTrackerTypeNone() {
+        NRVideoPlayerConfiguration config = new NRVideoPlayerConfiguration(
+            "TestPlayer", mockPlayer,
+            NRVideoPlayerConfiguration.AdTrackerType.NONE, null);
+
+        assertNull(config.getAdConfig());
+        assertEquals(NRVideoPlayerConfiguration.AdTrackerType.NONE, config.getAdTrackerType());
+        assertFalse(config.isAdEnabled());
     }
 }

--- a/NewRelicVideoCore/src/test/java/com/newrelic/videoagent/core/NRVideoTest.java
+++ b/NewRelicVideoCore/src/test/java/com/newrelic/videoagent/core/NRVideoTest.java
@@ -5,6 +5,7 @@ import android.content.Context;
 
 import androidx.media3.exoplayer.ExoPlayer;
 
+import com.newrelic.videoagent.core.NRAdConfig;
 import com.newrelic.videoagent.core.tracker.NRTracker;
 
 import org.junit.After;
@@ -174,7 +175,7 @@ public class NRVideoTest {
         NRVideoPlayerConfiguration playerConfig = new NRVideoPlayerConfiguration(
             "TestPlayer",
             mockPlayer,
-            false,
+            (NRAdConfig) null,
             null
         );
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Map<String, Object> customAttrs = new HashMap<>();
 customAttrs.put("contentTitle", "My Video Title");
 
 NRVideoPlayerConfiguration playerConfig =
-        new NRVideoPlayerConfiguration("my-player", player, false, customAttrs);
+        new NRVideoPlayerConfiguration("my-player", player, null, customAttrs);
 
 Integer trackerId = NRVideo.addPlayer(playerConfig);
 
@@ -170,40 +170,62 @@ protected void onDestroy() {
 
 ### Setup with ExoPlayer and AWS MediaTailor (SSAI)
 
+Pass `NRAdConfig.mediaTailor()` (or one of its overloads) as the third argument to
+`NRVideoPlayerConfiguration`. The tracker activates automatically when `addPlayer` is called.
+
 ```java
 // Step 1: Initialize NRVideo (same as basic setup)
 
-// Step 2: Explicit MediaTailor session init — POST to /v1/session/…, get back
-//         a sessionized manifest URL plus a tracking URL.
-//   POST  https://<hash>.mediatailor.<region>.amazonaws.com/v1/session/<hash>/<config>/<manifestFile>
-//   body  {"reportingMode":"server", "adsParams":{…custom targeting…}}
+// Step 2: POST to /v1/session/… to create a session.
+//   POST  https://<hash>.mediatailor.<region>.amazonaws.com/v1/session/<hash>/<config>/<manifest>
+//   body  {"reportingMode":"server", "adsParams":{…targeting params…}}
 //   resp  {"manifestUrl":"/v1/dash/…?aws.sessionId=…", "trackingUrl":"/v1/tracking/…"}
-// Both paths are relative — prefix them with your MediaTailor host.
+// Both returned paths are root-relative — prepend your MediaTailor host.
 
-String manifestUrl = /* absolute URL from session init */;
-String trackingUrl = /* absolute URL from session init */;
+String manifestUrl = /* absolute manifest URL from session-init response */;
+String trackingUrl = /* absolute tracking URL from session-init response */;
 
 ExoPlayer player = new ExoPlayer.Builder(this).build();
 
-// Step 3: Register with MEDIA_TAILOR as the ad tracker type.
+// Step 3: Register the player with NRAdConfig.mediaTailor().
+//   Pass the trackingUrl from session init directly — no extra wiring needed.
 NRVideoPlayerConfiguration playerConfig = new NRVideoPlayerConfiguration(
         "mediatailor-player",
         player,
-        NRVideoPlayerConfiguration.AdTrackerType.MEDIA_TAILOR,
+        NRAdConfig.mediaTailor(null, trackingUrl),
         /* custom attrs */ null);
 Integer trackerId = NRVideo.addPlayer(playerConfig);
 
-// Step 4: Hand ExoPlayer the sessionized manifest URL and start playback.
-//         The tracker auto-derives the tracking URL from aws.sessionId in
-//         this URI — no extra wiring needed in the normal flow.
+// Step 4: Hand ExoPlayer the manifest URL and start playback.
 player.setMediaItem(MediaItem.fromUri(manifestUrl));
 player.prepare();
 player.setPlayWhenReady(true);
 
-// Step 5 (Optional): For a "Skip ad" button in your UI, fire AD_SKIP via
+// Step 5 (Optional): For a "Skip ad" button in your UI.
 // NRTrackerMediaTailor adTracker = (NRTrackerMediaTailor)
 //         NewRelicVideoAgent.getInstance().getAdTracker(trackerId);
 // adTracker.notifyAdSkipped();
+```
+
+#### Custom CDN
+
+When MediaTailor serves ad segments from a customer-owned CDN domain, ad segments have no
+`segments.mediatailor` in their URLs. Pass your CDN's ad-segment path prefix so the tracker
+can detect them. The AWS-recommended prefix `/tm/` is already checked automatically — only set
+`segmentPrefix` if your CDN uses a different path.
+
+```java
+// /tm/ is checked automatically — no segmentPrefix needed for the common case
+NRAdConfig.mediaTailor()
+
+// Custom CDN with /tm/ ad-segment path — still automatic, no override needed
+NRAdConfig.mediaTailor()
+
+// Custom CDN with a non-/tm/ ad-segment path
+NRAdConfig.mediaTailor("/my-ads/")
+
+// Custom CDN + explicit tracking URL (POST session-init flow)
+NRAdConfig.mediaTailor("/my-ads/", trackingUrl)
 ```
 
 What the tracker emits on `VideoAdAction`:
@@ -224,7 +246,7 @@ ExoPlayer player = new ExoPlayer.Builder(this)
         .build();
 
 NRVideoPlayerConfiguration playerConfig =
-        new NRVideoPlayerConfiguration("my-player", player, true, null);
+        new NRVideoPlayerConfiguration("my-player", player, NRAdConfig.csai(), null);
 
 Integer trackerId = NRVideo.addPlayer(playerConfig);
 
@@ -356,8 +378,10 @@ if (shouldEnable) {
 |-----------|------|-------------|
 | `playerName` | `String` | Unique identifier for the video player. Used to distinguish between multiple players. |
 | `player` | `ExoPlayer` | The ExoPlayer instance to track. |
-| `isAdEnabled` | `boolean` | Set `true` if the player has an IMA ads loader; `false` otherwise. |
+| `adConfig` | `NRAdConfig` | Ad framework configuration. Pass `NRAdConfig.csai()` for IMA, `NRAdConfig.mediaTailor()` for MediaTailor, or `null` for no ad tracking. |
 | `customAttributes` | `Map<String, Object>` | Custom attributes to attach to all events from this player. |
+
+> **Upgrading from v4.2.0?** The old `boolean isAdEnabled` and `AdTrackerType` constructors are still supported but deprecated. They compile without changes — `true` maps to `NRAdConfig.csai()`, `AdTrackerType.IMA` maps to `NRAdConfig.csai()`, `AdTrackerType.MEDIA_TAILOR` maps to `NRAdConfig.mediaTailor()`. Migrate at your own pace.
 
 ### Custom Attribute Limits
 

--- a/app/src/main/java/com/newrelic/nrvideoproject/VideoPlayer.java
+++ b/app/src/main/java/com/newrelic/nrvideoproject/VideoPlayer.java
@@ -7,6 +7,7 @@ import androidx.media3.ui.PlayerView;
 import android.net.Uri;
 import android.os.Bundle;
 import android.util.Log;
+import com.newrelic.videoagent.core.NRAdConfig;
 import com.newrelic.videoagent.core.NRVideo;
 import com.newrelic.videoagent.core.NRVideoPlayerConfiguration;
 import com.newrelic.videoagent.core.NewRelicVideoAgent;
@@ -66,7 +67,7 @@ public class VideoPlayer extends AppCompatActivity {
         customAttr.put("myAttrStr", "Hello");
         customAttr.put("myAttrInt", 101);
         customAttr.put("name", "nr-video-agent-android-01-24JUL-john-starc");
-        NRVideoPlayerConfiguration playerConfiguration = new NRVideoPlayerConfiguration("test-player", player, false, customAttr);
+        NRVideoPlayerConfiguration playerConfiguration = new NRVideoPlayerConfiguration("test-player", player, (NRAdConfig) null, customAttr);
         trackerId = NRVideo.addPlayer(playerConfiguration);
         // Get the content tracker and configure aggregation
         NRTracker tracker = NewRelicVideoAgent.getInstance().getContentTracker(trackerId);

--- a/app/src/main/java/com/newrelic/nrvideoproject/VideoPlayerAds.java
+++ b/app/src/main/java/com/newrelic/nrvideoproject/VideoPlayerAds.java
@@ -4,6 +4,7 @@ import android.net.Uri;
 import android.os.Bundle;
 import com.google.ads.interactivemedia.v3.api.AdErrorEvent;
 import com.google.ads.interactivemedia.v3.api.AdEvent;
+import com.newrelic.videoagent.core.NRAdConfig;
 import com.newrelic.videoagent.core.NRVideo;
 import com.newrelic.videoagent.core.NRVideoPlayerConfiguration;
 import androidx.appcompat.app.AppCompatActivity;
@@ -80,7 +81,7 @@ public class VideoPlayerAds extends AppCompatActivity implements AdErrorEvent.Ad
         mediaSourceFactory.setAdViewProvider(playerView);
 
         player = new ExoPlayer.Builder(this).setMediaSourceFactory(mediaSourceFactory).build();
-        NRVideoPlayerConfiguration playerConfiguration = new NRVideoPlayerConfiguration("test-player-something-else", player, true, null);
+        NRVideoPlayerConfiguration playerConfiguration = new NRVideoPlayerConfiguration("test-player-something-else", player, NRAdConfig.csai(), null);
         trackerId = NRVideo.addPlayer(playerConfiguration);
         adTracker = (NRTrackerIMA) NewRelicVideoAgent.getInstance().getAdTracker(trackerId);
         // Get the ad tracker before building the loader

--- a/app/src/main/java/com/newrelic/nrvideoproject/VideoPlayerMediaTailor.java
+++ b/app/src/main/java/com/newrelic/nrvideoproject/VideoPlayerMediaTailor.java
@@ -11,9 +11,9 @@ import androidx.media3.common.MediaItem;
 import androidx.media3.exoplayer.ExoPlayer;
 import androidx.media3.ui.PlayerView;
 
+import com.newrelic.videoagent.core.NRAdConfig;
 import com.newrelic.videoagent.core.NRVideo;
 import com.newrelic.videoagent.core.NRVideoPlayerConfiguration;
-import com.newrelic.videoagent.core.NRVideoPlayerConfiguration.AdTrackerType;
 
 import org.json.JSONObject;
 
@@ -150,7 +150,7 @@ public class VideoPlayerMediaTailor extends AppCompatActivity {
         NRVideoPlayerConfiguration cfg = new NRVideoPlayerConfiguration(
                 "mediatailor-player",
                 player,
-                AdTrackerType.MEDIA_TAILOR,
+                NRAdConfig.mediaTailor(null, trackingUrl),
                 customAttrs);
 
         trackerId = NRVideo.addPlayer(cfg);


### PR DESCRIPTION
## Summary

Introduces `NRAdConfig` — a single typed object that holds all ad options for a player session, replacing the `AdTrackerType` enum. Mirrors VideoJS PR #108 (`config.ad`) for cross-platform consistency.

### NRAdConfig API

\`\`\`java
NRAdConfig.csai()                                    // Google IMA / any CSAI framework
NRAdConfig.mediaTailor()                             // AWS MediaTailor, default AWS detection
NRAdConfig.mediaTailor("/my-ads/")                   // custom CDN segment prefix override
NRAdConfig.mediaTailor("/my-ads/", trackingUrl)      // + explicit tracking URL
\`\`\`

Pass `null` as the `adConfig` argument to disable ad tracking.

### What changed

**NewRelicVideoCore**
- New `NRAdConfig` class with static factory methods
- `NRVideoPlayerConfiguration` accepts `NRAdConfig` instead of `AdTrackerType`
- `NRVideo.addPlayer()` reads `adConfig.type` and passes `NRAdConfig` to the tracker via two-arg constructor reflection

**NRMediaTailorTracker**
- `NRTrackerMediaTailor` gains a `(NRVideoConfiguration, NRAdConfig)` constructor
- `MT_DEFAULT_AD_SEGMENT_PATH = "/tm/"` — AWS-recommended CDN prefix, checked automatically for all customers (parity with VideoJS PR #106)
- `segmentPrefix` threaded through `MTHlsParser` and `MTDashParser` for non-`/tm/` CDN paths
- `explicitlyConfigured` flag — tracker activates unconditionally when `NRAdConfig.mediaTailor()` is passed, enabling fully custom CDN manifest domains
- `whichMarkerMatched()` logs which detection path fired: aws-hostname | /tm/ | custom
- Structured log tags: `[MT][CONFIG]` `[MT][DETECT]` `[MT][HLS]` `[MT][DASH]` `[MT][TRACK]` `[MT][EVENT]`

**Sample app**
- `VideoPlayerMediaTailor` updated to `NRAdConfig.mediaTailor(null, trackingUrl)`
- `VideoPlayer` and `VideoPlayerAds` updated to `null` / `NRAdConfig.csai()`

**Docs**
- `README.md` — setup examples updated to new API with custom CDN variants
- `CHANGELOG.md` — Unreleased section updated

## Test plan

- [ ] `NRVideoPlayerConfiguration` accepts `NRAdConfig` and `null`
- [ ] Correct tracker created for each `NRAdConfig` type (mediaTailor / csai / null)
- [ ] MediaTailor tracker activates on standard AWS domains
- [ ] MediaTailor tracker activates on custom CDN domains via explicit `NRAdConfig.mediaTailor()`
- [ ] `/tm/` ad segments detected automatically (`via=/tm/` in manifest dump)
- [ ] Custom `segmentPrefix` detected (`via=custom:'...'` in manifest dump)
- [ ] Tracking API fallback works when manifest detection yields 0 breaks
- [ ] Full ad lifecycle: `AD_BREAK_START` → `AD_START` → `AD_QUARTILE` (25/50/75%) → `AD_END` → `AD_BREAK_END`
- [ ] `./gradlew clean build` passes