### PR TITLE
fix: Refactor QOE

### DIFF
--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/qoe/NRQoEAggregator.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/qoe/NRQoEAggregator.java
@@ -1,0 +1,541 @@
+package com.newrelic.videoagent.core.qoe;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static com.newrelic.videoagent.core.NRDef.CONTENT_REQUEST;
+import static com.newrelic.videoagent.core.NRDef.CONTENT_START;
+import static com.newrelic.videoagent.core.NRDef.CONTENT_BUFFER_END;
+import static com.newrelic.videoagent.core.NRDef.CONTENT_RENDITION_CHANGE;
+import static com.newrelic.videoagent.core.NRDef.CONTENT_PAUSE;
+import static com.newrelic.videoagent.core.NRDef.CONTENT_RESUME;
+
+/**
+ * Standalone, thread-safe QoE (Quality of Experience) aggregator.
+ */
+public final class NRQoEAggregator {
+
+    // ---- Lifecycle gate ----------------------------------------------------
+    private boolean hasReceivedRequest;
+
+    // ---- Basic QoE KPIs ----------------------------------------------------
+    private Long qoePeakBitrate;
+    private Boolean qoeHadPlaybackError;
+    private Boolean qoeHadStartupError;
+    private Long qoeTotalRebufferingTime;
+    private Long qoeBitrateSum;
+    private Long qoeBitrateCount;
+    private Long qoeLastTrackedBitrate;
+    private Long qoeStartupTime;
+
+    // ---- Startup-period exclusions -----------------------------------------
+    private Long startupPeriodAdTime;
+    private Long startupPeriodPauseTime;
+    private boolean hasContentStarted;
+    private boolean initialBufferingHappened;
+
+    // ---- Download-rate tracking --------------------------------------------
+    private Long qoeDownloadRateSum;
+    private Long qoeDownloadRateCount;
+    private Long qoeMinDownloadRate;
+    private Long qoeMaxDownloadRate;
+
+    // ---- Rendition switch metrics ------------------------------------------
+    private long qoeTotalSwitchUps;
+    private long qoeTotalSwitchDowns;
+    private long qoeTotalTimeSwitchedDown;
+    private long qoeMaxRenditionBitrate;
+    private Long qoeSwitchedDownSinceMs;
+
+    // ---- Pause-time tracking -----------------------------------------------
+    private long qoeTotalPauseTime;
+    private Long qoePauseStartMs;
+
+    // ---- Distinct renditions (keyed by width*height) -----------------------
+    private final Set<Long> qoePlayedRenditions = new HashSet<>();
+
+    // ---- Time-weighted bitrate ---------------------------------------------
+    private Long qoeCurrentBitrate;
+    private Long qoeLastRenditionChangeTime;
+    private Long qoeTotalBitrateWeightedTime;
+    private Long qoeTotalActiveTime;
+    private boolean qoeBitrateTimerPaused;
+
+    public NRQoEAggregator() {
+        initState();
+    }
+
+    /** Initial values */
+    private void initState() {
+        hasReceivedRequest = false;
+
+        qoePeakBitrate = 0L;
+        qoeHadPlaybackError = false;
+        qoeHadStartupError = false;
+        qoeTotalRebufferingTime = 0L;
+        qoeBitrateSum = 0L;
+        qoeBitrateCount = 0L;
+        qoeLastTrackedBitrate = null;
+        qoeStartupTime = null;
+
+        startupPeriodAdTime = 0L;
+        startupPeriodPauseTime = 0L;
+        hasContentStarted = false;
+        initialBufferingHappened = false;
+
+        qoeCurrentBitrate = null;
+        qoeLastRenditionChangeTime = null;
+        qoeTotalBitrateWeightedTime = 0L;
+        qoeTotalActiveTime = 0L;
+        qoeBitrateTimerPaused = false;
+
+        qoeDownloadRateSum = 0L;
+        qoeDownloadRateCount = 0L;
+        qoeMinDownloadRate = null;
+        qoeMaxDownloadRate = null;
+
+        qoeTotalSwitchUps = 0L;
+        qoeTotalSwitchDowns = 0L;
+        qoeTotalTimeSwitchedDown = 0L;
+        qoeMaxRenditionBitrate = 0L;
+        qoeSwitchedDownSinceMs = null;
+
+        qoeTotalPauseTime = 0L;
+        qoePauseStartMs = null;
+
+        qoePlayedRenditions.clear();
+    }
+
+    // =========================================================================
+    // Public API (all synchronized)
+    // =========================================================================
+
+    /**
+     * Feed one fully-assembled content event. Runs the always-on extractors (download rate,
+     * bitrate, renditions) and dispatches by action. {@code isPlaying}/{@code adBreakActive}
+     * are reserved for a later phase (bitrate timer is currently driven by explicit calls).
+     */
+    public synchronized void processAction(String action, Map<String, Object> attributes,
+                                           boolean isPlaying, boolean adBreakActive) {
+        if (attributes == null) {
+            attributes = new HashMap<>();
+        }
+
+        // Always-on extractors (run for every content event, as getAttributes() did before).
+        trackDownloadRateMetrics(attributes);
+        trackBitrateFromProcessedAttributes(action, attributes);
+        trackPlayedRenditions(attributes);
+
+        if (CONTENT_REQUEST.equals(action)) {
+            hasReceivedRequest = true;
+        } else if (CONTENT_START.equals(action)) {
+            handleStart(attributes);
+        } else if (CONTENT_BUFFER_END.equals(action)) {
+            handleBufferEnd(attributes);
+        } else if (CONTENT_RENDITION_CHANGE.equals(action)) {
+            handleRenditionChange(attributes);
+        } else if (CONTENT_PAUSE.equals(action)) {
+            handlePause();
+        } else if (CONTENT_RESUME.equals(action)) {
+            handleResume();
+        }
+    }
+
+    /**
+     * Build the QoE KPI map. Returns {@code null} until a CONTENT_REQUEST has been fed (gate).
+     *
+     * @param realtimePlaytimeMs the tracker-computed real-time playtime (used for totalPlaytime
+     *                           and the rebufferingRatio denominator — these depend on
+     *                           tracker-private state, so they are passed in).
+     */
+    public synchronized Map<String, Object> generateAggregateAttributes(long realtimePlaytimeMs) {
+        if (!hasReceivedRequest) {
+            return null;
+        }
+
+        Map<String, Object> kpiAttributes = new HashMap<>();
+
+        if (qoePeakBitrate != null && qoePeakBitrate > 0) {
+            kpiAttributes.put("peakBitrate", qoePeakBitrate);
+        }
+
+        if (qoeHadPlaybackError == null) {
+            qoeHadPlaybackError = false;
+        }
+        kpiAttributes.put("hadPlaybackError", qoeHadPlaybackError);
+
+        if (qoeTotalRebufferingTime == null) {
+            qoeTotalRebufferingTime = 0L;
+        }
+        kpiAttributes.put("totalRebufferingTime", qoeTotalRebufferingTime);
+
+        long elapsedTime = realtimePlaytimeMs;
+
+        if (elapsedTime > 0) {
+            double rebufferingRatio = ((double) qoeTotalRebufferingTime / elapsedTime) * 100;
+            kpiAttributes.put("rebufferingRatio", rebufferingRatio);
+        } else {
+            kpiAttributes.put("rebufferingRatio", 0.0);
+        }
+
+        kpiAttributes.put("totalPlaytime", elapsedTime);
+
+        Long timeWeightedAverage = calculateTimeWeightedAverageBitrate();
+        if (timeWeightedAverage != null) {
+            kpiAttributes.put("averageBitrate", timeWeightedAverage);
+        } else if (qoeBitrateCount != null && qoeBitrateCount > 0 && qoeBitrateSum != null) {
+            long averageBitrate = Math.round((double) qoeBitrateSum / qoeBitrateCount);
+            kpiAttributes.put("averageBitrate", averageBitrate);
+        }
+
+        kpiAttributes.put("qoeAggregateVersion", "1.1.0");
+
+        if (qoeStartupTime != null && qoeStartupTime >= 0) {
+            kpiAttributes.put("startupTime", qoeStartupTime);
+        } else {
+            kpiAttributes.put("startupTime", 0L);
+        }
+
+        if (qoeHadStartupError == null) {
+            qoeHadStartupError = false;
+        }
+        kpiAttributes.put("hadStartupError", qoeHadStartupError);
+
+        if (qoeDownloadRateCount != null && qoeDownloadRateCount > 0) {
+            long avgDownloadRate = Math.round((double) qoeDownloadRateSum / qoeDownloadRateCount);
+            kpiAttributes.put("avgDownloadRate", avgDownloadRate);
+        }
+        if (qoeMinDownloadRate != null) {
+            kpiAttributes.put("minDownloadRate", qoeMinDownloadRate);
+        }
+        if (qoeMaxDownloadRate != null) {
+            kpiAttributes.put("maxDownloadRate", qoeMaxDownloadRate);
+        }
+
+        kpiAttributes.put("totalSwitchUps", qoeTotalSwitchUps);
+        kpiAttributes.put("totalSwitchDowns", qoeTotalSwitchDowns);
+        long openMs = (qoeSwitchedDownSinceMs == null) ? 0L : System.currentTimeMillis() - qoeSwitchedDownSinceMs;
+        kpiAttributes.put("totalTimeSwitchedDown", safeAdd(qoeTotalTimeSwitchedDown, openMs));
+
+        long openPauseMs = (qoePauseStartMs == null) ? 0L : System.currentTimeMillis() - qoePauseStartMs;
+        kpiAttributes.put("totalPauseTime", safeAdd(qoeTotalPauseTime, openPauseMs));
+
+        kpiAttributes.put("totalRenditions", (long) qoePlayedRenditions.size());
+
+        return kpiAttributes;
+    }
+
+    /** Reset per-view QoE state (mirrors the old resetQoeMetrics, KPI fields only). */
+    public synchronized void reset() {
+        qoePeakBitrate = null;
+        qoeHadPlaybackError = false;
+        qoeHadStartupError = false;
+        qoeTotalRebufferingTime = 0L;
+        qoeBitrateSum = 0L;
+        qoeBitrateCount = 0L;
+        qoeLastTrackedBitrate = null;
+        qoeStartupTime = null;
+        startupPeriodAdTime = null;
+        startupPeriodPauseTime = 0L;
+        hasContentStarted = false;
+        initialBufferingHappened = false;
+
+        qoeCurrentBitrate = null;
+        qoeLastRenditionChangeTime = null;
+        qoeTotalBitrateWeightedTime = 0L;
+        qoeTotalActiveTime = 0L;
+        qoeBitrateTimerPaused = false;
+
+        qoeDownloadRateSum = 0L;
+        qoeDownloadRateCount = 0L;
+        qoeMinDownloadRate = null;
+        qoeMaxDownloadRate = null;
+
+        qoeTotalSwitchUps = 0L;
+        qoeTotalSwitchDowns = 0L;
+        qoeTotalTimeSwitchedDown = 0L;
+        qoeMaxRenditionBitrate = 0L;
+        qoeSwitchedDownSinceMs = null;
+
+        qoeTotalPauseTime = 0L;
+        qoePauseStartMs = null;
+
+        qoePlayedRenditions.clear();
+
+        hasReceivedRequest = false;
+    }
+
+    /** Pre-roll ad time observed before CONTENT_START (excluded from startup time). */
+    public synchronized void setStartupAdTime(long ms) {
+        startupPeriodAdTime = ms;
+    }
+
+    /** Pause time during the startup period; ignored once content has started. */
+    public synchronized void addStartupPauseTime(long timeSincePaused) {
+        if (hasContentStarted || timeSincePaused <= 0) {
+            return;
+        }
+        try {
+            startupPeriodPauseTime = safeAdd(startupPeriodPauseTime, timeSincePaused);
+        } catch (ArithmeticException e) {
+            startupPeriodPauseTime = timeSincePaused;
+        }
+    }
+
+    public synchronized void recordStartupError() {
+        qoeHadStartupError = true;
+    }
+
+    /** Whether CONTENT_START has been processed (used by the tracker to gate startup-pause accrual). */
+    public synchronized boolean hasContentStarted() {
+        return hasContentStarted;
+    }
+
+    public synchronized void recordPlaybackError() {
+        qoeHadPlaybackError = true;
+    }
+
+    // =========================================================================
+    // Action handlers (private, called under the lock)
+    // =========================================================================
+
+    private void handleStart(Map<String, Object> attributes) {
+        hasContentStarted = true;
+
+        if (qoeStartupTime != null) {
+            return; // Already calculated
+        }
+
+        Object tsr = attributes.get("timeSinceRequested");
+        Long timeSinceRequested = (tsr instanceof Long) ? (Long) tsr : null;
+
+        if (timeSinceRequested != null && timeSinceRequested >= 0) {
+            long totalExclusionTime = 0L;
+            if (startupPeriodAdTime != null && startupPeriodAdTime > 0) {
+                totalExclusionTime += startupPeriodAdTime;
+            }
+            if (startupPeriodPauseTime != null && startupPeriodPauseTime > 0) {
+                totalExclusionTime += startupPeriodPauseTime;
+            }
+            qoeStartupTime = Math.max(timeSinceRequested - totalExclusionTime, 0L);
+        } else {
+            qoeStartupTime = 0L;
+        }
+    }
+
+    private void handleBufferEnd(Map<String, Object> attributes) {
+        Object timeSinceBufferBegin = attributes.get("timeSinceBufferBegin");
+        if (timeSinceBufferBegin instanceof Long && initialBufferingHappened) {
+            try {
+                qoeTotalRebufferingTime = safeAdd(qoeTotalRebufferingTime, (Long) timeSinceBufferBegin);
+            } catch (ArithmeticException e) {
+                qoeTotalRebufferingTime = (Long) timeSinceBufferBegin;
+            }
+        }
+        if (!initialBufferingHappened) {
+            initialBufferingHappened = true;
+        }
+    }
+
+    private void handleRenditionChange(Map<String, Object> attributes) {
+        Object shift = attributes.get("shift");
+        if ("up".equals(shift))   qoeTotalSwitchUps++;
+        if ("down".equals(shift)) qoeTotalSwitchDowns++;
+
+        Long bitrate = extractBitrateValue(attributes.get("contentRenditionBitrate"));
+        if (bitrate == null || bitrate <= 0) return;
+        long now = System.currentTimeMillis();
+
+        // Recovered to/above the session peak -> close the open below-max interval.
+        if (qoeSwitchedDownSinceMs != null && bitrate >= qoeMaxRenditionBitrate) {
+            qoeTotalTimeSwitchedDown = safeAdd(qoeTotalTimeSwitchedDown, now - qoeSwitchedDownSinceMs);
+            qoeSwitchedDownSinceMs = null;
+        }
+        // New session peak.
+        if (bitrate > qoeMaxRenditionBitrate) {
+            qoeMaxRenditionBitrate = bitrate;
+        }
+        // Dropped below the peak with no interval open -> start one.
+        if (bitrate < qoeMaxRenditionBitrate && qoeSwitchedDownSinceMs == null) {
+            qoeSwitchedDownSinceMs = now;
+        }
+    }
+
+    private void handlePause() {
+        qoePauseStartMs = System.currentTimeMillis();
+    }
+
+    private void handleResume() {
+        if (qoePauseStartMs != null) {
+            qoeTotalPauseTime = safeAdd(qoeTotalPauseTime, System.currentTimeMillis() - qoePauseStartMs);
+            qoePauseStartMs = null;
+        }
+    }
+
+    // =========================================================================
+    // Bitrate timer
+    // =========================================================================
+
+    public synchronized void pauseBitrateTimer() {
+        if (qoeBitrateTimerPaused) {
+            return;
+        }
+        if (qoeCurrentBitrate != null && qoeLastRenditionChangeTime != null && qoeCurrentBitrate > 0) {
+            long currentTime = System.currentTimeMillis();
+            if (qoeLastRenditionChangeTime > 0 && currentTime >= qoeLastRenditionChangeTime) {
+                long segmentDuration = currentTime - qoeLastRenditionChangeTime;
+                if (segmentDuration > 0) {
+                    if (qoeCurrentBitrate <= Long.MAX_VALUE / segmentDuration) {
+                        try {
+                            qoeTotalBitrateWeightedTime = safeAdd(qoeTotalBitrateWeightedTime, qoeCurrentBitrate * segmentDuration);
+                            qoeTotalActiveTime = safeAdd(qoeTotalActiveTime, segmentDuration);
+                        } catch (ArithmeticException e) {
+                            qoeTotalBitrateWeightedTime = 0L;
+                            qoeTotalActiveTime = 0L;
+                        }
+                    }
+                }
+            }
+        }
+        qoeBitrateTimerPaused = true;
+    }
+
+    public synchronized void resumeBitrateTimer() {
+        if (!qoeBitrateTimerPaused) {
+            return;
+        }
+        qoeLastRenditionChangeTime = System.currentTimeMillis();
+        qoeBitrateTimerPaused = false;
+    }
+
+    private void updateTimeWeightedBitrate(Long newBitrate) {
+        long currentTime = System.currentTimeMillis();
+        if (qoeCurrentBitrate != null && qoeLastRenditionChangeTime != null && qoeCurrentBitrate > 0) {
+            if (qoeLastRenditionChangeTime > 0 && currentTime >= qoeLastRenditionChangeTime) {
+                long segmentDuration = currentTime - qoeLastRenditionChangeTime;
+                if (segmentDuration > 0) {
+                    if (qoeCurrentBitrate <= Long.MAX_VALUE / segmentDuration) {
+                        try {
+                            qoeTotalBitrateWeightedTime = safeAdd(qoeTotalBitrateWeightedTime, qoeCurrentBitrate * segmentDuration);
+                            qoeTotalActiveTime = safeAdd(qoeTotalActiveTime, segmentDuration);
+                        } catch (ArithmeticException e) {
+                            qoeTotalBitrateWeightedTime = 0L;
+                            qoeTotalActiveTime = 0L;
+                        }
+                    }
+                }
+            }
+        }
+        qoeCurrentBitrate = newBitrate;
+        qoeLastRenditionChangeTime = currentTime;
+    }
+
+    private Long calculateTimeWeightedAverageBitrate() {
+        if (!qoeBitrateTimerPaused && qoeCurrentBitrate != null && qoeLastRenditionChangeTime != null && qoeCurrentBitrate > 0) {
+            long currentTime = System.currentTimeMillis();
+            if (qoeLastRenditionChangeTime > 0 && currentTime >= qoeLastRenditionChangeTime) {
+                long currentSegmentDuration = currentTime - qoeLastRenditionChangeTime;
+                if (currentSegmentDuration > 0) {
+                    if (qoeCurrentBitrate <= Long.MAX_VALUE / currentSegmentDuration) {
+                        try {
+                            long totalWeightedTime = safeAdd(qoeTotalBitrateWeightedTime, qoeCurrentBitrate * currentSegmentDuration);
+                            long totalTime = safeAdd(qoeTotalActiveTime, currentSegmentDuration);
+                            if (totalTime > 0) {
+                                return Math.round((double) totalWeightedTime / totalTime);
+                            }
+                        } catch (ArithmeticException e) {
+                            qoeTotalBitrateWeightedTime = 0L;
+                            qoeTotalActiveTime = 0L;
+                        }
+                    }
+                } else if (qoeTotalActiveTime > 0) {
+                    return Math.round((double) qoeTotalBitrateWeightedTime / qoeTotalActiveTime);
+                } else if (qoeTotalActiveTime == 0 && currentSegmentDuration == 0) {
+                    return qoeCurrentBitrate;
+                }
+            }
+        }
+
+        if (qoeTotalActiveTime != null && qoeTotalActiveTime > 0 && qoeTotalBitrateWeightedTime != null) {
+            return Math.round((double) qoeTotalBitrateWeightedTime / qoeTotalActiveTime);
+        }
+
+        return null;
+    }
+
+    // =========================================================================
+    // Always-on extractors
+    // =========================================================================
+
+    private void trackBitrateFromProcessedAttributes(String action, Map<String, Object> processedAttributes) {
+        Long currentBitrate = extractBitrateValue(processedAttributes.get("contentBitrate"));
+        if (currentBitrate == null || currentBitrate <= 0) {
+            return;
+        }
+        if (qoeLastTrackedBitrate != null && qoeLastTrackedBitrate.equals(currentBitrate)) {
+            return;
+        }
+        qoeLastTrackedBitrate = currentBitrate;
+        updateQoeBitrateMetrics(currentBitrate, action);
+    }
+
+    private void trackDownloadRateMetrics(Map<String, Object> processedAttributes) {
+        Long sample = extractBitrateValue(processedAttributes.get("contentNetworkDownloadBitrate"));
+        if (sample == null || sample <= 0) {
+            return;
+        }
+        if (qoeDownloadRateCount < Long.MAX_VALUE - 1) {
+            qoeDownloadRateSum = safeAdd(qoeDownloadRateSum, sample);
+            qoeDownloadRateCount++;
+        }
+        qoeMinDownloadRate = (qoeMinDownloadRate == null) ? sample : Math.min(qoeMinDownloadRate, sample);
+        qoeMaxDownloadRate = (qoeMaxDownloadRate == null) ? sample : Math.max(qoeMaxDownloadRate, sample);
+    }
+
+    private void trackPlayedRenditions(Map<String, Object> processedAttributes) {
+        Long w = extractBitrateValue(processedAttributes.get("contentRenditionWidth"));
+        Long h = extractBitrateValue(processedAttributes.get("contentRenditionHeight"));
+        if (w != null && w > 0 && h != null && h > 0) {
+            qoePlayedRenditions.add(w * h);
+        }
+    }
+
+    private void updateQoeBitrateMetrics(Long bitrate, String action) {
+        updateTimeWeightedBitrate(bitrate);
+        if (qoePeakBitrate == null || bitrate > qoePeakBitrate) {
+            qoePeakBitrate = bitrate;
+        }
+        if (qoeBitrateCount < Long.MAX_VALUE - 1) {
+            qoeBitrateSum = safeAdd(qoeBitrateSum, bitrate);
+            qoeBitrateCount++;
+        }
+    }
+
+    // =========================================================================
+    // Utilities
+    // =========================================================================
+
+    private static Long extractBitrateValue(Object bitrateObj) {
+        if (bitrateObj instanceof Long) {
+            return (Long) bitrateObj;
+        } else if (bitrateObj instanceof Integer) {
+            return ((Integer) bitrateObj).longValue();
+        } else if (bitrateObj instanceof Double) {
+            return ((Double) bitrateObj).longValue();
+        } else if (bitrateObj instanceof Float) {
+            return ((Float) bitrateObj).longValue();
+        }
+        return null;
+    }
+
+    /** Overflow-safe long addition (Math.addExact equivalent, API 16+ safe). */
+    private static long safeAdd(long a, long b) {
+        long result = a + b;
+        if (((a ^ result) & (b ^ result)) < 0) {
+            throw new ArithmeticException("long overflow");
+        }
+        return result;
+    }
+}

