### PR TITLE
QoE Phase 2.1 — iOS parity: totalPauseTime + download-rate dedup

### DIFF
--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/qoe/NRQoEAggregator.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/qoe/NRQoEAggregator.java
@@ -137,9 +137,9 @@ public final class NRQoEAggregator {
         } else if (CONTENT_RENDITION_CHANGE.equals(action)) {
             handleRenditionChange(attributes);
         } else if (CONTENT_PAUSE.equals(action)) {
-            handlePause();
+            handlePause(adBreakActive);
         } else if (CONTENT_RESUME.equals(action)) {
-            handleResume();
+            handleResume(attributes);
         }
     }
 
@@ -216,8 +216,6 @@ public final class NRQoEAggregator {
 
         kpiAttributes.put("totalSwitchUps", qoeTotalSwitchUps);
         kpiAttributes.put("totalSwitchDowns", qoeTotalSwitchDowns);
-        long openMs = (qoeSwitchedDownSinceMs == null) ? 0L : System.currentTimeMillis() - qoeSwitchedDownSinceMs;
-        kpiAttributes.put("totalTimeSwitchedDown", safeAdd(qoeTotalTimeSwitchedDown, openMs));
 
         long openPauseMs = (qoePauseStartMs == null) ? 0L : System.currentTimeMillis() - qoePauseStartMs;
         kpiAttributes.put("totalPauseTime", safeAdd(qoeTotalPauseTime, openPauseMs));
@@ -363,15 +361,22 @@ public final class NRQoEAggregator {
         }
     }
 
