### PR TITLE
Phase 2.2: iOS-parity QoE fixes — bitrate timer, per-session cadence, final-QoE durability

### DIFF
--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/harvest/HarvestManager.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/harvest/HarvestManager.java
@@ -174,9 +174,6 @@ public class HarvestManager implements EventBufferInterface.CapacityCallback {
      * Like iOS: QOE is sent independently on each qualified harvest cycle,
      * regardless of whether the batch contains other VideoAction events.
      *
-     * Final QOE from CONTENT_END (marked with "isFinalQoe" flag) is always injected
-     * and triggers provider unregistration.
-     *
      * @param batch The harvest batch to potentially inject QOE events into
      * @param cycleNumber The current harvest cycle number
      */
@@ -193,19 +190,8 @@ public class HarvestManager implements EventBufferInterface.CapacityCallback {
                 Map<String, Object> currentQoeEvent = provider.generateQoeIfNeeded(batch, cycleNumber);
 
                 if (currentQoeEvent != null) {
-                    // Check if this is the final QOE from CONTENT_END
-                    if (Boolean.TRUE.equals(currentQoeEvent.get("isFinalQoe"))) {
-                        // FINAL QOE - remove internal flag before sending
-                        currentQoeEvent.remove("isFinalQoe");
-                        batch.add(currentQoeEvent);
-                        NRLog.d("Final QOE_AGGREGATE from CONTENT_END injected - provider will be unregistered");
-
-                        // Unregister provider after injecting final QOE
-                        qoeProviders.remove(provider);
-                        continue;
-                    }
-
-                    // Regular QOE - send independently (like iOS)
+                    // Periodic QOE - inject into the batch. The final QoE at CONTENT_END is recorded
+                    // to the buffer directly by the tracker, not via this provider path.
                     batch.add(currentQoeEvent);
                     NRLog.d("QOE_AGGREGATE injected into harvest batch (cycle " + cycleNumber + ")");
                 }

--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/qoe/NRQoEAggregator.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/qoe/NRQoEAggregator.java
@@ -137,9 +137,9 @@ public final class NRQoEAggregator {
         } else if (CONTENT_RENDITION_CHANGE.equals(action)) {
             handleRenditionChange(attributes);
         } else if (CONTENT_PAUSE.equals(action)) {
-            handlePause();
+            handlePause(adBreakActive);
         } else if (CONTENT_RESUME.equals(action)) {
-            handleResume();
+            handleResume(attributes);
         }
     }
 
@@ -216,8 +216,6 @@ public final class NRQoEAggregator {
 
         kpiAttributes.put("totalSwitchUps", qoeTotalSwitchUps);
         kpiAttributes.put("totalSwitchDowns", qoeTotalSwitchDowns);
-        long openMs = (qoeSwitchedDownSinceMs == null) ? 0L : System.currentTimeMillis() - qoeSwitchedDownSinceMs;
-        kpiAttributes.put("totalTimeSwitchedDown", safeAdd(qoeTotalTimeSwitchedDown, openMs));
 
         long openPauseMs = (qoePauseStartMs == null) ? 0L : System.currentTimeMillis() - qoePauseStartMs;
         kpiAttributes.put("totalPauseTime", safeAdd(qoeTotalPauseTime, openPauseMs));
@@ -363,15 +361,22 @@ public final class NRQoEAggregator {
         }
     }
 
-    private void handlePause() {
+    private void handlePause(boolean adBreakActive) {
+        if (adBreakActive) {
+            return;
+        }
         qoePauseStartMs = System.currentTimeMillis();
     }
 
-    private void handleResume() {
-        if (qoePauseStartMs != null) {
-            qoeTotalPauseTime = safeAdd(qoeTotalPauseTime, System.currentTimeMillis() - qoePauseStartMs);
-            qoePauseStartMs = null;
+    private void handleResume(Map<String, Object> attributes) {
+        if (qoePauseStartMs == null) {
+            return;
         }
+        Object timeSincePaused = attributes.get("timeSincePaused");
+        if (timeSincePaused instanceof Long) {
+            qoeTotalPauseTime = safeAdd(qoeTotalPauseTime, (Long) timeSincePaused);
+        }
+        qoePauseStartMs = null;
     }
 
     // =========================================================================

--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/qoe/NRQoEAggregator.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/qoe/NRQoEAggregator.java
@@ -90,7 +90,7 @@ public final class NRQoEAggregator {
         qoeLastRenditionChangeTime = null;
         qoeTotalBitrateWeightedTime = 0L;
         qoeTotalActiveTime = 0L;
-        qoeBitrateTimerPaused = false;
+        qoeBitrateTimerPaused = true;   // start "not running" until CONTENT_START
 
         qoeDownloadRateSum = 0L;
         qoeDownloadRateCount = 0L;
@@ -123,6 +123,17 @@ public final class NRQoEAggregator {
                                            boolean isPlaying, boolean adBreakActive) {
         if (attributes == null) {
             attributes = new HashMap<>();
+        }
+
+        // Drive the bitrate timer from play state, replacing the explicit sender
+        // call-sites. state.isPlaying is set by the tracker's goXxx state machine before this runs
+        // and is false during pause/buffer/seek. Done before the extractors so a resume restarts
+        // the segment clock from "now".
+        boolean timerRunning = !qoeBitrateTimerPaused;
+        if (timerRunning && !isPlaying) {
+            pauseBitrateTimer();
+        } else if (!timerRunning && isPlaying) {
+            resumeBitrateTimer();
         }
 
         // Always-on extractors (run for every content event, as getAttributes() did before).
@@ -246,7 +257,7 @@ public final class NRQoEAggregator {
         qoeLastRenditionChangeTime = null;
         qoeTotalBitrateWeightedTime = 0L;
         qoeTotalActiveTime = 0L;
-        qoeBitrateTimerPaused = false;
+        qoeBitrateTimerPaused = true;   // start "not running" until CONTENT_START
 
         qoeDownloadRateSum = 0L;
         qoeDownloadRateCount = 0L;
@@ -386,7 +397,8 @@ public final class NRQoEAggregator {
     // Bitrate timer
     // =========================================================================
 
-    public synchronized void pauseBitrateTimer() {
+    // Driven by processAction from the isPlaying transition (already under the lock).
+    private void pauseBitrateTimer() {
         if (qoeBitrateTimerPaused) {
             return;
         }
@@ -410,7 +422,7 @@ public final class NRQoEAggregator {
         qoeBitrateTimerPaused = true;
     }
 
-    public synchronized void resumeBitrateTimer() {
+    private void resumeBitrateTimer() {
         if (!qoeBitrateTimerPaused) {
             return;
         }

--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/qoe/NRQoEAggregator.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/qoe/NRQoEAggregator.java
@@ -494,7 +494,6 @@ public final class NRQoEAggregator {
         if (sample == null || sample <= 0) {
             return;
         }
-        // iOS parity: the adapter holds the last segment's download bitrate and echoes it on every
         // heartbeat; skip a sample identical to the previous one so stale repeats don't skew the avg.
         if (qoeLastDownloadRate != null && qoeLastDownloadRate.equals(sample)) {
             return;

--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/qoe/NRQoEAggregator.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/qoe/NRQoEAggregator.java
@@ -41,6 +41,7 @@ public final class NRQoEAggregator {
     private Long qoeDownloadRateCount;
     private Long qoeMinDownloadRate;
     private Long qoeMaxDownloadRate;
+    private Long qoeLastDownloadRate;  // last download sample;
 
     // ---- Rendition switch metrics ------------------------------------------
     private long qoeTotalSwitchUps;
@@ -95,6 +96,7 @@ public final class NRQoEAggregator {
         qoeDownloadRateCount = 0L;
         qoeMinDownloadRate = null;
         qoeMaxDownloadRate = null;
+        qoeLastDownloadRate = null;
 
         qoeTotalSwitchUps = 0L;
         qoeTotalSwitchDowns = 0L;
@@ -250,6 +252,7 @@ public final class NRQoEAggregator {
         qoeDownloadRateCount = 0L;
         qoeMinDownloadRate = null;
         qoeMaxDownloadRate = null;
+        qoeLastDownloadRate = null;
 
         qoeTotalSwitchUps = 0L;
         qoeTotalSwitchDowns = 0L;
@@ -491,6 +494,12 @@ public final class NRQoEAggregator {
         if (sample == null || sample <= 0) {
             return;
         }
+        // iOS parity: the adapter holds the last segment's download bitrate and echoes it on every
+        // heartbeat; skip a sample identical to the previous one so stale repeats don't skew the avg.
+        if (qoeLastDownloadRate != null && qoeLastDownloadRate.equals(sample)) {
+            return;
+        }
+        qoeLastDownloadRate = sample;
         if (qoeDownloadRateCount < Long.MAX_VALUE - 1) {
             qoeDownloadRateSum = safeAdd(qoeDownloadRateSum, sample);
             qoeDownloadRateCount++;

--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/tracker/NRVideoTracker.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/tracker/NRVideoTracker.java
@@ -314,9 +314,9 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
         if (CONTENT_START.equals(action)) {
             qoeAggregator.setStartupAdTime(startupPeriodAdTime == null ? 0L : startupPeriodAdTime);
         }
-        // Phase 1: adBreakActive is inert (false); the bitrate timer is still driven by the
-        // explicit sender call-sites. isPlaying is reserved for a later phase.
-        qoeAggregator.processAction(action, attributes, state.isPlaying, false);
+        boolean adBreakActive = (linkedTracker instanceof NRVideoTracker)
+                && ((NRVideoTracker) linkedTracker).state.isAdBreak;
+        qoeAggregator.processAction(action, attributes, state.isPlaying, adBreakActive);
         // Cache the fully-assembled snapshot for the harvest-time QOE envelope.
         cachedStandardAttributes = new HashMap<>(attributes);
     }

--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/tracker/NRVideoTracker.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/tracker/NRVideoTracker.java
@@ -380,9 +380,6 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
                 // startupPeriodAdTime (set above) is pushed into the aggregator by onQoeEvent
                 // when it processes CONTENT_START; the aggregator caches startup time there too.
                 sendVideoEvent(CONTENT_START);
-
-                // Resume bitrate timer when content starts playing
-                qoeAggregator.resumeBitrateTimer();
             }
             playtimeSinceLastEventTimestamp = System.currentTimeMillis();
         }
@@ -402,8 +399,6 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
                 sendVideoAdEvent(AD_PAUSE);
             } else {
                 sendVideoEvent(CONTENT_PAUSE);
-                // Pause bitrate timer during pause to exclude paused time from average
-                qoeAggregator.pauseBitrateTimer();
             }
             playtimeSinceLastEventTimestamp = 0L;
         }
@@ -432,10 +427,6 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
                 sendVideoAdEvent(AD_RESUME);
             } else {
                 sendVideoEvent(CONTENT_RESUME);
-                // Resume bitrate timer when playback resumes (only if not buffering or seeking)
-                if (!state.isBuffering && !state.isSeeking) {
-                    qoeAggregator.resumeBitrateTimer();
-                }
             }
             if (!state.isBuffering && !state.isSeeking) {
                 playtimeSinceLastEventTimestamp = System.currentTimeMillis();
@@ -496,8 +487,6 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
                 sendVideoAdEvent(AD_SEEK_START);
             } else {
                 sendVideoEvent(CONTENT_SEEK_START);
-                // Pause bitrate timer during seeking to exclude seek time from average
-                qoeAggregator.pauseBitrateTimer();
             }
             playtimeSinceLastEventTimestamp = 0L;
         }
@@ -512,10 +501,6 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
                 sendVideoAdEvent(AD_SEEK_END);
             } else {
                 sendVideoEvent(CONTENT_SEEK_END);
-                // Resume bitrate timer when seeking ends (only if not buffering or paused)
-                if (!state.isBuffering && !state.isPaused) {
-                    qoeAggregator.resumeBitrateTimer();
-                }
             }
             if (!state.isBuffering && !state.isPaused) {
                 playtimeSinceLastEventTimestamp = System.currentTimeMillis();
@@ -536,8 +521,6 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
                 sendVideoAdEvent(AD_BUFFER_START);
             } else {
                 sendVideoEvent(CONTENT_BUFFER_START);
-                // Pause bitrate timer during buffering to exclude buffering time from average
-                qoeAggregator.pauseBitrateTimer();
             }
             playtimeSinceLastEventTimestamp = 0L;
         }
@@ -558,10 +541,6 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
                 sendVideoAdEvent(AD_BUFFER_END);
             } else {
                 sendVideoEvent(CONTENT_BUFFER_END);
-                // Resume bitrate timer when buffering ends (only if not seeking or paused)
-                if (!state.isSeeking && !state.isPaused) {
-                    qoeAggregator.resumeBitrateTimer();
-                }
             }
             if (!state.isSeeking && !state.isPaused) {
                 playtimeSinceLastEventTimestamp = System.currentTimeMillis();

--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/tracker/NRVideoTracker.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/tracker/NRVideoTracker.java
@@ -55,7 +55,6 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
 
     // QOE_AGGREGATE provider fields
     private boolean qoeProviderRegistered = false;
-    private volatile Map<String, Object> pendingQoeForNextHarvest = null; // For CONTENT_END (volatile for thread safety)
     private Map<String, Object> lastSentQoeKpis = null; // Snapshot of last sent QoE KPIs for dirty check
     private volatile Map<String, Object> cachedStandardAttributes = null; // Cached attributes for thread-safe access
     private int qoeCycleCount = 0;   // per-session QoE harvest counter (reset at CONTENT_REQUEST)
@@ -143,8 +142,6 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
     public void dispose() {
         super.dispose();
         stopHeartbeat();
-        // Clean up pending QOE to prevent memory leaks
-        pendingQoeForNextHarvest = null;
         // Unregister the QOE provider so a disposed tracker is no longer polled at harvest.
         if (qoeProviderRegistered && NRVideo.getInstance() != null
                 && NRVideo.getInstance().getHarvestManager() != null) {
@@ -448,21 +445,23 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
                 }
                 totalAdPlaytime = totalAdPlaytime + totalPlaytime;
             } else {
-                // Build final QOE at CONTENT_END and mark for next harvest cycle
-                if (configuration != null && configuration.isQoeAggregateEnabled() && qoeProviderRegistered) {
-                    // Build final QOE with complete metrics
-                    Map<String, Object> finalQoe = buildQoeEventWithStandardAttributes();
-
-                    // Mark as final QOE so HarvestManager knows to unregister provider
-                    finalQoe.put("isFinalQoe", true);
-
-                    // Store for next harvest cycle (will be sent with priority)
-                    pendingQoeForNextHarvest = finalQoe;
-
-                    NRLog.d("Final QOE_AGGREGATE prepared at CONTENT_END, will send on next harvest cycle");
-                }
-
+                // Send CONTENT_END first, then build the final QoE and record it straight into
+                // the crash-safe buffer. Survives a crash before the next harvest and drops the
+                // pending / isFinalQoe machinery.
                 sendVideoEvent(CONTENT_END);
+
+                if (configuration != null && configuration.isQoeAggregateEnabled() && qoeProviderRegistered) {
+                    Map<String, Object> finalQoe = buildQoeEventWithStandardAttributes();
+                    NRVideo.recordEvent(NR_VIDEO_EVENT, finalQoe);
+
+                    // Unregister now so no further periodic QoE fires for this ended session;
+                    // a new view re-registers at its next CONTENT_REQUEST.
+                    if (NRVideo.getInstance() != null && NRVideo.getInstance().getHarvestManager() != null) {
+                        NRVideo.getInstance().getHarvestManager().unregisterQoeProvider(this);
+                    }
+                    qoeProviderRegistered = false;
+                    NRLog.d("Final QOE_AGGREGATE recorded to crash-safe buffer at CONTENT_END");
+                }
             }
 
             stopHeartbeat();
@@ -473,7 +472,7 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
             playtimeSinceLastEvent = 0L;
             totalPlaytime = 0L;
             // Reset QoE state for new view session (aggregator KPIs + tracker-side dirty-check
-            // snapshot). pendingQoeForNextHarvest is intentionally NOT cleared here.
+            // snapshot). The final QoE was already recorded to the buffer above.
             qoeAggregator.reset();
             lastSentQoeKpis = null;
         }
@@ -599,15 +598,8 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
      */
     @Override
     public Map<String, Object> generateQoeIfNeeded(List<Map<String, Object>> batch, int harvestCycleNumber) {
-        // Priority 1: Check if there's a pending final QOE from CONTENT_END
-        if (pendingQoeForNextHarvest != null) {
-            Map<String, Object> finalQoe = pendingQoeForNextHarvest;
-            pendingQoeForNextHarvest = null; // Clear after retrieving
-            NRLog.d("Sending pending final QOE_AGGREGATE from CONTENT_END");
-            return finalQoe; // HarvestManager will see "isFinalQoe" flag and unregister provider
-        }
-
-        // Priority 2: Generate regular harvest QOE if conditions are met
+        // Periodic harvest QOE only. The final QoE at CONTENT_END is recorded directly to the
+        // crash-safe buffer by sendEnd(), not routed through this provider.
         if (!state.isAd && configuration != null && configuration.isQoeAggregateEnabled()) {
             // Check if this harvest cycle should send based on interval multiplier
             int intervalMultiplier = configuration.getQoeAggregateIntervalMultiplier();

--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/tracker/NRVideoTracker.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/tracker/NRVideoTracker.java
@@ -58,6 +58,7 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
     private volatile Map<String, Object> pendingQoeForNextHarvest = null; // For CONTENT_END (volatile for thread safety)
     private Map<String, Object> lastSentQoeKpis = null; // Snapshot of last sent QoE KPIs for dirty check
     private volatile Map<String, Object> cachedStandardAttributes = null; // Cached attributes for thread-safe access
+    private int qoeCycleCount = 0;   // per-session QoE harvest counter (reset at CONTENT_REQUEST)
 
     /**
      * Create a new NRVideoTracker.
@@ -349,7 +350,7 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
                         NRLog.d("QOE provider registered at CONTENT_REQUEST");
                     }
                 }
-
+                qoeCycleCount = 0;   // reset cadence for the new view
                 sendVideoEvent(CONTENT_REQUEST);
             }
         }
@@ -611,12 +612,14 @@ public class NRVideoTracker extends NRTracker implements QoeProvider {
             // Check if this harvest cycle should send based on interval multiplier
             int intervalMultiplier = configuration.getQoeAggregateIntervalMultiplier();
 
-            // Formula matches iOS: (harvestCycleNumber - 1) % multiplier == 0
-            // Examples:
-            //   multiplier=1: cycles 1,2,3,4... (every harvest)
-            //   multiplier=2: cycles 1,3,5,7... (every other)
-            //   multiplier=3: cycles 1,4,7,10... (every third)
-            boolean shouldSend = (harvestCycleNumber - 1) % intervalMultiplier == 0;
+            // Per-session cadence: gate on this tracker's own poll count (reset at
+            // CONTENT_REQUEST), so the first periodic QoE fires on the session's first harvest
+            // regardless of global harvest parity.
+            //   multiplier=1: 1,2,3,4... (every harvest)
+            //   multiplier=2: 1,3,5,7... (every other)
+            //   multiplier=3: 1,4,7,10... (every third)
+            qoeCycleCount++;
+            boolean shouldSend = (qoeCycleCount - 1) % intervalMultiplier == 0;
 
             if (shouldSend) {
                 // Calculate current QoE KPIs from the aggregator

--- a/NewRelicVideoCore/src/test/java/com/newrelic/videoagent/core/qoe/NRQoEAggregatorTest.java
+++ b/NewRelicVideoCore/src/test/java/com/newrelic/videoagent/core/qoe/NRQoEAggregatorTest.java
@@ -208,16 +208,37 @@ public class NRQoEAggregatorTest {
         assertTrue((Boolean) k.get("hadPlaybackError"));
     }
 
-    // ---- pause time (time-based, tolerance) --------------------------------
+    // ---- pause time (banks the event's timeSincePaused) ---------
 
     @Test
-    public void pauseTime_banksOnResume() {
+    public void pauseTime_banksTimeSincePaused() {
         request();
         feed(CONTENT_START, attrs("timeSinceRequested", 0L));
         feed(CONTENT_PAUSE, attrs());
-        sleep(SLEEP_MS);
-        feed(CONTENT_RESUME, attrs());
-        assertTrue(lng(kpis(), "totalPauseTime") >= MIN_ELAPSED);
+        feed(CONTENT_RESUME, attrs("timeSincePaused", 5000L));
+        // Banked from the event attribute (deterministic), not a wall-clock delta.
+        assertEquals(5000L, lng(kpis(), "totalPauseTime"));
+    }
+
+    @Test
+    public void pauseTime_accumulatesAcrossPauses() {
+        request();
+        feed(CONTENT_START, attrs("timeSinceRequested", 0L));
+        feed(CONTENT_PAUSE, attrs());
+        feed(CONTENT_RESUME, attrs("timeSincePaused", 5000L));
+        feed(CONTENT_PAUSE, attrs());
+        feed(CONTENT_RESUME, attrs("timeSincePaused", 3000L));
+        assertEquals(8000L, lng(kpis(), "totalPauseTime"));
+    }
+
+    @Test
+    public void pauseTime_excludedDuringAdBreak() {
+        request();
+        feed(CONTENT_START, attrs("timeSinceRequested", 0L));
+        // adBreakActive = true -> the pause is the player pausing for an ad, not a user pause.
+        agg.processAction(CONTENT_PAUSE, attrs(), true, true);
+        agg.processAction(CONTENT_RESUME, attrs("timeSincePaused", 5000L), true, false);
+        assertEquals(0L, lng(kpis(), "totalPauseTime"));
     }
 
     @Test

--- a/NewRelicVideoCore/src/test/java/com/newrelic/videoagent/core/qoe/NRQoEAggregatorTest.java
+++ b/NewRelicVideoCore/src/test/java/com/newrelic/videoagent/core/qoe/NRQoEAggregatorTest.java
@@ -104,6 +104,16 @@ public class NRQoEAggregatorTest {
         assertEquals(4000L, lng(k, "avgDownloadRate"));
     }
 
+    @Test
+    public void downloadRate_dedupsConsecutiveIdenticalSamples() {
+        request();
+        feed(CONTENT_HEARTBEAT, attrs("contentNetworkDownloadBitrate", 1000L));
+        feed(CONTENT_HEARTBEAT, attrs("contentNetworkDownloadBitrate", 1000L)); // stale repeat -> skipped
+        feed(CONTENT_HEARTBEAT, attrs("contentNetworkDownloadBitrate", 3000L));
+        // (1000 + 3000) / 2 = 2000, not (1000 + 1000 + 3000) / 3
+        assertEquals(2000L, lng(kpis(), "avgDownloadRate"));
+    }
+
     // ---- peak bitrate ------------------------------------------------------
 
     @Test

--- a/NewRelicVideoCore/src/test/java/com/newrelic/videoagent/core/tracker/NRVideoTrackerQoeTest.java
+++ b/NewRelicVideoCore/src/test/java/com/newrelic/videoagent/core/tracker/NRVideoTrackerQoeTest.java
@@ -15,8 +15,8 @@ import static org.junit.Assert.*;
 /**
  * Unit tests for the QoE attributes added in qoeAggregateVersion 1.1.0:
  *   - avgDownloadRate / minDownloadRate / maxDownloadRate
- *   - totalSwitchUps / totalSwitchDowns / totalTimeSwitchedDown
- *   - totalPauseTime
+ *   - totalSwitchUps / totalSwitchDowns
+ *   - totalPauseTime (banks timeSincePaused; excludes ad-break pauses)
  *   - totalRenditions
  *
  * Strategy:
@@ -111,9 +111,8 @@ public class NRVideoTrackerQoeTest {
     }
 
     /**
-     * Drive a CONTENT_RENDITION_CHANGE carrying a rendition bitrate. The bitrate is what
-     * totalTimeSwitchedDown is anchored on (session-max); requires the tracker to be started
-     * so getAttributes() populates contentRenditionBitrate.
+     * Drive a CONTENT_RENDITION_CHANGE carrying a rendition bitrate; requires the tracker to be
+     * started so getAttributes() populates contentRenditionBitrate. Used to drive switch counts.
      */
     private void renditionChange(String shift, long bitrate) {
         tracker.renditionBitrate = bitrate;
@@ -139,7 +138,6 @@ public class NRVideoTrackerQoeTest {
 
         assertEquals(0L, lng(k, "totalSwitchUps"));
         assertEquals(0L, lng(k, "totalSwitchDowns"));
-        assertEquals(0L, lng(k, "totalTimeSwitchedDown"));
         assertEquals(0L, lng(k, "totalPauseTime"));
         assertEquals(0L, lng(k, "totalRenditions"));
 
@@ -229,74 +227,6 @@ public class NRVideoTrackerQoeTest {
         Map<String, Object> k = kpis();
         assertEquals(0L, lng(k, "totalSwitchUps"));
         assertEquals(0L, lng(k, "totalSwitchDowns"));
-        assertEquals(0L, lng(k, "totalTimeSwitchedDown"));
-    }
-
-    // =========================================================================
-    // totalTimeSwitchedDown
-    // =========================================================================
-
-    @Test
-    public void timeSwitchedDown_banksWhenRecoveringToPeak() {
-        startContent();
-
-        renditionChange("down", 5_000_000L);   // establishes session peak = 5M, no interval
-        renditionChange("down", 3_000_000L);   // below peak -> open interval
-        sleep(SLEEP_MS);
-        renditionChange("up",   5_000_000L);   // back to peak -> close, bank elapsed
-
-        long t = lng(kpis(), "totalTimeSwitchedDown");
-        assertTrue("below-peak time banked (was " + t + ")", t >= MIN_ELAPSED);
-    }
-
-    @Test
-    public void timeSwitchedDown_partialRecoveryStaysBelowPeak() {
-        // The defining session-max behavior: an upswitch that is still below the session
-        // peak must NOT close the interval (unlike the previous-rendition semantic).
-        startContent();
-
-        renditionChange("down", 5_000_000L);   // peak = 5M
-        renditionChange("down", 2_000_000L);   // open interval
-        sleep(SLEEP_MS);
-        renditionChange("up",   3_000_000L);   // 3M < 5M -> still below peak, interval stays OPEN
-
-        long v1 = lng(kpis(), "totalTimeSwitchedDown");
-        sleep(SLEEP_MS);
-        long v2 = lng(kpis(), "totalTimeSwitchedDown");
-        assertTrue("still counting below the session peak (" + v1 + " -> " + v2 + ")", v2 > v1);
-    }
-
-    @Test
-    public void timeSwitchedDown_consecutiveDownsKeepOneInterval() {
-        startContent();
-
-        renditionChange("down", 5_000_000L);   // peak = 5M
-        renditionChange("down", 3_000_000L);   // open interval
-        sleep(SLEEP_MS);
-        renditionChange("down", 2_000_000L);   // still below peak — interval start must NOT reset
-        sleep(SLEEP_MS);
-        renditionChange("up",   5_000_000L);   // recover to peak -> close
-
-        long t = lng(kpis(), "totalTimeSwitchedDown");
-        // One continuous interval spanning both sleeps.
-        assertTrue("continuous interval (was " + t + ")", t >= (2 * MIN_ELAPSED));
-    }
-
-    @Test
-    public void timeSwitchedDown_openIntervalSnapshotIsNonMutating() {
-        startContent();
-
-        renditionChange("down", 5_000_000L);   // peak = 5M
-        renditionChange("down", 3_000_000L);   // open, never recovered
-        sleep(SLEEP_MS);
-
-        long first = lng(kpis(), "totalTimeSwitchedDown");
-        assertTrue("open interval reflected at emit (was " + first + ")", first >= MIN_ELAPSED);
-
-        sleep(SLEEP_MS);
-        long second = lng(kpis(), "totalTimeSwitchedDown");
-        // Non-mutating snapshot: the interval is still open, so it keeps growing.
-        assertTrue("snapshot keeps growing (" + first + " -> " + second + ")", second > first);
     }
 
     // =========================================================================
@@ -387,11 +317,10 @@ public class NRVideoTrackerQoeTest {
         tracker.sendPause(); sleep(SLEEP_MS); tracker.sendResume();
         sleep(SLEEP_MS);
 
-        // Sanity: state accumulated (incl. an OPEN switched-down interval).
+        // Sanity: state accumulated.
         Map<String, Object> before = kpis();
         assertEquals(1L, lng(before, "totalSwitchUps"));
         assertEquals(1L, lng(before, "totalSwitchDowns"));
-        assertTrue(lng(before, "totalTimeSwitchedDown") > 0);
         assertTrue(lng(before, "totalPauseTime") > 0);
         assertTrue(lng(before, "totalRenditions") >= 1);
         assertTrue(before.containsKey("avgDownloadRate"));
@@ -410,7 +339,6 @@ public class NRVideoTrackerQoeTest {
         Map<String, Object> after = kpis();
         assertEquals(0L, lng(after, "totalSwitchUps"));
         assertEquals(0L, lng(after, "totalSwitchDowns"));
-        assertEquals(0L, lng(after, "totalTimeSwitchedDown"));
         assertEquals(0L, lng(after, "totalPauseTime"));
         assertEquals(0L, lng(after, "totalRenditions"));
         assertFalse("download rate cleared", after.containsKey("avgDownloadRate"));

--- a/NewRelicVideoCore/src/test/java/com/newrelic/videoagent/core/tracker/NRVideoTrackerQoeTest.java
+++ b/NewRelicVideoCore/src/test/java/com/newrelic/videoagent/core/tracker/NRVideoTrackerQoeTest.java
@@ -6,8 +6,12 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+
+import com.newrelic.videoagent.core.NRVideoConfiguration;
 
 import static com.newrelic.videoagent.core.NRDef.*;
 import static org.junit.Assert.*;
@@ -62,6 +66,9 @@ public class NRVideoTrackerQoeTest {
         Long renditionHeight;
         Long renditionBitrate;
         Long networkDownloadBitrate;
+
+        QoeTestTracker() { super(); }
+        QoeTestTracker(NRVideoConfiguration config) { super(config); }
 
         @Override public Long getRenditionWidth()        { return renditionWidth; }
         @Override public Long getRenditionHeight()       { return renditionHeight; }
@@ -299,6 +306,47 @@ public class NRVideoTrackerQoeTest {
         tracker.renditionWidth = 1280L; tracker.renditionHeight = 720L;  emitContentEvent(); // counted
 
         assertEquals(1L, lng(kpis(), "totalRenditions"));
+    }
+
+    // =========================================================================
+    // Per-session harvest cadence (qoeCycleCount), independent of global harvest number
+    // =========================================================================
+
+    /**
+     * The periodic-QoE gate must count this session's own polls (reset at CONTENT_REQUEST),
+     * NOT the global harvest number passed in. We use multiplier=2 and pass a constant global
+     * cycle (2) that the old global-parity formula {@code (harvestCycleNumber-1)%2} maps to
+     * "skip" forever — so if the gate still used it, nothing would ever emit.
+     */
+    @Test
+    public void cadence_gatesOnPerSessionPolls_notGlobalHarvestNumber() {
+        NRVideoConfiguration config = new NRVideoConfiguration.Builder("token")
+                .withQoeAggregateIntervalMultiplier(2)
+                .build();
+        QoeTestTracker t = new QoeTestTracker(config);
+        t.setPlayer(new Object());
+        t.sendRequest();   // CONTENT_REQUEST -> qoeCycleCount reset to 0, gate opened
+        t.sendStart();
+
+        final int GLOBAL = 2;                       // old formula: (2-1)%2==1 -> would never send
+        final List<Map<String, Object>> batch = new ArrayList<>();
+
+        // Session poll 1 -> emits (first poll always fires, regardless of global cycle).
+        t.networkDownloadBitrate = 1000L; t.sendVideoEvent(CONTENT_HEARTBEAT, null);
+        assertNotNull("session poll 1 must emit regardless of global harvest number",
+                t.generateQoeIfNeeded(batch, GLOBAL));
+
+        // Session poll 2 -> skipped by multiplier=2 (KPI still changed, so only cadence gates it).
+        t.networkDownloadBitrate = 2000L; t.sendVideoEvent(CONTENT_HEARTBEAT, null);
+        assertNull("session poll 2 skipped by multiplier",
+                t.generateQoeIfNeeded(batch, GLOBAL));
+
+        // Session poll 3 -> emits again.
+        t.networkDownloadBitrate = 3000L; t.sendVideoEvent(CONTENT_HEARTBEAT, null);
+        assertNotNull("session poll 3 emits",
+                t.generateQoeIfNeeded(batch, GLOBAL));
+
+        t.dispose();
     }
 
     // =========================================================================


### PR DESCRIPTION
## Changes

**1. Drive the bitrate timer from `isPlaying` transitions**
Replaces the 8 explicit `pause/resumeBitrateTimer()` call-sites with a single
`isPlaying`-transition check inside the aggregator, matching iOS. The time-weighted
`averageBitrate` now pauses/resumes exactly with playback state — one source of truth
instead of scattered sender wiring.

**2. Per-session harvest cadence (`qoeCycleCount`) instead of the global counter**
The periodic-QoE gate now counts each session's own polls (reset at `CONTENT_REQUEST`)
rather than the global `harvestCycleNumber`. Every session emits its first periodic QoE
on its first harvest regardless of global parity, and concurrent trackers no longer
cluster on the same cycles. Matches iOS `qoeCycleCount`.

**3. Final QoE recorded to the crash-safe buffer at `CONTENT_END`**
At `CONTENT_END` the final QoE is now `recordEvent`-ed straight into the crash-safe
buffer (like iOS), instead of being stashed in an in-memory `pendingQoeForNextHarvest`
field and injected next harvest. Gains crash durability and removes the
`isFinalQoe`/pending machinery. Also fixes a latent bug where a rapid end→start within
one harvest window could unregister the shared provider and drop the new view's periodic
QoE.