--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/qoe/NRQoEAggregator.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/qoe/NRQoEAggregator.java
@@ -171,16 +171,16 @@ public final class NRQoEAggregator {
         }
         kpiAttributes.put("totalRebufferingTime", qoeTotalRebufferingTime);
 
-        long elapsedTime = realtimePlaytimeMs;
+        long playtimeMs = realtimePlaytimeMs;
 
-        if (elapsedTime > 0) {
-            double rebufferingRatio = ((double) qoeTotalRebufferingTime / elapsedTime) * 100;
+        if (playtimeMs > 0) {
+            double rebufferingRatio = ((double) qoeTotalRebufferingTime / playtimeMs) * 100;
             kpiAttributes.put("rebufferingRatio", rebufferingRatio);
         } else {
             kpiAttributes.put("rebufferingRatio", 0.0);
         }
 
-        kpiAttributes.put("totalPlaytime", elapsedTime);
+        kpiAttributes.put("totalPlaytime", playtimeMs);
 
         Long timeWeightedAverage = calculateTimeWeightedAverageBitrate();
         if (timeWeightedAverage != null) {

--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/tracker/NRTracker.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/tracker/NRTracker.java
@@ -162,8 +162,8 @@ public class NRTracker {
         attributes = getAttributes(action, attributes);
         timeSinceTable.applyAttributes(action, attributes);
 
-        // Process QoE events that require timing attributes
-        processQoeEvents(action, attributes);
+        // Hook for subclasses that need fully-assembled (post-timeSince) attributes (e.g. QoE)
+        onQoeEvent(action, attributes);
 
         attributes.put("agentSession", getAgentSession());
         attributes.put("instrumentation.provider", "newrelic");
@@ -271,33 +271,15 @@ public class NRTracker {
         return NewRelicVideoAgent.getInstance().getSessionId();
     }
     /**
-     * Process QoE events that require timing attributes to be already applied.
-     * This method handles QOE_AGGREGATE and CONTENT_BUFFER_END events for various QoE calculations.
+     * Hook called from {@link #sendEvent} after attributes are fully assembled
+     * (post {@code getAttributes} + {@code timeSinceTable.applyAttributes}). No-op in the base
+     * class; {@link NRVideoTracker} overrides it to feed its QoE aggregator. This replaces the
+     * former {@code instanceof}-based downcast.
      *
      * @param action The event action name
-     * @param attributes The event attributes map (timing attributes already applied)
+     * @param attributes The fully-assembled event attributes (timing attributes already applied)
      */
-    private void processQoeEvents(String action, Map<String, Object> attributes) {
-        if (this instanceof NRVideoTracker) {
-            NRVideoTracker videoTracker = (NRVideoTracker) this;
-
-            if (QOE_AGGREGATE.equals(action)) {
-                // Process QOE_AGGREGATE events for startup time calculation
-                Long timeSinceRequested = (Long) attributes.get("timeSinceRequested");
-                Long timeSinceStarted = (Long) attributes.get("timeSinceStarted");
-                Long timeSinceLastError = (Long) attributes.get("timeSinceLastError");
-                videoTracker.calculateAndAddStartupTime(attributes, timeSinceRequested, timeSinceStarted, timeSinceLastError);
-            }
-            else if (CONTENT_BUFFER_END.equals(action)) {
-                // Process CONTENT_BUFFER_END events for rebuffering time calculation
-                videoTracker.calculateRebufferingTime(attributes);
-            }
-            else if (CONTENT_RENDITION_CHANGE.equals(action)) {
-                videoTracker.processQoeRenditionChange(attributes);
-            }
-            else if (CONTENT_PAUSE.equals(action) || CONTENT_RESUME.equals(action)) {
-                videoTracker.processQoePauseTime(action);
-            }
-        }
+    protected void onQoeEvent(String action, Map<String, Object> attributes) {
+        // no-op in base
     }
 }

--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/tracker/NRVideoTracker.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/tracker/NRVideoTracker.java
@@ -8,6 +8,7 @@ import com.newrelic.videoagent.core.model.NRTimeSince;
 import com.newrelic.videoagent.core.model.NRTrackerState;
 import com.newrelic.videoagent.core.utils.NRLog;
 import com.newrelic.videoagent.core.harvest.QoeProvider;
+import com.newrelic.videoagent.core.qoe.NRQoEAggregator;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
@@ -15,9 +16,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
-import java.util.Set;
-import java.util.Collections;
-import java.util.concurrent.ConcurrentHashMap;
 
 
 import static com.newrelic.videoagent.core.NRDef.*;
@@ -50,47 +48,10 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
     private String bufferType;
     private NRTimeSince lastAdTimeSince;
 
-    // QoE (Quality of Experience) tracking fields
-    private Long qoePeakBitrate;
-    private Boolean qoeHadPlaybackError;
-    private Boolean qoeHadStartupError;
-    private Long qoeTotalRebufferingTime;
-    private Long qoeBitrateSum;
-    private Long qoeBitrateCount;
-    private Long qoeLastTrackedBitrate;
-    private Long qoeStartupTime; // Cached startup time, calculated once per view session
-    private Long startupPeriodAdTime; // Ad time that occurred during startup period
-    private Long startupPeriodPauseTime; // Pause time that occurred during startup period
-    private boolean hasContentStarted; // Tracks whether content has successfully started (for buffer classification)
-    private boolean initialBufferingHappened; // Tracks if initial buffering completed
-
-    // QoE network download-rate tracking (samples of contentNetworkDownloadBitrate)
-    private Long qoeDownloadRateSum;
-    private Long qoeDownloadRateCount;
-    private Long qoeMinDownloadRate;
-    private Long qoeMaxDownloadRate;
-
-    // QOE switch ups and downs
-    private long qoeTotalSwitchUps;
-    private long qoeTotalSwitchDowns;
-    private long qoeTotalTimeSwitchedDown;
-    private long qoeMaxRenditionBitrate;  // highest rendition bitrate seen this view
-    private Long qoeSwitchedDownSinceMs;
-
-    // QOE total pause time
-    private long qoeTotalPauseTime;
-    private Long qoePauseStartMs; // start of open pause; null = not paused
-
-    // QOE distinct renditions (keyed by width*height)
-    private final Set<Long> qoePlayedRenditions =
-            Collections.newSetFromMap(new ConcurrentHashMap<Long, Boolean>());
-
-    // Time-weighted bitrate calculation fields
-    private Long qoeCurrentBitrate;
-    private Long qoeLastRenditionChangeTime;
-    private Long qoeTotalBitrateWeightedTime;
-    private Long qoeTotalActiveTime;
-    private boolean qoeBitrateTimerPaused;
+    // QoE (Quality of Experience) aggregator — owns all QoE KPI state + math (thread-safe).
+    // Startup ad time is still computed by the tracker (from totalAdPlaytime) and pushed in.
+    private final NRQoEAggregator qoeAggregator = new NRQoEAggregator();
+    private Long startupPeriodAdTime; // Ad time during startup; pushed into the aggregator at CONTENT_START
 
     // QOE_AGGREGATE provider fields
     private boolean qoeProviderRegistered = false;
@@ -169,43 +130,8 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
     }
 
     private void initializeTracker() {
-
-        // Initialize QoE tracking fields
-        qoePeakBitrate = 0L;
-        qoeHadPlaybackError = false;
-        qoeHadStartupError = false;
-        qoeTotalRebufferingTime = 0L;
-        qoeBitrateSum = 0L;
-        qoeBitrateCount = 0L;
-        qoeLastTrackedBitrate = null;
-        qoeStartupTime = null; // Will be calculated during first QOE_AGGREGATE event
-
-        // Initialize startup time calculation fields
+        // QoE KPI state lives in the aggregator; only the tracker-side startup ad time is reset here.
         startupPeriodAdTime = 0L;
-        startupPeriodPauseTime = 0L;
-        hasContentStarted = false;
-        initialBufferingHappened = false;
-
-        // Initialize time-weighted bitrate tracking
-        qoeCurrentBitrate = null;
-        qoeLastRenditionChangeTime = null;
-        qoeTotalBitrateWeightedTime = 0L;
-        qoeTotalActiveTime = 0L;
-        qoeBitrateTimerPaused = false;
-
-        qoeDownloadRateSum = 0L;
-        qoeDownloadRateCount = 0L;
-        qoeMinDownloadRate = null;
-        qoeMaxDownloadRate = null;
-
-        qoeTotalSwitchUps = 0L;
-        qoeTotalSwitchDowns = 0L;
-        qoeTotalTimeSwitchedDown = 0L;
-        qoeMaxRenditionBitrate = 0L;
-        qoeSwitchedDownSinceMs = null;
-
-        qoeTotalPauseTime = 0L;
-        qoePauseStartMs = null;
     }
 
     /**
@@ -218,6 +144,12 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
         stopHeartbeat();
         // Clean up pending QOE to prevent memory leaks
         pendingQoeForNextHarvest = null;
+        // Unregister the QOE provider so a disposed tracker is no longer polled at harvest.
+        if (qoeProviderRegistered && NRVideo.getInstance() != null
+                && NRVideo.getInstance().getHarvestManager() != null) {
+            NRVideo.getInstance().getHarvestManager().unregisterQoeProvider(this);
+        }
+        qoeProviderRegistered = false;
     }
 
     /**
@@ -363,22 +295,30 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
             attr.put("contentIsLive", getIsLive());
         }
         attr = super.getAttributes(action, attr);
-        // QoE: Track bitrate after all attributes are processed (including contentBitrate)
-        if (!state.isAd && !QOE_AGGREGATE.equals(action)) {
-            trackBitrateFromProcessedAttributes(action, attr);
-            trackDownloadRateMetrics(attr);
-            trackPlayedRenditions(attr);
-        }
-
-        // Cache attributes for non-QOE events (for thread-safe QOE generation)
-        // QOE generation runs on harvest background thread but ExoPlayer requires main thread access.
-        // By caching attributes here (called on main thread during video events), QOE can safely
-        // use these attributes without accessing the player directly.
-        if (attr != null && !QOE_AGGREGATE.equals(action)) {
-            cachedStandardAttributes = new HashMap<>(attr);
-        }
-
+        // QoE feed + attribute caching now happen in onQoeEvent(), after timeSince attributes
+        // are applied (NRTracker.sendEvent), so the aggregator always sees a fully-assembled map.
         return attr;
+    }
+
+    /**
+     * QoE hook — fires from NRTracker.sendEvent after attributes are fully assembled
+     * (post getAttributes + timeSinceTable.applyAttributes). Feeds the aggregator and caches the
+     * fully-assembled snapshot used to build the QOE_AGGREGATE envelope at harvest time.
+     */
+    @Override
+    protected void onQoeEvent(String action, Map<String, Object> attributes) {
+        if (state.isAd || QOE_AGGREGATE.equals(action) || action == null || !action.startsWith("CONTENT_")) {
+            return;
+        }
+        // Push the startup ad time before CONTENT_START is processed by the aggregator.
+        if (CONTENT_START.equals(action)) {
+            qoeAggregator.setStartupAdTime(startupPeriodAdTime == null ? 0L : startupPeriodAdTime);
+        }
+        // Phase 1: adBreakActive is inert (false); the bitrate timer is still driven by the
+        // explicit sender call-sites. isPlaying is reserved for a later phase.
+        qoeAggregator.processAction(action, attributes, state.isPlaying, false);
+        // Cache the fully-assembled snapshot for the harvest-time QOE envelope.
+        cachedStandardAttributes = new HashMap<>(attributes);
     }
     public void updatePlaytime() {
         if (playtimeSinceLastEventTimestamp > 0) {
@@ -437,16 +377,12 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
                 }
                 numberOfVideos++;
 
-                // QoE: Mark that content has successfully started (for buffer type classification)
-                hasContentStarted = true;
-
+                // startupPeriodAdTime (set above) is pushed into the aggregator by onQoeEvent
+                // when it processes CONTENT_START; the aggregator caches startup time there too.
                 sendVideoEvent(CONTENT_START);
 
-                // Calculate and cache startup time at CONTENT_START (for QOE reporting)
-                calculateAndCacheStartupTime();
-
                 // Resume bitrate timer when content starts playing
-                resumeBitrateTimer();
+                qoeAggregator.resumeBitrateTimer();
             }
             playtimeSinceLastEventTimestamp = System.currentTimeMillis();
         }
@@ -467,7 +403,7 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
             } else {
                 sendVideoEvent(CONTENT_PAUSE);
                 // Pause bitrate timer during pause to exclude paused time from average
-                pauseBitrateTimer();
+                qoeAggregator.pauseBitrateTimer();
             }
             playtimeSinceLastEventTimestamp = 0L;
         }
