### PR TITLE
chore: trigger release-notes-docs-pr after release creation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   publish-release:
@@ -58,3 +59,12 @@ jobs:
             --title "$TAG_NAME" \
             --notes "$NOTES" \
             --target ${{ github.base_ref }}
+
+          echo "tag=${TAG_NAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Trigger Release Notes Docs PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run release-notes-docs-pr.yml --ref master --field tag=${{ steps.create_release.outputs.tag }} --field dry_run=false
+          echo "Triggered release-notes-docs-pr.yml for ${{ steps.create_release.outputs.tag }}"


### PR DESCRIPTION
## Summary

GitHub Actions does not fire downstream workflow triggers (like `release: published`) for events created by `GITHUB_TOKEN`. This means `release-notes-docs-pr.yml` never auto-fires after an automated release.

**Fix:** Add `actions: write` permission and explicitly dispatch `release-notes-docs-pr.yml` via `gh workflow run` after the GitHub release is created in `publish.yml`.

## Test plan

- [ ] Merge and trigger a release — verify `release-notes-docs-pr.yml` runs automatically
- [ ] Alternatively, manually create a release and confirm the docs PR workflow is triggered