-    private void handlePause() {
+    private void handlePause(boolean adBreakActive) {
+        if (adBreakActive) {
+            return;
+        }
         qoePauseStartMs = System.currentTimeMillis();
     }
 
-    private void handleResume() {
-        if (qoePauseStartMs != null) {
-            qoeTotalPauseTime = safeAdd(qoeTotalPauseTime, System.currentTimeMillis() - qoePauseStartMs);
-            qoePauseStartMs = null;
+    private void handleResume(Map<String, Object> attributes) {
+        if (qoePauseStartMs == null) {
+            return;
         }
+        Object timeSincePaused = attributes.get("timeSincePaused");
+        if (timeSincePaused instanceof Long) {
+            qoeTotalPauseTime = safeAdd(qoeTotalPauseTime, (Long) timeSincePaused);
+        }
+        qoePauseStartMs = null;
     }
 
     // =========================================================================

--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/qoe/NRQoEAggregator.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/qoe/NRQoEAggregator.java
@@ -494,7 +494,6 @@ public final class NRQoEAggregator {
         if (sample == null || sample <= 0) {
             return;
         }
-        // iOS parity: the adapter holds the last segment's download bitrate and echoes it on every
         // heartbeat; skip a sample identical to the previous one so stale repeats don't skew the avg.
         if (qoeLastDownloadRate != null && qoeLastDownloadRate.equals(sample)) {
             return;

--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/qoe/NRQoEAggregator.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/qoe/NRQoEAggregator.java
@@ -41,6 +41,7 @@ public final class NRQoEAggregator {
     private Long qoeDownloadRateCount;
     private Long qoeMinDownloadRate;
     private Long qoeMaxDownloadRate;
+    private Long qoeLastDownloadRate;  // last download sample;
 
     // ---- Rendition switch metrics ------------------------------------------
     private long qoeTotalSwitchUps;
@@ -95,6 +96,7 @@ public final class NRQoEAggregator {
         qoeDownloadRateCount = 0L;
         qoeMinDownloadRate = null;
         qoeMaxDownloadRate = null;
+        qoeLastDownloadRate = null;
 
         qoeTotalSwitchUps = 0L;
         qoeTotalSwitchDowns = 0L;
@@ -250,6 +252,7 @@ public final class NRQoEAggregator {
         qoeDownloadRateCount = 0L;
         qoeMinDownloadRate = null;
         qoeMaxDownloadRate = null;
+        qoeLastDownloadRate = null;
 
         qoeTotalSwitchUps = 0L;
         qoeTotalSwitchDowns = 0L;
@@ -491,6 +494,12 @@ public final class NRQoEAggregator {
         if (sample == null || sample <= 0) {
             return;
         }
+        // iOS parity: the adapter holds the last segment's download bitrate and echoes it on every
+        // heartbeat; skip a sample identical to the previous one so stale repeats don't skew the avg.
+        if (qoeLastDownloadRate != null && qoeLastDownloadRate.equals(sample)) {
+            return;
+        }
+        qoeLastDownloadRate = sample;
         if (qoeDownloadRateCount < Long.MAX_VALUE - 1) {
             qoeDownloadRateSum = safeAdd(qoeDownloadRateSum, sample);
             qoeDownloadRateCount++;

--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/tracker/NRVideoTracker.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/tracker/NRVideoTracker.java
@@ -314,9 +314,9 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
         if (CONTENT_START.equals(action)) {
             qoeAggregator.setStartupAdTime(startupPeriodAdTime == null ? 0L : startupPeriodAdTime);
         }
-        // Phase 1: adBreakActive is inert (false); the bitrate timer is still driven by the
-        // explicit sender call-sites. isPlaying is reserved for a later phase.
-        qoeAggregator.processAction(action, attributes, state.isPlaying, false);
+        boolean adBreakActive = (linkedTracker instanceof NRVideoTracker)
+                && ((NRVideoTracker) linkedTracker).state.isAdBreak;
+        qoeAggregator.processAction(action, attributes, state.isPlaying, adBreakActive);
         // Cache the fully-assembled snapshot for the harvest-time QOE envelope.
         cachedStandardAttributes = new HashMap<>(attributes);
     }

--- a/NewRelicVideoCore/src/test/java/com/newrelic/videoagent/core/qoe/NRQoEAggregatorTest.java
+++ b/NewRelicVideoCore/src/test/java/com/newrelic/videoagent/core/qoe/NRQoEAggregatorTest.java
@@ -208,16 +208,37 @@ public class NRQoEAggregatorTest {
         assertTrue((Boolean) k.get("hadPlaybackError"));
     }
 
-    // ---- pause time (time-based, tolerance) --------------------------------
+    // ---- pause time (banks the event's timeSincePaused) ---------
 
     @Test
-    public void pauseTime_banksOnResume() {
+    public void pauseTime_banksTimeSincePaused() {
         request();
         feed(CONTENT_START, attrs("timeSinceRequested", 0L));
         feed(CONTENT_PAUSE, attrs());
-        sleep(SLEEP_MS);
-        feed(CONTENT_RESUME, attrs());
-        assertTrue(lng(kpis(), "totalPauseTime") >= MIN_ELAPSED);
+        feed(CONTENT_RESUME, attrs("timeSincePaused", 5000L));
+        // Banked from the event attribute (deterministic), not a wall-clock delta.
+        assertEquals(5000L, lng(kpis(), "totalPauseTime"));
+    }
+
+    @Test
+    public void pauseTime_accumulatesAcrossPauses() {
+        request();
+        feed(CONTENT_START, attrs("timeSinceRequested", 0L));
+        feed(CONTENT_PAUSE, attrs());
+        feed(CONTENT_RESUME, attrs("timeSincePaused", 5000L));
+        feed(CONTENT_PAUSE, attrs());
+        feed(CONTENT_RESUME, attrs("timeSincePaused", 3000L));
+        assertEquals(8000L, lng(kpis(), "totalPauseTime"));
+    }
+
+    @Test
+    public void pauseTime_excludedDuringAdBreak() {
+        request();
+        feed(CONTENT_START, attrs("timeSinceRequested", 0L));
+        // adBreakActive = true -> the pause is the player pausing for an ad, not a user pause.
+        agg.processAction(CONTENT_PAUSE, attrs(), true, true);
+        agg.processAction(CONTENT_RESUME, attrs("timeSincePaused", 5000L), true, false);
+        assertEquals(0L, lng(kpis(), "totalPauseTime"));
     }
 
     @Test

--- a/NewRelicVideoCore/src/test/java/com/newrelic/videoagent/core/qoe/NRQoEAggregatorTest.java
+++ b/NewRelicVideoCore/src/test/java/com/newrelic/videoagent/core/qoe/NRQoEAggregatorTest.java
@@ -104,6 +104,16 @@ public class NRQoEAggregatorTest {
         assertEquals(4000L, lng(k, "avgDownloadRate"));
     }
 
+    @Test
+    public void downloadRate_dedupsConsecutiveIdenticalSamples() {
+        request();
+        feed(CONTENT_HEARTBEAT, attrs("contentNetworkDownloadBitrate", 1000L));
+        feed(CONTENT_HEARTBEAT, attrs("contentNetworkDownloadBitrate", 1000L)); // stale repeat -> skipped
+        feed(CONTENT_HEARTBEAT, attrs("contentNetworkDownloadBitrate", 3000L));
+        // (1000 + 3000) / 2 = 2000, not (1000 + 1000 + 3000) / 3
+        assertEquals(2000L, lng(kpis(), "avgDownloadRate"));
+    }
+
     // ---- peak bitrate ------------------------------------------------------
 
     @Test

--- a/NewRelicVideoCore/src/test/java/com/newrelic/videoagent/core/tracker/NRVideoTrackerQoeTest.java
+++ b/NewRelicVideoCore/src/test/java/com/newrelic/videoagent/core/tracker/NRVideoTrackerQoeTest.java
@@ -15,8 +15,8 @@ import static org.junit.Assert.*;
 /**
  * Unit tests for the QoE attributes added in qoeAggregateVersion 1.1.0:
  *   - avgDownloadRate / minDownloadRate / maxDownloadRate
- *   - totalSwitchUps / totalSwitchDowns / totalTimeSwitchedDown
- *   - totalPauseTime
+ *   - totalSwitchUps / totalSwitchDowns
+ *   - totalPauseTime (banks timeSincePaused; excludes ad-break pauses)
  *   - totalRenditions
  *
  * Strategy:
@@ -111,9 +111,8 @@ public class NRVideoTrackerQoeTest {
     }
 
     /**
-     * Drive a CONTENT_RENDITION_CHANGE carrying a rendition bitrate. The bitrate is what
-     * totalTimeSwitchedDown is anchored on (session-max); requires the tracker to be started
-     * so getAttributes() populates contentRenditionBitrate.
+     * Drive a CONTENT_RENDITION_CHANGE carrying a rendition bitrate; requires the tracker to be
+     * started so getAttributes() populates contentRenditionBitrate. Used to drive switch counts.
      */
     private void renditionChange(String shift, long bitrate) {
         tracker.renditionBitrate = bitrate;
@@ -139,7 +138,6 @@ public class NRVideoTrackerQoeTest {
 
         assertEquals(0L, lng(k, "totalSwitchUps"));
         assertEquals(0L, lng(k, "totalSwitchDowns"));
-        assertEquals(0L, lng(k, "totalTimeSwitchedDown"));
         assertEquals(0L, lng(k, "totalPauseTime"));
         assertEquals(0L, lng(k, "totalRenditions"));
 
@@ -229,74 +227,6 @@ public class NRVideoTrackerQoeTest {
         Map<String, Object> k = kpis();
         assertEquals(0L, lng(k, "totalSwitchUps"));
         assertEquals(0L, lng(k, "totalSwitchDowns"));
-        assertEquals(0L, lng(k, "totalTimeSwitchedDown"));
-    }
-
-    // =========================================================================
-    // totalTimeSwitchedDown
-    // =========================================================================
-
-    @Test
-    public void timeSwitchedDown_banksWhenRecoveringToPeak() {
-        startContent();
-
-        renditionChange("down", 5_000_000L);   // establishes session peak = 5M, no interval
-        renditionChange("down", 3_000_000L);   // below peak -> open interval
-        sleep(SLEEP_MS);
-        renditionChange("up",   5_000_000L);   // back to peak -> close, bank elapsed
-
-        long t = lng(kpis(), "totalTimeSwitchedDown");
-        assertTrue("below-peak time banked (was " + t + ")", t >= MIN_ELAPSED);
-    }
-
-    @Test
-    public void timeSwitchedDown_partialRecoveryStaysBelowPeak() {
-        // The defining session-max behavior: an upswitch that is still below the session
-        // peak must NOT close the interval (unlike the previous-rendition semantic).
-        startContent();
-
-        renditionChange("down", 5_000_000L);   // peak = 5M
-        renditionChange("down", 2_000_000L);   // open interval
-        sleep(SLEEP_MS);
-        renditionChange("up",   3_000_000L);   // 3M < 5M -> still below peak, interval stays OPEN
-
-        long v1 = lng(kpis(), "totalTimeSwitchedDown");
-        sleep(SLEEP_MS);
-        long v2 = lng(kpis(), "totalTimeSwitchedDown");
-        assertTrue("still counting below the session peak (" + v1 + " -> " + v2 + ")", v2 > v1);
-    }
-
-    @Test
-    public void timeSwitchedDown_consecutiveDownsKeepOneInterval() {
-        startContent();
-
-        renditionChange("down", 5_000_000L);   // peak = 5M
-        renditionChange("down", 3_000_000L);   // open interval
-        sleep(SLEEP_MS);
-        renditionChange("down", 2_000_000L);   // still below peak — interval start must NOT reset
-        sleep(SLEEP_MS);
-        renditionChange("up",   5_000_000L);   // recover to peak -> close
-
-        long t = lng(kpis(), "totalTimeSwitchedDown");
-        // One continuous interval spanning both sleeps.
-        assertTrue("continuous interval (was " + t + ")", t >= (2 * MIN_ELAPSED));
-    }
-
-    @Test
-    public void timeSwitchedDown_openIntervalSnapshotIsNonMutating() {
-        startContent();
-
-        renditionChange("down", 5_000_000L);   // peak = 5M
-        renditionChange("down", 3_000_000L);   // open, never recovered
-        sleep(SLEEP_MS);
-
-        long first = lng(kpis(), "totalTimeSwitchedDown");
-        assertTrue("open interval reflected at emit (was " + first + ")", first >= MIN_ELAPSED);
-
-        sleep(SLEEP_MS);
-        long second = lng(kpis(), "totalTimeSwitchedDown");
-        // Non-mutating snapshot: the interval is still open, so it keeps growing.
-        assertTrue("snapshot keeps growing (" + first + " -> " + second + ")", second > first);
     }
 
     // =========================================================================
@@ -387,11 +317,10 @@ public class NRVideoTrackerQoeTest {
         tracker.sendPause(); sleep(SLEEP_MS); tracker.sendResume();
         sleep(SLEEP_MS);
 
-        // Sanity: state accumulated (incl. an OPEN switched-down interval).
+        // Sanity: state accumulated.
         Map<String, Object> before = kpis();
         assertEquals(1L, lng(before, "totalSwitchUps"));
         assertEquals(1L, lng(before, "totalSwitchDowns"));
-        assertTrue(lng(before, "totalTimeSwitchedDown") > 0);
         assertTrue(lng(before, "totalPauseTime") > 0);
         assertTrue(lng(before, "totalRenditions") >= 1);
         assertTrue(before.containsKey("avgDownloadRate"));
@@ -410,7 +339,6 @@ public class NRVideoTrackerQoeTest {
         Map<String, Object> after = kpis();
         assertEquals(0L, lng(after, "totalSwitchUps"));
         assertEquals(0L, lng(after, "totalSwitchDowns"));
-        assertEquals(0L, lng(after, "totalTimeSwitchedDown"));
         assertEquals(0L, lng(after, "totalPauseTime"));
         assertEquals(0L, lng(after, "totalRenditions"));
         assertFalse("download rate cleared", after.containsKey("avgDownloadRate"));


### PR DESCRIPTION
Two small, independent QoE metric alignments with iOS. Both are aggregator-level, unit-tested, and validated on-device.

**1. totalPauseTime → iOS clock model; stop emitting totalTimeSwitchedDown**

Exclude content pauses that occur during an ad break (a content pause for an ad isn't user pause time) — the tracker now passes a real adBreakActive (linkedTracker.state.isAdBreak) into the aggregator.
Bank the event's timeSincePaused on resume instead of a separate System.currentTimeMillis() delta, so pause time uses one consistent source — matching iOS.
Stop emitting totalTimeSwitchedDown (iOS has no such field); totalSwitchUps/totalSwitchDowns are unchanged.

**2. Dedup consecutive identical download-rate samples**

The ExoPlayer adapter computes contentNetworkDownloadBitrate once per segment (onLoadCompleted) and echoes it on every heartbeat, so avgDownloadRate was weighted by heartbeat count with a stale reading.
Skip a sample identical to the previous one (mirrors iOS's lastDownloadRateSample and the existing bitrate dedup), so each real download counts once. min/maxDownloadRate unaffected.