@@ -482,19 +418,13 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
                 state.chrono.start();
             }
 
-            // QoE: Calculate pause time during startup period for content events
-            if (!state.isAd && !hasContentStarted) {
-                // Content hasn't started yet, so this pause time should be excluded from startup calculation
+            // QoE: accumulate startup-period pause time (excluded from startup time).
+            // Only meaningful before content starts; the aggregator ignores it once started.
+            if (!state.isAd && !qoeAggregator.hasContentStarted()) {
                 Map<String, Object> resumeAttributes = getAttributes(CONTENT_RESUME, null);
                 Object timeSincePaused = resumeAttributes.get("timeSincePaused");
-
-                if (timeSincePaused instanceof Long && ((Long) timeSincePaused) > 0) {
-                    try {
-                        startupPeriodPauseTime = safeAdd(startupPeriodPauseTime, (Long) timeSincePaused);
-                    } catch (ArithmeticException e) {
-                        NRLog.w("QoE startup pause time accumulation overflow");
-                        startupPeriodPauseTime = (Long) timeSincePaused;
-                    }
+                if (timeSincePaused instanceof Long) {
+                    qoeAggregator.addStartupPauseTime((Long) timeSincePaused);
                 }
             }
 
@@ -504,7 +434,7 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
                 sendVideoEvent(CONTENT_RESUME);
                 // Resume bitrate timer when playback resumes (only if not buffering or seeking)
                 if (!state.isBuffering && !state.isSeeking) {
-                    resumeBitrateTimer();
+                    qoeAggregator.resumeBitrateTimer();
                 }
             }
             if (!state.isBuffering && !state.isSeeking) {
@@ -550,8 +480,10 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
             playtimeSinceLastEventTimestamp = 0L;
             playtimeSinceLastEvent = 0L;
             totalPlaytime = 0L;
-            // Reset QoE metrics for new view session
-            resetQoeMetrics();
+            // Reset QoE state for new view session (aggregator KPIs + tracker-side dirty-check
+            // snapshot). pendingQoeForNextHarvest is intentionally NOT cleared here.
+            qoeAggregator.reset();
+            lastSentQoeKpis = null;
         }
     }
 
@@ -565,7 +497,7 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
             } else {
                 sendVideoEvent(CONTENT_SEEK_START);
                 // Pause bitrate timer during seeking to exclude seek time from average
-                pauseBitrateTimer();
+                qoeAggregator.pauseBitrateTimer();
             }
             playtimeSinceLastEventTimestamp = 0L;
         }
@@ -582,7 +514,7 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
                 sendVideoEvent(CONTENT_SEEK_END);
                 // Resume bitrate timer when seeking ends (only if not buffering or paused)
                 if (!state.isBuffering && !state.isPaused) {
-                    resumeBitrateTimer();
+                    qoeAggregator.resumeBitrateTimer();
                 }
             }
             if (!state.isBuffering && !state.isPaused) {
@@ -605,7 +537,7 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
             } else {
                 sendVideoEvent(CONTENT_BUFFER_START);
                 // Pause bitrate timer during buffering to exclude buffering time from average
-                pauseBitrateTimer();
+                qoeAggregator.pauseBitrateTimer();
             }
             playtimeSinceLastEventTimestamp = 0L;
         }
@@ -628,7 +560,7 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
                 sendVideoEvent(CONTENT_BUFFER_END);
                 // Resume bitrate timer when buffering ends (only if not seeking or paused)
                 if (!state.isSeeking && !state.isPaused) {
-                    resumeBitrateTimer();
+                    qoeAggregator.resumeBitrateTimer();
                 }
             }
             if (!state.isSeeking && !state.isPaused) {
@@ -708,11 +640,11 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
             boolean shouldSend = (harvestCycleNumber - 1) % intervalMultiplier == 0;
 
             if (shouldSend) {
-                // Calculate current QoE KPIs
-                Map<String, Object> currentKpis = calculateQOEKpiAttributes();
+                // Calculate current QoE KPIs from the aggregator
+                Map<String, Object> currentKpis = qoeAggregator.generateAggregateAttributes(computeRealtimePlaytimeMs());
 
                 // Dirty check: Only send if KPI values have changed since last send
-                if (haveQoeKpisChanged(currentKpis)) {
+                if (currentKpis != null && haveQoeKpisChanged(currentKpis)) {
                     // Build QOE event with standard attributes
                     Map<String, Object> qoeEvent = buildQoeEventWithStandardAttributes();
 
@@ -738,8 +670,12 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
      * @return Complete QOE event map with standard attributes
      */
     private Map<String, Object> buildQoeEventWithStandardAttributes() {
-        // Start with QOE KPI attributes
-        Map<String, Object> qoeEvent = calculateQOEKpiAttributes();
+        // Start with QOE KPI attributes from the aggregator (real-time playtime supplied by tracker)
+        Map<String, Object> qoeEvent = qoeAggregator.generateAggregateAttributes(computeRealtimePlaytimeMs());
+        if (qoeEvent == null) {
+            // Aggregator gate: no CONTENT_REQUEST seen yet (should not happen at build time)
+            qoeEvent = new HashMap<>();
+        }
 
         // Add filtered cached attributes (match iOS behavior)
         // Note: Cache is populated by video events (CONTENT_START, HEARTBEAT, etc.) on main thread
@@ -871,470 +807,27 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
     }
 
     /**
-     * Calculate QoE KPI attributes based on tracked metrics during playback.
-     * @return Map containing the KPI attributes
+     * Compute real-time playtime (cumulative totalPlaytime topped up with time since the last
+     * event while playing). Lives on the tracker because it reads tracker-private playtime state;
+     * passed into the aggregator so rebufferingRatio/totalPlaytime stay exact.
      */
-    private Map<String, Object> calculateQOEKpiAttributes() {
-        Map<String, Object> kpiAttributes = new HashMap<>();
-
-        // peakBitrate - Maximum contentBitrate observed during content playback
-        if (qoePeakBitrate != null && qoePeakBitrate > 0) {
-            kpiAttributes.put("peakBitrate", qoePeakBitrate);
-        }
-
-        // hadPlaybackError - Boolean indicating if CONTENT_ERROR occurred at any time during content playback
-        if (qoeHadPlaybackError == null) {
-            qoeHadPlaybackError = false;
-        }
-        kpiAttributes.put("hadPlaybackError", qoeHadPlaybackError);
-
-        // totalRebufferingTime - Total milliseconds spent rebuffering during content playback
-        if (qoeTotalRebufferingTime == null) {
-            qoeTotalRebufferingTime = 0L;
-        }
-        kpiAttributes.put("totalRebufferingTime", qoeTotalRebufferingTime);
-
-        // Calculate real-time totalPlaytime (cumulative, not reset like accumulatedVideoWatchTime)
-        // totalPlaytime is updated during video events, but we add time since last event for real-time value
-        Long elapsedTime = totalPlaytime;
-        if (elapsedTime == null) {
-            elapsedTime = 0L;
-        }
-
-        // If video is playing, add time since last video event update
+    private long computeRealtimePlaytimeMs() {
+        long elapsedTime = (totalPlaytime == null) ? 0L : totalPlaytime;
         if (state.isPlaying && playtimeSinceLastEventTimestamp > 0) {
             long timeSinceLastUpdate = System.currentTimeMillis() - playtimeSinceLastEventTimestamp;
             if (timeSinceLastUpdate > 0) {
                 elapsedTime += timeSinceLastUpdate;
             }
         }
-
-        // rebufferingRatio - Rebuffering time as a percentage of elapsed watch time
-        if (elapsedTime > 0) {
-            double rebufferingRatio = ((double) qoeTotalRebufferingTime / elapsedTime) * 100;
-            kpiAttributes.put("rebufferingRatio", rebufferingRatio);
-        } else {
-            kpiAttributes.put("rebufferingRatio", 0.0);
-        }
-
-        // totalPlaytime - Real-time cumulative playtime
-        kpiAttributes.put("totalPlaytime", elapsedTime);
-
-        // averageBitrate - Time-weighted average bitrate across all content playback
-        Long timeWeightedAverage = calculateTimeWeightedAverageBitrate();
-        if (timeWeightedAverage != null) {
-            kpiAttributes.put("averageBitrate", timeWeightedAverage);
-        } else if (qoeBitrateCount != null && qoeBitrateCount > 0 && qoeBitrateSum != null) {
-            // Fallback to simple average if time-weighted calculation is not available
-            long averageBitrate = Math.round((double) qoeBitrateSum / qoeBitrateCount);
-            kpiAttributes.put("averageBitrate", averageBitrate);
-        }
-
-        // qoeAggregateVersion - Version identifier for QOE calculation algorithm
-        kpiAttributes.put("qoeAggregateVersion", "1.1.0");
-
-        // startupTime - Cached value calculated at CONTENT_START
-        if (qoeStartupTime != null && qoeStartupTime >= 0) {
-            kpiAttributes.put("startupTime", qoeStartupTime);
-        } else {
-            kpiAttributes.put("startupTime", 0L);
-        }
-
-        // hadStartupError - Boolean indicating if error occurred before CONTENT_START
-        if (qoeHadStartupError == null) {
-            qoeHadStartupError = false;
-        }
-        kpiAttributes.put("hadStartupError", qoeHadStartupError);
-
-        // Download-rate KPIs (from contentNetworkDownloadBitrate samples)
-        if (qoeDownloadRateCount != null && qoeDownloadRateCount > 0) {
-            long avgDownloadRate = Math.round((double) qoeDownloadRateSum / qoeDownloadRateCount);
-            kpiAttributes.put("avgDownloadRate", avgDownloadRate);
-        }
-        if (qoeMinDownloadRate != null) {
-            kpiAttributes.put("minDownloadRate", qoeMinDownloadRate);
-        }
-        if (qoeMaxDownloadRate != null) {
-            kpiAttributes.put("maxDownloadRate", qoeMaxDownloadRate);
-        }
-
-        // rendition switch ups and downs
-        kpiAttributes.put("totalSwitchUps", qoeTotalSwitchUps);
-        kpiAttributes.put("totalSwitchDowns", qoeTotalSwitchDowns);
-        long openMs = (qoeSwitchedDownSinceMs == null) ? 0L : System.currentTimeMillis() - qoeSwitchedDownSinceMs;
-        kpiAttributes.put("totalTimeSwitchedDown", safeAdd(qoeTotalTimeSwitchedDown, openMs));
-
-        // totalPauseTime — bank + currently-open pause, without closing it
-        long openPauseMs = (qoePauseStartMs == null) ? 0L : System.currentTimeMillis() - qoePauseStartMs;
-        kpiAttributes.put("totalPauseTime", safeAdd(qoeTotalPauseTime, openPauseMs));
-
-        kpiAttributes.put("totalRenditions", (long) qoePlayedRenditions.size());
-
-        return kpiAttributes;
+        return elapsedTime;
     }
 
-    /**
-     * Calculate rebuffering time from CONTENT_BUFFER_END events.
-     * Called from NRTracker.processBufferEndEvent() where timing attributes are already available.
-     *
-     * @param attributes The CONTENT_BUFFER_END attributes map (timing attributes already applied)
-     */
-    public void calculateRebufferingTime(Map<String, Object> attributes) {
-        // Extract timeSinceBufferBegin which is now available after applyAttributes()
-        Object timeSinceBufferBegin = attributes.get("timeSinceBufferBegin");
-        if (timeSinceBufferBegin instanceof Long &&
-                initialBufferingHappened) { // Only count if initial buffering already completed
-            try {
-                long previousTotal = qoeTotalRebufferingTime;
-                qoeTotalRebufferingTime = safeAdd(
-                        qoeTotalRebufferingTime,
-                        (Long) timeSinceBufferBegin
-                );
-            } catch (ArithmeticException e) {
-                NRLog.w("QoE rebuffering time accumulation overflow");
-                qoeTotalRebufferingTime = (Long) timeSinceBufferBegin;
-            }
-        }
-        // Set initialBufferingHappened flag after processing this buffer event
-        if (!initialBufferingHappened) {
-            initialBufferingHappened = true;
-        }
+    /** Package-private accessor for tests. */
+    NRQoEAggregator getQoeAggregator() {
+        return qoeAggregator;
     }
 
-    // Update rendition-switch QoE metrics from a CONTENT_RENDITION_CHANGE event.
-    void processQoeRenditionChange(Map<String, Object> attributes) {
-        if (state.isAd) return;
 
-        // Switch up/down counters — driven by the player-published shift (unchanged).
-        Object shift = attributes.get("shift");
-        if ("up".equals(shift))   qoeTotalSwitchUps++;
-        if ("down".equals(shift)) qoeTotalSwitchDowns++;
-
-        // totalTimeSwitchedDown: cumulative time below the highest rendition bitrate
-        // seen so far in this view.
-        Long bitrate = extractBitrateValue(attributes.get("contentRenditionBitrate"));
-        if (bitrate == null || bitrate <= 0) return;
-        long now = System.currentTimeMillis();
-
-        // Recovered to/above the session peak → close the open below-max interval.
-        if (qoeSwitchedDownSinceMs != null && bitrate >= qoeMaxRenditionBitrate) {
-            qoeTotalTimeSwitchedDown = safeAdd(qoeTotalTimeSwitchedDown, now - qoeSwitchedDownSinceMs);
-            qoeSwitchedDownSinceMs = null;
-        }
-        // New session peak.
-        if (bitrate > qoeMaxRenditionBitrate) {
-            qoeMaxRenditionBitrate = bitrate;
-        }
-        // Dropped below the peak with no interval open → start one.
-        if (bitrate < qoeMaxRenditionBitrate && qoeSwitchedDownSinceMs == null) {
-            qoeSwitchedDownSinceMs = now;
-        }
-    }
-
-    /**
-     * Update total pause time. Opens an interval on CONTENT_PAUSE, banks it on CONTENT_RESUME.
-     * An interval still open at emit is added by the snapshot in calculateQOEKpiAttributes().
-     */
-    void processQoePauseTime(String action) {
-        if (state.isAd) return;
-        if (CONTENT_PAUSE.equals(action)) {
-            qoePauseStartMs = System.currentTimeMillis();
-        } else if (CONTENT_RESUME.equals(action) && qoePauseStartMs != null) {
-            qoeTotalPauseTime = safeAdd(qoeTotalPauseTime, System.currentTimeMillis() - qoePauseStartMs);
-            qoePauseStartMs = null;
-        }
-    }
-
-    /**
-     * Calculate and cache startup time at CONTENT_START.
-     * This method calculates startup time once and caches it for all subsequent QOE reports.
-     * Called immediately after CONTENT_START event is sent.
-     */
-    private void calculateAndCacheStartupTime() {
-        if (qoeStartupTime != null) {
-            return; // Already calculated
-        }
-
-        // Get the CONTENT_START attributes to extract timing values
-        Map<String, Object> startAttributes = getAttributes(CONTENT_START, null);
-        timeSinceTable.applyAttributes(CONTENT_START, startAttributes);
-
-        Long timeSinceRequested = (Long) startAttributes.get("timeSinceRequested");
-
-        if (timeSinceRequested != null && timeSinceRequested >= 0) {
-            Long totalExclusionTime = 0L;
-
-            // Exclude ad time that occurred during startup period
-            if (startupPeriodAdTime != null && startupPeriodAdTime > 0) {
-                totalExclusionTime += startupPeriodAdTime;
-            }
-
-            // Exclude pause time that occurred during startup period
-            if (startupPeriodPauseTime != null && startupPeriodPauseTime > 0) {
-                totalExclusionTime += startupPeriodPauseTime;
-            }
-
-            // Calculate: startupTime = timeSinceRequested - adTime - pauseTime
-            // Ensure result is non-negative
-            qoeStartupTime = Math.max(timeSinceRequested - totalExclusionTime, 0L);
-
-            NRLog.d("Startup time calculated and cached: " + qoeStartupTime + "ms");
-        } else {
-            qoeStartupTime = 0L;
-        }
-    }
-
-    /**
-     * Calculate and add startup time to QOE_AGGREGATE attributes.
-     * Called from NRTracker.sendEvent() where timing attributes are already available.
-     * @deprecated This method is kept for backward compatibility but is no longer used
-     * in the harvest-time QOE generation architecture. Use calculateAndCacheStartupTime() instead.
-     *
-     * @param attributes The QOE_AGGREGATE attributes map to add startup time to
-     * @param timeSinceRequested Time since CONTENT_REQUEST event
-     * @param timeSinceStarted Time since CONTENT_START event
-     * @param timeSinceLastError Time since CONTENT_ERROR event
-     */
-    @Deprecated
-    public void calculateAndAddStartupTime(Map<String, Object> attributes,
-                                           Long timeSinceRequested,
-                                           Long timeSinceStarted,
-                                           Long timeSinceLastError) {
-        // startupTime - Calculate once during first QOE_AGGREGATE event and cache for reuse
-        if (qoeStartupTime == null && timeSinceRequested != null) {
-            Long rawStartupTime = null;
-
-            // Calculate startup time using timeSince values
-            if (timeSinceStarted != null) {
-                // Normal startup success: rawStartupTime = timeSinceRequested - timeSinceStarted
-                rawStartupTime = timeSinceRequested - timeSinceStarted;
-            } else if (timeSinceLastError != null) {
-                // Startup failure: rawStartupTime = timeSinceRequested - timeSinceLastError
-                rawStartupTime = timeSinceRequested - timeSinceLastError;
-            }
-
-            if (rawStartupTime != null && rawStartupTime >= 0) {
-                // For content trackers only - exclude ad time and pause time from startup calculation
-                if (!state.isAd) {
-                    Long totalExclusionTime = 0L;
-
-                    // Exclude ad time that occurred during startup period
-                    if (startupPeriodAdTime != null && startupPeriodAdTime > 0) {
-                        totalExclusionTime += startupPeriodAdTime;
-                    }
-                    // Exclude pause time that occurred during startup period
-                    if (startupPeriodPauseTime != null && startupPeriodPauseTime > 0) {
-                        totalExclusionTime += startupPeriodPauseTime;
-                    }
-                    // Apply enhanced exclusion pattern: max(rawTime - adTime - pauseTime, 0)
-                    qoeStartupTime = Math.max(rawStartupTime - totalExclusionTime, 0L);
-                } else {
-                    // Ad tracker itself - use raw calculation
-                    qoeStartupTime = rawStartupTime;
-                }
-            }
-        }
-        // Include cached startup time if available (including zero for instant startup)
-        if (qoeStartupTime != null && qoeStartupTime >= 0) {
-            attributes.put("startupTime", qoeStartupTime);
-        } else {
-            attributes.put("startupTime", 0L);
-        }
-
-        // Use the tracked startup failure flag (set during error handling)
-        if (qoeHadStartupError == null) {
-            qoeHadStartupError = false;
-        }
-        attributes.put("hadStartupError", qoeHadStartupError);
-    }
-
-    /**
-     * Update time-weighted bitrate calculation when bitrate changes.
-     * This method accumulates the weighted time for each bitrate segment.
-     *
-     * @param newBitrate The new bitrate that just became active
-     */
-    private void updateTimeWeightedBitrate(Long newBitrate) {
-        long currentTime = System.currentTimeMillis();
-
-        // If we have a previous bitrate and timing, accumulate its weighted time
-        if (qoeCurrentBitrate != null && qoeLastRenditionChangeTime != null && qoeCurrentBitrate > 0) {
-            // Ensure valid timestamps
-            if (qoeLastRenditionChangeTime > 0 && currentTime >= qoeLastRenditionChangeTime) {
-                long segmentDuration = currentTime - qoeLastRenditionChangeTime;
-                if (segmentDuration > 0) {
-                    // Prevent overflow in multiplication
-                    if (qoeCurrentBitrate <= Long.MAX_VALUE / segmentDuration) {
-                        try {
-                            qoeTotalBitrateWeightedTime = safeAdd(qoeTotalBitrateWeightedTime, qoeCurrentBitrate * segmentDuration);
-                            qoeTotalActiveTime = safeAdd(qoeTotalActiveTime, segmentDuration);
-                        } catch (ArithmeticException e) {
-                            // Overflow in time-weighted bitrate accumulation - reset to prevent future overflows
-                            NRLog.w("QoE bitrate accumulation overflow - resetting accumulated values to start fresh");
-                            qoeTotalBitrateWeightedTime = 0L;
-                            qoeTotalActiveTime = 0L;
-                        }
-                    }
-                }
-            }
-        }
-
-        // Update current tracking values (accept null/zero values for reset scenarios)
-        qoeCurrentBitrate = newBitrate;
-        qoeLastRenditionChangeTime = currentTime;
-    }
-
-    /**
-     * Pause the bitrate timer during non-play states (pause, buffering, seeking).
-     * This ensures that time spent in non-play states is not counted in the
-     * time-weighted average bitrate calculation.
-     */
-    private void pauseBitrateTimer() {
-        if (qoeBitrateTimerPaused) {
-            return; // Already paused, nothing to do
-        }
-
-        // Save the current segment before pausing
-        if (qoeCurrentBitrate != null && qoeLastRenditionChangeTime != null && qoeCurrentBitrate > 0) {
-            long currentTime = System.currentTimeMillis();
-
-            // Ensure valid timestamps
-            if (qoeLastRenditionChangeTime > 0 && currentTime >= qoeLastRenditionChangeTime) {
-                long segmentDuration = currentTime - qoeLastRenditionChangeTime;
-
-                if (segmentDuration > 0) {
-                    // Prevent overflow in multiplication
-                    if (qoeCurrentBitrate <= Long.MAX_VALUE / segmentDuration) {
-                        try {
-                            qoeTotalBitrateWeightedTime = safeAdd(qoeTotalBitrateWeightedTime, qoeCurrentBitrate * segmentDuration);
-                            qoeTotalActiveTime = safeAdd(qoeTotalActiveTime, segmentDuration);
-                        } catch (ArithmeticException e) {
-                            NRLog.w("QoE bitrate accumulation overflow during pause - resetting");
-                            qoeTotalBitrateWeightedTime = 0L;
-                            qoeTotalActiveTime = 0L;
-                        }
-                    }
-                }
-            }
-        }
-
-        qoeBitrateTimerPaused = true;
-    }
-
-    /**
-     * Resume the bitrate timer after exiting non-play states.
-     * Restarts timing from the current moment so paused time is excluded.
-     */
-    private void resumeBitrateTimer() {
-        if (!qoeBitrateTimerPaused) {
-            return; // Already running, nothing to do
-        }
-
-        // Restart the timer from now (exclude the paused time)
-        qoeLastRenditionChangeTime = System.currentTimeMillis();
-        qoeBitrateTimerPaused = false;
-    }
-
-    /**
-     * Finalize time-weighted bitrate calculation by including the current segment.
-     * Called during QoE calculation to include the time since the last rendition change.
-     *
-     * @return Time-weighted average bitrate, or null if no data available
-     */
-    private Long calculateTimeWeightedAverageBitrate() {
-        // Include current segment in calculation (only if timer is not paused)
-        if (!qoeBitrateTimerPaused && qoeCurrentBitrate != null && qoeLastRenditionChangeTime != null && qoeCurrentBitrate > 0) {
-            long currentTime = System.currentTimeMillis();
-
-            // Safety check: ensure valid timestamp
-            if (qoeLastRenditionChangeTime > 0 && currentTime >= qoeLastRenditionChangeTime) {
-                long currentSegmentDuration = currentTime - qoeLastRenditionChangeTime;
-
-                // Include current segment if it has meaningful duration
-                if (currentSegmentDuration > 0) {
-                    // Prevent overflow in multiplication
-                    if (qoeCurrentBitrate <= Long.MAX_VALUE / currentSegmentDuration) {
-                        try {
-                            long totalWeightedTime = safeAdd(qoeTotalBitrateWeightedTime, qoeCurrentBitrate * currentSegmentDuration);
-                            long totalTime = safeAdd(qoeTotalActiveTime, currentSegmentDuration);
-
-                            if (totalTime > 0) {
-                                return Math.round((double) totalWeightedTime / totalTime);
-                            }
-                        } catch (ArithmeticException e) {
-                            // Overflow in time-weighted bitrate calculation - reset to prevent future overflows
-                            NRLog.w("QoE bitrate calculation overflow - resetting accumulated values to start fresh");
-                            qoeTotalBitrateWeightedTime = 0L;
-                            qoeTotalActiveTime = 0L;
-                        }
-                    }
-                }
-                // If current segment has zero duration, check if we have accumulated data
-                else if (qoeTotalActiveTime > 0) {
-                    return Math.round((double) qoeTotalBitrateWeightedTime / qoeTotalActiveTime);
-                }
-                // If we have current bitrate but no accumulated time and zero segment duration,
-                // return current bitrate as the average (single point average)
-                else if (qoeTotalActiveTime == 0 && currentSegmentDuration == 0) {
-                    return qoeCurrentBitrate;
-                }
-            }
-        }
-
-        // Fallback to accumulated data only
-        if (qoeTotalActiveTime != null && qoeTotalActiveTime > 0 && qoeTotalBitrateWeightedTime != null) {
-            return Math.round((double) qoeTotalBitrateWeightedTime / qoeTotalActiveTime);
-        }
-
-        return null; // No time-weighted data available
-    }
-
-    /**
-     * Reset QoE metrics when starting a new view session.
-     * This ensures that QoE KPIs are isolated per view ID.
-     */
-    private void resetQoeMetrics() {
-        qoePeakBitrate = null;
-        qoeHadPlaybackError = false;
-        qoeHadStartupError = false;
-        qoeTotalRebufferingTime = 0L;
-        qoeBitrateSum = 0L;
-        qoeBitrateCount = 0L;
-        qoeLastTrackedBitrate = null; // Reset cache
-        qoeStartupTime = null; // Reset cached startup time for new view session
-        startupPeriodAdTime = null;
-        startupPeriodPauseTime = 0L; // Reset pause time tracking for new view session
-        hasContentStarted = false;
-        initialBufferingHappened = false; // Reset initial buffering flag for new view session
-
-        // Reset time-weighted bitrate fields
-        qoeCurrentBitrate = null;
-        qoeLastRenditionChangeTime = null;
-        qoeTotalBitrateWeightedTime = 0L;
-        qoeTotalActiveTime = 0L;
-        qoeBitrateTimerPaused = false;
-
-        qoeDownloadRateSum = 0L;
-        qoeDownloadRateCount = 0L;
-        qoeMinDownloadRate = null;
-        qoeMaxDownloadRate = null;
-
-        qoeTotalSwitchUps = 0L;
-        qoeTotalSwitchDowns = 0L;
-        qoeTotalTimeSwitchedDown = 0L;
-        qoeMaxRenditionBitrate = 0L;
-        qoeSwitchedDownSinceMs = null;
-
-        qoeTotalPauseTime = 0L;
-        qoePauseStartMs = null;
-        
-        qoePlayedRenditions.clear();
-
-        // Reset QOE provider fields for new view session
-        // NOTE: Don't reset pendingQoeForNextHarvest here - it needs to persist until next harvest
-        // pendingQoeForNextHarvest = null;  // DON'T CLEAR - final QOE needs to be sent on next harvest
-        lastSentQoeKpis = null; // Reset dirty check snapshot for new view session
-    }
 
 
     /**
@@ -1367,10 +860,10 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
         } else {
             if (totalPlaytime != null && totalPlaytime > 0) {
                 // Error occurred after content started playing, so it's a playback error
-                qoeHadPlaybackError = true;
+                qoeAggregator.recordPlaybackError();
             } else {
                 // Error occurred before content started playing, so it's a startup error
-                qoeHadStartupError = true;
+                qoeAggregator.recordStartupError();
             }
         }
         sendVideoErrorEvent(actionName, errAttr);
@@ -1848,92 +1341,7 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
     }
 
 
-    /**
-     * Optimized bitrate tracking from processed attributes.
-     * Efficiently handles bitrate extraction, duplicate detection, and metric updates.
-     *
-     * @param action The action being processed
-     * @param processedAttributes Fully processed attributes including contentBitrate
-     */
-    private void trackBitrateFromProcessedAttributes(String action, Map<String, Object> processedAttributes) {
-        Long currentBitrate = extractBitrateValue(processedAttributes.get("contentBitrate"));
-        if (currentBitrate == null || currentBitrate <= 0) {
-            return;
-        }
-        // Skip if this is the same bitrate we just tracked (avoid duplicate processing)
-        if (qoeLastTrackedBitrate != null && qoeLastTrackedBitrate.equals(currentBitrate)) {
-            return;
-        }
-        // Update cached value to prevent duplicate processing
-        qoeLastTrackedBitrate = currentBitrate;
-        // Update QoE metrics efficiently
-        updateQoeBitrateMetrics(currentBitrate, action);
-    }
 
-     // Sample contentNetworkDownloadBitrate for QoE download-rate KPIs
-    private void trackDownloadRateMetrics(Map<String, Object> processedAttributes) {
-        Long sample = extractBitrateValue(processedAttributes.get("contentNetworkDownloadBitrate"));
-        if (sample == null || sample <= 0) {
-            return;   // getNetworkDownloadBitrate() returns null/<=0 when unavailable
-        }
-
-        // Accumulate for average (overflow-safe, mirrors updateQoeBitrateMetrics)
-        if (qoeDownloadRateCount < Long.MAX_VALUE - 1) {
-            qoeDownloadRateSum = safeAdd(qoeDownloadRateSum, sample);
-            qoeDownloadRateCount++;
-        }
-
-        // Running min / max with null sentinel for first sample
-        qoeMinDownloadRate = (qoeMinDownloadRate == null) ? sample : Math.min(qoeMinDownloadRate, sample);
-        qoeMaxDownloadRate = (qoeMaxDownloadRate == null) ? sample : Math.max(qoeMaxDownloadRate, sample);
-    }
-
-    // Record distinct renditions played, keyed by width*height
-    private void trackPlayedRenditions(Map<String, Object> processedAttributes) {
-        Long w = extractBitrateValue(processedAttributes.get("contentRenditionWidth"));
-        Long h = extractBitrateValue(processedAttributes.get("contentRenditionHeight"));
-        if (w != null && w > 0 && h != null && h > 0) {
-            qoePlayedRenditions.add(w * h);
-        }
-    }
-
-    /**
-     * Efficiently extract Long bitrate value from various numeric types.
-     * @param bitrateObj Object that may contain bitrate value
-     * @return Long bitrate value or null if invalid
-     */
-    private static Long extractBitrateValue(Object bitrateObj) {
-        if (bitrateObj instanceof Long) {
-            return (Long) bitrateObj;
-        } else if (bitrateObj instanceof Integer) {
-            return ((Integer) bitrateObj).longValue();
-        } else if (bitrateObj instanceof Double) {
-            return ((Double) bitrateObj).longValue();
-        } else if (bitrateObj instanceof Float) {
-            return ((Float) bitrateObj).longValue();
-        }
-        return null;
-    }
-
-    /**
-     * Update all QoE bitrate metrics in one place for efficiency.
-     * @param bitrate The validated bitrate value
-     * @param action Action name for logging context
-     */
-    private void updateQoeBitrateMetrics(Long bitrate, String action) {
-        // Update time-weighted average calculation
-        updateTimeWeightedBitrate(bitrate);
-        // Update peak bitrate
-        if (qoePeakBitrate == null || bitrate > qoePeakBitrate) {
-            qoePeakBitrate = bitrate;
-        }
-        // Update simple average (with overflow protection)
-        if (qoeBitrateCount < Long.MAX_VALUE - 1) {
-            qoeBitrateSum = safeAdd(qoeBitrateSum, bitrate);
-            qoeBitrateCount++;
-        }
-        // QoE bitrate tracking completed
-    }
 
 
     public void sendVideoErrorEvent(String action, Map<String, Object> attributes) {
@@ -1941,22 +1349,5 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
         super.sendVideoErrorEvent(action, attributes);
     }
 
-    /**
-     * Safe addition with overflow detection, compatible with Android API 16+
-     * Equivalent to Math.addExact but works on older Android versions
-     *
-     * @param a first operand
-     * @param b second operand
-     * @return the sum
-     * @throws ArithmeticException if the result overflows a long
-     */
-    private static long safeAdd(long a, long b) {
-        long result = a + b;
 
-        // Check for overflow using the same logic as Math.addExact
-        if (((a ^ result) & (b ^ result)) < 0) {
-            throw new ArithmeticException("long overflow");
-        }
-        return result;
-    }
 }

--- a/NewRelicVideoCore/src/test/java/com/newrelic/videoagent/core/qoe/NRQoEAggregatorTest.java
+++ b/NewRelicVideoCore/src/test/java/com/newrelic/videoagent/core/qoe/NRQoEAggregatorTest.java
@@ -1,0 +1,252 @@
+package com.newrelic.videoagent.core.qoe;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.newrelic.videoagent.core.NRDef.*;
+import static org.junit.Assert.*;
+
+/**
+ * Isolation unit tests for {@link NRQoEAggregator}. The aggregator is pure Java (no Android,
+ * player, or harvest dependencies), so it can be driven directly with hand-built attribute maps.
+ *
+ * Time-independent KPIs are asserted exactly; time-based KPIs (pause, switched-down, averageBitrate)
+ * use the existing sleep + tolerance approach since the production code reads System clock directly.
+ */
+public class NRQoEAggregatorTest {
+
+    private static final long SLEEP_MS = 60L;
+    private static final long MIN_ELAPSED = 25L;
+
+    private NRQoEAggregator agg;
+
+    @Before
+    public void setUp() {
+        agg = new NRQoEAggregator();
+    }
+
+    // ---- helpers -----------------------------------------------------------
+
+    private static Map<String, Object> attrs(Object... kv) {
+        Map<String, Object> m = new HashMap<>();
+        for (int i = 0; i + 1 < kv.length; i += 2) {
+            m.put((String) kv[i], kv[i + 1]);
+        }
+        return m;
+    }
+
+    private void feed(String action, Map<String, Object> a) {
+        agg.processAction(action, a, true, false);
+    }
+
+    private Map<String, Object> kpis() {
+        return agg.generateAggregateAttributes(0L);
+    }
+
+    private static long lng(Map<String, Object> m, String key) {
+        Object v = m.get(key);
+        assertNotNull("KPI '" + key + "' should be present", v);
+        return ((Number) v).longValue();
+    }
+
+    private void request() {
+        feed(CONTENT_REQUEST, attrs());
+    }
+
+    private static void sleep(long ms) {
+        try { Thread.sleep(ms); } catch (InterruptedException ignored) { }
+    }
+
+    // ---- gate --------------------------------------------------------------
+
+    @Test
+    public void returnsNullBeforeContentRequest() {
+        assertNull("no KPIs before CONTENT_REQUEST", kpis());
+    }
+
+    @Test
+    public void returnsMapAfterContentRequest() {
+        request();
+        Map<String, Object> k = kpis();
+        assertNotNull(k);
+        assertEquals(0L, lng(k, "totalSwitchUps"));
+        assertEquals(0L, lng(k, "totalSwitchDowns"));
+        assertEquals(0L, lng(k, "totalRenditions"));
+        assertFalse(k.containsKey("avgDownloadRate"));
+    }
+
+    // ---- download rate -----------------------------------------------------
+
+    @Test
+    public void downloadRate_avgMinMax() {
+        request();
+        feed(CONTENT_HEARTBEAT, attrs("contentNetworkDownloadBitrate", 1000L));
+        feed(CONTENT_HEARTBEAT, attrs("contentNetworkDownloadBitrate", 3000L));
+        feed(CONTENT_HEARTBEAT, attrs("contentNetworkDownloadBitrate", 2000L));
+
+        Map<String, Object> k = kpis();
+        assertEquals(2000L, lng(k, "avgDownloadRate"));
+        assertEquals(1000L, lng(k, "minDownloadRate"));
+        assertEquals(3000L, lng(k, "maxDownloadRate"));
+    }
+
+    @Test
+    public void downloadRate_ignoresNonPositive() {
+        request();
+        feed(CONTENT_HEARTBEAT, attrs("contentNetworkDownloadBitrate", 0L));
+        feed(CONTENT_HEARTBEAT, attrs("contentNetworkDownloadBitrate", -5L));
+        feed(CONTENT_HEARTBEAT, attrs("contentNetworkDownloadBitrate", 4000L));
+
+        Map<String, Object> k = kpis();
+        assertEquals(4000L, lng(k, "avgDownloadRate"));
+    }
+
+    // ---- peak bitrate ------------------------------------------------------
+
+    @Test
+    public void peakBitrate_tracksMax() {
+        request();
+        feed(CONTENT_HEARTBEAT, attrs("contentBitrate", 1000L));
+        feed(CONTENT_HEARTBEAT, attrs("contentBitrate", 4000L));
+        feed(CONTENT_HEARTBEAT, attrs("contentBitrate", 2000L));
+        assertEquals(4000L, lng(kpis(), "peakBitrate"));
+    }
+
+    // ---- switch counts -----------------------------------------------------
+
+    @Test
+    public void switches_countUpsAndDowns() {
+        request();
+        feed(CONTENT_RENDITION_CHANGE, attrs("shift", "down"));
+        feed(CONTENT_RENDITION_CHANGE, attrs("shift", "down"));
+        feed(CONTENT_RENDITION_CHANGE, attrs("shift", "up"));
+
+        Map<String, Object> k = kpis();
+        assertEquals(1L, lng(k, "totalSwitchUps"));
+        assertEquals(2L, lng(k, "totalSwitchDowns"));
+    }
+
+    // ---- distinct renditions ----------------------------------------------
+
+    @Test
+    public void renditions_countsDistinct() {
+        request();
+        feed(CONTENT_HEARTBEAT, attrs("contentRenditionWidth", 1920L, "contentRenditionHeight", 1080L));
+        feed(CONTENT_HEARTBEAT, attrs("contentRenditionWidth", 1280L, "contentRenditionHeight", 720L));
+        feed(CONTENT_HEARTBEAT, attrs("contentRenditionWidth", 1920L, "contentRenditionHeight", 1080L)); // dup
+        assertEquals(2L, lng(kpis(), "totalRenditions"));
+    }
+
+    // ---- startup time (two exclusions + clamp) -----------------------------
+
+    @Test
+    public void startupTime_subtractsAdAndPause() {
+        request();
+        agg.addStartupPauseTime(500L);          // before start -> counted
+        agg.setStartupAdTime(1000L);
+        feed(CONTENT_START, attrs("timeSinceRequested", 5000L));
+        // 5000 - 1000(ad) - 500(pause) = 3500
+        assertEquals(3500L, lng(kpis(), "startupTime"));
+    }
+
+    @Test
+    public void startupTime_clampedToZero() {
+        request();
+        agg.setStartupAdTime(9000L);
+        feed(CONTENT_START, attrs("timeSinceRequested", 5000L));
+        assertEquals(0L, lng(kpis(), "startupTime"));
+    }
+
+    @Test
+    public void startupPauseTime_ignoredAfterStart() {
+        request();
+        agg.setStartupAdTime(0L);
+        feed(CONTENT_START, attrs("timeSinceRequested", 5000L));
+        agg.addStartupPauseTime(2000L);         // after start -> ignored
+        assertEquals(5000L, lng(kpis(), "startupTime"));
+    }
+
+    // ---- rebuffering (skip-first) -----------------------------------------
+
+    @Test
+    public void rebuffering_skipsFirstBuffer() {
+        request();
+        feed(CONTENT_START, attrs("timeSinceRequested", 1000L));
+        feed(CONTENT_BUFFER_END, attrs("timeSinceBufferBegin", 2000L)); // initial -> skipped
+        feed(CONTENT_BUFFER_END, attrs("timeSinceBufferBegin", 3000L)); // counted
+        feed(CONTENT_BUFFER_END, attrs("timeSinceBufferBegin", 1000L)); // counted
+        assertEquals(4000L, lng(kpis(), "totalRebufferingTime"));
+    }
+
+    @Test
+    public void rebufferingRatio_usesSuppliedPlaytime() {
+        request();
+        feed(CONTENT_START, attrs("timeSinceRequested", 0L));
+        feed(CONTENT_BUFFER_END, attrs("timeSinceBufferBegin", 0L));    // skipped
+        feed(CONTENT_BUFFER_END, attrs("timeSinceBufferBegin", 3000L)); // counted
+        Map<String, Object> k = agg.generateAggregateAttributes(30000L);
+        assertEquals(10.0, ((Number) k.get("rebufferingRatio")).doubleValue(), 0.0001);
+        assertEquals(30000L, lng(k, "totalPlaytime"));
+    }
+
+    // ---- error flags -------------------------------------------------------
+
+    @Test
+    public void errorFlags() {
+        request();
+        Map<String, Object> k = kpis();
+        assertFalse((Boolean) k.get("hadStartupError"));
+        assertFalse((Boolean) k.get("hadPlaybackError"));
+
+        agg.recordStartupError();
+        agg.recordPlaybackError();
+        k = kpis();
+        assertTrue((Boolean) k.get("hadStartupError"));
+        assertTrue((Boolean) k.get("hadPlaybackError"));
+    }
+
+    // ---- pause time (time-based, tolerance) --------------------------------
+
+    @Test
+    public void pauseTime_banksOnResume() {
+        request();
+        feed(CONTENT_START, attrs("timeSinceRequested", 0L));
+        feed(CONTENT_PAUSE, attrs());
+        sleep(SLEEP_MS);
+        feed(CONTENT_RESUME, attrs());
+        assertTrue(lng(kpis(), "totalPauseTime") >= MIN_ELAPSED);
+    }
+
+    @Test
+    public void pauseTime_openSnapshotIsNonMutating() {
+        request();
+        feed(CONTENT_START, attrs("timeSinceRequested", 0L));
+        feed(CONTENT_PAUSE, attrs());           // open, never resumed
+        sleep(SLEEP_MS);
+        long first = lng(kpis(), "totalPauseTime");
+        sleep(SLEEP_MS);
+        long second = lng(kpis(), "totalPauseTime");
+        assertTrue("open pause keeps growing (" + first + " -> " + second + ")", second > first);
+    }
+
+    // ---- reset -------------------------------------------------------------
+
+    @Test
+    public void reset_clearsStateAndGate() {
+        request();
+        feed(CONTENT_RENDITION_CHANGE, attrs("shift", "up"));
+        feed(CONTENT_HEARTBEAT, attrs("contentNetworkDownloadBitrate", 5000L));
+        assertTrue(lng(kpis(), "totalSwitchUps") >= 1);
+
+        agg.reset();
+        assertNull("gate closed again after reset", kpis());
+
+        request();
+        Map<String, Object> k = kpis();
+        assertEquals(0L, lng(k, "totalSwitchUps"));
+        assertFalse(k.containsKey("avgDownloadRate"));
+    }
+}

--- a/NewRelicVideoCore/src/test/java/com/newrelic/videoagent/core/tracker/NRVideoTrackerQoeTest.java
+++ b/NewRelicVideoCore/src/test/java/com/newrelic/videoagent/core/tracker/NRVideoTrackerQoeTest.java
@@ -6,7 +6,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
-import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -27,7 +26,7 @@ import static org.junit.Assert.*;
  *     path. Switch and pause metrics are driven through the real event pipeline
  *     (sendVideoEvent / sendPause / sendResume) so the NRTracker.processQoeEvents()
  *     wiring is exercised too.
- *   - KPI values are read back from the private calculateQOEKpiAttributes() via reflection.
+ *   - KPI values are read back from the extracted NRQoEAggregator via getQoeAggregator().
  *
  * Time-based assertions use small real sleeps with generous tolerance (the production
  * code uses System.currentTimeMillis()); this mirrors the existing playtime tests.
@@ -70,15 +69,20 @@ public class NRVideoTrackerQoeTest {
         @Override public Long getNetworkDownloadBitrate(){ return networkDownloadBitrate; }
     }
 
-    @SuppressWarnings("unchecked")
+    /**
+     * Phase 1: KPIs now come from the extracted aggregator (via the package-private accessor).
+     * Real-time playtime is supplied by the tracker in production; tests that don't exercise
+     * playtime pass 0. Returns null before a CONTENT_REQUEST (the aggregator's gate), so tests
+     * that read KPIs must establish a session (startContent() or requestOnly()) first.
+     */
     private Map<String, Object> kpis() {
-        try {
-            Method m = NRVideoTracker.class.getDeclaredMethod("calculateQOEKpiAttributes");
-            m.setAccessible(true);
-            return (Map<String, Object>) m.invoke(tracker);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+        return tracker.getQoeAggregator().generateAggregateAttributes(0L);
+    }
+
+    /** Open the aggregator gate without starting playback (feeds CONTENT_REQUEST). */
+    private void requestOnly() {
+        tracker.setPlayer(new Object());
+        tracker.sendRequest();
     }
 
     private static long lng(Map<String, Object> m, String key) {
@@ -93,9 +97,9 @@ public class NRVideoTrackerQoeTest {
         tracker.sendStart();
     }
 
-    /** Drive one content event so the getAttributes() capture hooks run. */
+    /** Drive one content event through the real pipeline so the onQoeEvent feed hook runs. */
     private void emitContentEvent() {
-        tracker.getAttributes(CONTENT_HEARTBEAT, null);
+        tracker.sendVideoEvent(CONTENT_HEARTBEAT, null);
     }
 
     private void sendShift(String shift) {
@@ -130,6 +134,7 @@ public class NRVideoTrackerQoeTest {
 
     @Test
     public void defaults_countersZero_downloadOmitted() {
+        requestOnly();
         Map<String, Object> k = kpis();
 
         assertEquals(0L, lng(k, "totalSwitchUps"));
@@ -204,6 +209,7 @@ public class NRVideoTrackerQoeTest {
 
     @Test
     public void switches_countUpsAndDowns() {
+        requestOnly();
         sendShift("down");
         sendShift("down");
         sendShift("up");
@@ -216,6 +222,7 @@ public class NRVideoTrackerQoeTest {
 
     @Test
     public void switches_missingOrUnknownShiftIgnored() {
+        requestOnly();
         sendShift(null);          // no "shift" attribute
         sendShift("sideways");    // unrecognised value
 
@@ -365,7 +372,7 @@ public class NRVideoTrackerQoeTest {
     }
 
     // =========================================================================
-    // Reset per view (sendEnd -> resetQoeMetrics)
+    // Reset per view (sendEnd -> aggregator.reset())
     // =========================================================================
 
     @Test
@@ -389,9 +396,17 @@ public class NRVideoTrackerQoeTest {
         assertTrue(lng(before, "totalRenditions") >= 1);
         assertTrue(before.containsKey("avgDownloadRate"));
 
-        // End the view -> resetQoeMetrics().
+        // End the view -> aggregator.reset() (closes the gate too).
         tracker.sendEnd();
+        assertNull("gate closed after view end", kpis());
 
+        // A fresh view (new CONTENT_REQUEST) starts clean. Clear the player-data getters so the
+        // new session carries no rendition/download samples yet.
+        tracker.renditionWidth = null;
+        tracker.renditionHeight = null;
+        tracker.renditionBitrate = null;
+        tracker.networkDownloadBitrate = null;
+        tracker.sendRequest();
         Map<String, Object> after = kpis();
         assertEquals(0L, lng(after, "totalSwitchUps"));
         assertEquals(0L, lng(after, "totalSwitchDowns"));


### PR DESCRIPTION
### Phase 1: Extract QoE into NRQoEAggregator (architecture only)

**What changed**

1. New NRQoEAggregator — a standalone, synchronized, pure-Java model that owns all QoE state + math. Fed fully-assembled event attributes; returns the KPI map on demand.
2. Removed the instanceof anti-pattern — NRTracker now exposes an overridable onQoeEvent(action, attributes) hook (no-op in base; NRVideoTracker overrides it to feed the aggregator).
3. Thread-safety — the aggregator is a monitor, so the event thread (feed) and harvest thread (read) can't race.
Provider lifecycle fix — the tracker now unregisters its QoE provider on dispose(), fixing a latent leak where a disposed tracker kept being polled. 
4. Deleted dead calculateAndAddStartupTime; the tracker passes real-time playtime into the aggregator so rebufferingRatio/totalPlaytime stay exact.
5. Behavior impact
KPIs are unchanged except avgDownloadRate: this removes an unintended startup double-count (the old calculateAndCacheStartupTime re-ran getAttributes(CONTENT_START), feeding the download sample twice). All other KPIs and the full non-QoE event stream are byte-identical.