### PR TITLE
Fix/content dropped frames fields

### DIFF
--- a/DATAMODEL.md
+++ b/DATAMODEL.md
@@ -92,6 +92,7 @@ An Attribute is a piece of data associated with an event. Attributes provide add
 | CONTENT_BUFFER_END       | Content video buffering ended.                                                                   |
 | CONTENT_HEARTBEAT        | Content video heartbeat, an event that happens once every 30 seconds while the video is playing. |
 | CONTENT_RENDITION_CHANGE | Content video stream quality changed.                                                            |
+| CONTENT_DROPPED_FRAMES   | ExoPlayer reported a batch of dropped video frames during content playback. Fired when the accumulated dropped frame count reaches the ExoPlayer threshold (default: 50 frames) or when playback stops. See [CONTENT_DROPPED_FRAMES attributes](#content_dropped_frames-and-ad_dropped_frames-attributes) below. |
 
 ### VideoAdAction
 
@@ -163,11 +164,71 @@ An Attribute is a piece of data associated with an event. Attributes provide add
 | AD_BUFFER_END       | Ad video buffering ended.                                                                   |
 | AD_HEARTBEAT        | Ad video heartbeat, an event that happens once every 30 seconds while the video is playing. |
 | AD_RENDITION_CHANGE | Ad video stream quality changed.                                                            |
+| AD_DROPPED_FRAMES   | ExoPlayer reported a batch of dropped video frames during ad playback. Same semantics as CONTENT_DROPPED_FRAMES. |
 | AD_BREAK_START      | Ad break (a block of ads) started.                                                          |
 | AD_BREAK_END        | Ad break ended.                                                                             |
 | AD_QUARTILE         | Ad quartile happened.                                                                       |
 | AD_CLICK            | Ad has been clicked.                                                                        |
 | AD_SKIP             | *(MediaTailor)* User skipped a skippable ad.           |
+
+---
+
+### CONTENT_DROPPED_FRAMES and AD_DROPPED_FRAMES attributes
+
+These events carry all standard VideoAction / VideoAdAction attributes plus the following dropped-frames-specific fields.
+
+ExoPlayer accumulates dropped frames internally and fires the callback when the accumulated count reaches its notification threshold (default: 50 frames via `DefaultRenderersFactory.MAX_DROPPED_VIDEO_FRAME_COUNT_TO_NOTIFY`) or when the renderer stops (pause, seek, end of stream). Each event is a **delta** — it reports frames dropped since the previous notification, not a cumulative session total.
+
+#### Always-present fields
+
+| Attribute Name      | Type   | Definition |
+| ------------------- | ------ | ---------- |
+| lostFrames          | int    | Number of frames dropped in this aggregation window. This is the sum of all ExoPlayer-reported drops across all callbacks merged into this event. |
+| lostFramesDuration  | int    | Sum of ExoPlayer's elapsed measurement windows (ms) across all callbacks in this event. This is ExoPlayer's own observation time — it is **not** `lostFrames / contentFps × 1000`. |
+| eventCount          | int    | Number of ExoPlayer `onDroppedVideoFrames` callbacks aggregated into this single event. `1` is the common case for healthy sessions with occasional bursts. |
+| contentFps          | double | Stream frame rate at the time of the event, in frames per second. |
+
+#### Fields present only when `eventCount > 1`
+
+These fields are absent when `eventCount = 1` because they would always be zero or identical to each other, providing no information.
+
+| Attribute Name                | Type | Definition |
+| ----------------------------- | ---- | ---------- |
+| firstDropTimestamp            | long | Agent wall-clock time (ms since epoch) when the first ExoPlayer callback arrived in this aggregation window. |
+| lastDropTimestamp             | long | Agent wall-clock time (ms since epoch) when the last ExoPlayer callback arrived in this aggregation window. |
+| actualAggregationDurationMs   | long | `lastDropTimestamp − firstDropTimestamp`. The actual elapsed time between the first and last ExoPlayer callback in this window. Use this as the denominator for drop rate when `eventCount > 1`. |
+
+#### Computing drop rate
+
+When `eventCount = 1`:
+```
+dropRate = lostFrames / (contentFps × lostFramesDuration / 1000)
+```
+
+When `eventCount > 1`:
+```
+dropRate = lostFrames / (contentFps × actualAggregationDurationMs / 1000)
+```
+
+A `dropRate` of 1.0 means all expected frames were dropped during the observation window.
+
+#### Example NRQL
+
+Total dropped frames per session (last hour):
+```sql
+SELECT SUM(lostFrames) FROM VideoAction
+WHERE actionName = 'CONTENT_DROPPED_FRAMES'
+FACET viewSession SINCE 1 hour ago
+```
+
+Sessions with sustained frame drops (multiple ExoPlayer callbacks aggregated):
+```sql
+SELECT viewSession, SUM(lostFrames), MAX(eventCount)
+FROM VideoAction WHERE actionName = 'CONTENT_DROPPED_FRAMES'
+AND eventCount > 1 SINCE 1 day ago
+```
+
+---
 
 ### VideoErrorAction
 

--- a/NRExoPlayerTracker/src/main/java/com/newrelic/videoagent/exoplayer/tracker/NRTrackerExoPlayer.java
+++ b/NRExoPlayerTracker/src/main/java/com/newrelic/videoagent/exoplayer/tracker/NRTrackerExoPlayer.java
@@ -25,11 +25,9 @@ import com.newrelic.videoagent.core.utils.NRLog;
 import com.newrelic.videoagent.exoplayer.BuildConfig;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -63,7 +61,6 @@ public class NRTrackerExoPlayer extends NRVideoTracker implements Player.Listene
     private static final int MAX_EVENTS_PER_AGGREGATE = 50;
     private volatile boolean droppedFrameAggregationEnabled = true;
 
-    private final ConcurrentHashMap<String, Object> lastTrackData = new ConcurrentHashMap<>();
     private final AtomicInteger totalLostFrames = new AtomicInteger(0);
     private final AtomicInteger totalLostFramesDuration = new AtomicInteger(0);
     private final AtomicInteger eventCount = new AtomicInteger(0);
@@ -497,7 +494,6 @@ public class NRTrackerExoPlayer extends NRVideoTracker implements Player.Listene
         } else {
             startNewAggregation(count, elapsed, currentTime);
         }
-        updateLastFrameDropSnapshot(count, elapsed, currentTime);
         scheduleDelayedFlush();
     }
     private void startNewAggregation(int count, int elapsed, long timestamp) {
@@ -513,16 +509,6 @@ public class NRTrackerExoPlayer extends NRVideoTracker implements Player.Listene
         totalLostFramesDuration.addAndGet(elapsed);
         eventCount.incrementAndGet();
         lastDropTimestamp.set(timestamp);
-    }
-    private void updateLastFrameDropSnapshot(int count, int elapsed, long timestamp) {
-        lastTrackData.put("lastFrameDropCount", count);
-        lastTrackData.put("lastFrameDropDuration", elapsed);
-        lastTrackData.put("lastFrameDropTime", timestamp);
-        lastTrackData.put("lastUpdateTime", System.currentTimeMillis());
-
-        lastTrackData.put("currentTotalFrames", totalLostFrames.get());
-        lastTrackData.put("currentTotalDuration", totalLostFramesDuration.get());
-        lastTrackData.put("currentEventCount", eventCount.get());
     }
     private boolean isAggregationExpired(long currentTime) {
         long firstTime = firstDropTimestamp.get();
@@ -559,10 +545,11 @@ public class NRTrackerExoPlayer extends NRVideoTracker implements Player.Listene
         eventAttributes.put("lostFrames", lostFrames);
         eventAttributes.put("lostFramesDuration", lostDuration);
         eventAttributes.put("eventCount", count);
-        eventAttributes.put("aggregationWindowMs", DEFAULT_AGGREGATION_WINDOW_MS);
-        eventAttributes.put("firstDropTimestamp", firstTime);
-        eventAttributes.put("lastDropTimestamp", lastTime);
-        eventAttributes.put("actualAggregationDurationMs", lastTime - firstTime);
+        if (count > 1) {
+            eventAttributes.put("firstDropTimestamp", firstTime);
+            eventAttributes.put("lastDropTimestamp", lastTime);
+            eventAttributes.put("actualAggregationDurationMs", lastTime - firstTime);
+        }
 
         if (getState().isAd) {
             sendVideoAdEvent("AD_DROPPED_FRAMES", eventAttributes);
@@ -584,7 +571,6 @@ public class NRTrackerExoPlayer extends NRVideoTracker implements Player.Listene
     }
 
     private void sendDroppedFrameImmediate(int count, int elapsed) {
-        // Original implementation for backward compatibility
         Map<String, Object> attr = new HashMap<>();
         attr.put("lostFrames", count);
         attr.put("lostFramesDuration", elapsed);
@@ -601,27 +587,6 @@ public class NRTrackerExoPlayer extends NRVideoTracker implements Player.Listene
             flushCurrentAggregation();
         }
         this.droppedFrameAggregationEnabled = enabled;
-    }
-    public ConcurrentHashMap<String, Object> getLastTrackData() {
-        return lastTrackData;
-    }
-    public Map<String, Object> getCurrentAggregationStatus() {
-        boolean hasAggregation = hasActiveAggregation.get();
-        int lostFrames = totalLostFrames.get();
-        int lostDuration = totalLostFramesDuration.get();
-        int count = eventCount.get();
-        long firstTime = firstDropTimestamp.get();
-        long lastTime = lastDropTimestamp.get();
-
-        Map<String, Object> status = new HashMap<>();
-        status.put("hasActiveAggregation", hasAggregation);
-        status.put("totalLostFrames", lostFrames);
-        status.put("totalLostFramesDuration", lostDuration);
-        status.put("eventCount", count);
-        status.put("firstDropTimestamp", firstTime);
-        status.put("lastDropTimestamp", lastTime);
-
-        return Collections.unmodifiableMap(status);
     }
     public boolean isDroppedFrameAggregationEnabled() {
         return droppedFrameAggregationEnabled;

--- a/NRExoPlayerTracker/src/test/java/com/newrelic/videoagent/exoplayer/tracker/MockNRTrackerExoPlayer.java
+++ b/NRExoPlayerTracker/src/test/java/com/newrelic/videoagent/exoplayer/tracker/MockNRTrackerExoPlayer.java
@@ -1,53 +1,38 @@
 package com.newrelic.videoagent.exoplayer.tracker;
 
+import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Test double for NRTrackerExoPlayer.
+ *
+ * Only intercepts event emission (sendVideoEvent / sendVideoAdEvent) and
+ * suppresses the Android Handler used for delayed flush scheduling.
+ * All aggregation logic runs from the real production implementation.
+ */
 public class MockNRTrackerExoPlayer extends NRTrackerExoPlayer {
 
     private boolean eventSent = false;
     private String lastEventType = null;
     private Map<String, Object> lastEventAttributes = null;
 
-    private long currentTimeMs = System.currentTimeMillis();
-    private final ConcurrentHashMap<String, Object> mockLastTrackData = new ConcurrentHashMap<>();
-    private final Map<String, Object> mockAggregationStatus = new ConcurrentHashMap<>();
-    private boolean mockAggregationEnabled = true;
-
-    public MockNRTrackerExoPlayer() {
-        super();
-        mockLastTrackData.put("lastFrameDropCount", 0);
-        mockLastTrackData.put("lastFrameDropDuration", 0);
-        mockLastTrackData.put("lastFrameDropTime", 0L);
-        mockLastTrackData.put("lastUpdateTime", System.currentTimeMillis());
-        mockLastTrackData.put("currentTotalFrames", 0);
-        mockLastTrackData.put("currentTotalDuration", 0);
-        mockLastTrackData.put("currentEventCount", 0);
-
-        mockAggregationStatus.put("hasActiveAggregation", false);
-        mockAggregationStatus.put("totalLostFrames", 0);
-        mockAggregationStatus.put("totalLostFramesDuration", 0);
-        mockAggregationStatus.put("eventCount", 0);
-        mockAggregationStatus.put("firstDropTimestamp", 0L);
-        mockAggregationStatus.put("lastDropTimestamp", 0L);
-    }
-
-    public void simulateTimeExpiry() {
-        this.currentTimeMs += 6000; // Beyond DEFAULT_AGGREGATION_WINDOW_MS (5000)
-        simulateFlush();
-    }
-
     @Override
     public void sendVideoEvent(String eventType, Map<String, Object> attributes) {
         this.eventSent = true;
         this.lastEventType = eventType;
-        this.lastEventAttributes = attributes != null ? new ConcurrentHashMap<>(attributes) : null;
+        this.lastEventAttributes = attributes != null ? new HashMap<>(attributes) : null;
     }
 
     @Override
     public void sendVideoAdEvent(String eventType, Map<String, Object> attributes) {
         this.eventSent = true;
         this.lastEventType = eventType;
-        this.lastEventAttributes = attributes != null ? new ConcurrentHashMap<>(attributes) : null;
+        this.lastEventAttributes = attributes != null ? new HashMap<>(attributes) : null;
+    }
+
+    @Override
+    protected void scheduleDelayedFlush() {
+        // Suppress Android Handler — tests call simulateFlush() explicitly.
     }
 
     public boolean wasEventSent() {
@@ -68,116 +53,8 @@ public class MockNRTrackerExoPlayer extends NRTrackerExoPlayer {
         lastEventAttributes = null;
     }
 
-    @Override
-    protected void scheduleDelayedFlush() {
-        // Bypass Android Handler for unit tests - use explicit flush calls instead
-    }
-
-    @Override
-    public void sendDroppedFrame(int count, int elapsed) {
-        long currentTime = System.currentTimeMillis();
-
-        mockLastTrackData.put("lastFrameDropCount", count);
-        mockLastTrackData.put("lastFrameDropDuration", elapsed);
-        mockLastTrackData.put("lastFrameDropTime", currentTime);
-        mockLastTrackData.put("lastUpdateTime", currentTime);
-
-        if (mockAggregationEnabled) {
-            boolean hasActive = (boolean) mockAggregationStatus.get("hasActiveAggregation");
-            int currentTotal = (int) mockAggregationStatus.get("totalLostFrames");
-            int currentDuration = (int) mockAggregationStatus.get("totalLostFramesDuration");
-            int eventCount = (int) mockAggregationStatus.get("eventCount");
-
-            if (!hasActive) {
-                // Start new aggregation
-                mockAggregationStatus.put("hasActiveAggregation", true);
-                mockAggregationStatus.put("totalLostFrames", count);
-                mockAggregationStatus.put("totalLostFramesDuration", elapsed);
-                mockAggregationStatus.put("eventCount", 1);
-                mockAggregationStatus.put("firstDropTimestamp", currentTime);
-                mockAggregationStatus.put("lastDropTimestamp", currentTime);
-            } else {
-                // Add to existing aggregation
-                int newEventCount = eventCount + 1;
-                mockAggregationStatus.put("totalLostFrames", currentTotal + count);
-                mockAggregationStatus.put("totalLostFramesDuration", currentDuration + elapsed);
-                mockAggregationStatus.put("eventCount", newEventCount);
-                mockAggregationStatus.put("lastDropTimestamp", currentTime);
-
-                if (newEventCount >= 50) {
-                    simulateFlush();
-                }
-            }
-            mockLastTrackData.put("currentTotalFrames", mockAggregationStatus.get("totalLostFrames"));
-            mockLastTrackData.put("currentTotalDuration", mockAggregationStatus.get("totalLostFramesDuration"));
-            mockLastTrackData.put("currentEventCount", mockAggregationStatus.get("eventCount"));
-        } else {
-            Map<String, Object> attributes = new ConcurrentHashMap<>();
-            attributes.put("lostFrames", count);
-            attributes.put("lostFramesDuration", elapsed);
-            sendVideoEvent("CONTENT_DROPPED_FRAMES", attributes);
-        }
-    }
-
-    public ConcurrentHashMap<String, Object> getLastTrackData() {
-        return mockLastTrackData;
-    }
-    public Map<String, Object> getCurrentAggregationStatus() {
-        return mockAggregationStatus;
-    }
-    @Override
-    public void setDroppedFrameAggregationEnabled(boolean enabled) {
-        if (!enabled && mockAggregationEnabled) {
-            // Flush current aggregation when disabling
-            simulateFlush();
-        }
-        this.mockAggregationEnabled = enabled;
-    }
-    @Override
-    public boolean isDroppedFrameAggregationEnabled() {
-        return mockAggregationEnabled;
-    }
-    public void resetAggregationState() {
-        // Reset aggregation state but preserve last track data
-        mockAggregationStatus.put("hasActiveAggregation", false);
-        mockAggregationStatus.put("totalLostFrames", 0);
-        mockAggregationStatus.put("totalLostFramesDuration", 0);
-        mockAggregationStatus.put("eventCount", 0);
-        mockAggregationStatus.put("firstDropTimestamp", 0L);
-        mockAggregationStatus.put("lastDropTimestamp", 0L);
-
-        // Reset event capture state - only clear if no event was just sent
-        // This is needed for external resets, not after flushing
-        eventSent = false;
-        lastEventType = null;
-        lastEventAttributes = null;
-    }
+    /** Force-flush the current aggregation window without waiting for the 5-second timer. */
     public void simulateFlush() {
-        boolean hasActive = (boolean) mockAggregationStatus.get("hasActiveAggregation");
-        if (hasActive) {
-            Map<String, Object> attributes = new ConcurrentHashMap<>();
-            attributes.put("lostFrames", mockAggregationStatus.get("totalLostFrames"));
-            attributes.put("lostFramesDuration", mockAggregationStatus.get("totalLostFramesDuration"));
-            attributes.put("eventCount", mockAggregationStatus.get("eventCount"));
-            attributes.put("aggregationWindowMs", 5000L); // DEFAULT_AGGREGATION_WINDOW_MS
-            attributes.put("firstDropTimestamp", mockAggregationStatus.get("firstDropTimestamp"));
-            attributes.put("lastDropTimestamp", mockAggregationStatus.get("lastDropTimestamp"));
-
-            long firstTime = (long) mockAggregationStatus.get("firstDropTimestamp");
-            long lastTime = (long) mockAggregationStatus.get("lastDropTimestamp");
-            attributes.put("actualAggregationDurationMs", lastTime - firstTime);
-
-            sendVideoEvent("CONTENT_DROPPED_FRAMES", attributes);
-            resetAggregationAfterFlush();
-        }
-    }
-    private void resetAggregationAfterFlush() {
-        mockAggregationStatus.put("hasActiveAggregation", false);
-        mockAggregationStatus.put("totalLostFrames", 0);
-        mockAggregationStatus.put("totalLostFramesDuration", 0);
-        mockAggregationStatus.put("eventCount", 0);
-        mockAggregationStatus.put("firstDropTimestamp", 0L);
-        mockAggregationStatus.put("lastDropTimestamp", 0L);
-        // DON'T reset eventSent flag here - we want to preserve it after flushing
+        flushCurrentAggregation();
     }
 }

--- a/NRExoPlayerTracker/src/test/java/com/newrelic/videoagent/exoplayer/tracker/NRTrackerExoPlayerFrameDropAggregationTest.java
+++ b/NRExoPlayerTracker/src/test/java/com/newrelic/videoagent/exoplayer/tracker/NRTrackerExoPlayerFrameDropAggregationTest.java
@@ -14,17 +14,6 @@ import org.robolectric.RuntimeEnvironment;
 
 import java.util.Map;
 
-/**
- * Comprehensive unit tests for NRTrackerExoPlayer frame drop aggregation functionality.
- *
- * This test class covers:
- * - Core aggregation logic (single/multiple frame drops)
- * - "Last track always" pattern verification
- * - Configuration management (enable/disable aggregation)
- * - Event attributes validation
- * - State management and reset functionality
- * - Data consistency verification
- */
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = 28, manifest = Config.NONE)
 public class NRTrackerExoPlayerFrameDropAggregationTest {
@@ -35,218 +24,184 @@ public class NRTrackerExoPlayerFrameDropAggregationTest {
     public void setUp() {
         Context context = RuntimeEnvironment.getApplication();
         ExoPlayer realPlayer = new ExoPlayer.Builder(context).build();
-
         tracker = new MockNRTrackerExoPlayer();
         tracker.setPlayer(realPlayer);
-        tracker.setDroppedFrameAggregationEnabled(true);
+        // Clear TRACKER_READY / PLAYER_READY events fired during setup
+        tracker.clearEvents();
+    }
+
+    // -------------------------------------------------------------------------
+    // Single-event payload shape (eventCount=1)
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void singleEvent_payloadContainsCoreFields() {
+        tracker.sendDroppedFrame(50, 1800);
+        tracker.simulateFlush();
+
+        Map<String, Object> attrs = tracker.getLastEventAttributes();
+        assertNotNull("Event should have been emitted", attrs);
+        assertEquals("lostFrames should match", 50, attrs.get("lostFrames"));
+        assertEquals("lostFramesDuration should match", 1800, attrs.get("lostFramesDuration"));
+        assertEquals("eventCount should be 1", 1, attrs.get("eventCount"));
     }
 
     @Test
-    public void testSingleFrameDropEvent() {
-        tracker.sendDroppedFrame(5, 100);
+    public void singleEvent_timingFieldsAbsent() {
+        tracker.sendDroppedFrame(50, 1800);
+        tracker.simulateFlush();
 
-        Map<String, Object> lastTrackData = tracker.getLastTrackData();
-
-        assertEquals("Last frame drop count should match", 5, lastTrackData.get("lastFrameDropCount"));
-        assertEquals("Last frame drop duration should match", 100, lastTrackData.get("lastFrameDropDuration"));
-        assertNotNull("Last frame drop time should be set", lastTrackData.get("lastFrameDropTime"));
-        assertNotNull("Last update time should be set", lastTrackData.get("lastUpdateTime"));
-
-        // Verify aggregation state
-        assertEquals("Current total frames should match", 5, lastTrackData.get("currentTotalFrames"));
-        assertEquals("Current total duration should match", 100, lastTrackData.get("currentTotalDuration"));
-        assertEquals("Current event count should be 1", 1, lastTrackData.get("currentEventCount"));
+        Map<String, Object> attrs = tracker.getLastEventAttributes();
+        assertNull("firstDropTimestamp must be absent when eventCount=1", attrs.get("firstDropTimestamp"));
+        assertNull("lastDropTimestamp must be absent when eventCount=1", attrs.get("lastDropTimestamp"));
+        assertNull("actualAggregationDurationMs must be absent when eventCount=1", attrs.get("actualAggregationDurationMs"));
     }
 
     @Test
-    public void testMultipleFrameDropAggregation() {
+    public void singleEvent_aggregationWindowMsNeverPresent() {
+        tracker.sendDroppedFrame(50, 1800);
+        tracker.simulateFlush();
+
+        assertNull("aggregationWindowMs must never appear in the event",
+                tracker.getLastEventAttributes().get("aggregationWindowMs"));
+    }
+
+    // -------------------------------------------------------------------------
+    // Multi-event payload shape (eventCount > 1)
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void multipleEvents_framesAndDurationAreSummed() {
         tracker.sendDroppedFrame(5, 100);
         tracker.sendDroppedFrame(3, 50);
         tracker.sendDroppedFrame(2, 25);
+        tracker.simulateFlush();
 
-        Map<String, Object> status = tracker.getCurrentAggregationStatus();
-
-        assertEquals("Should have active aggregation", true, status.get("hasActiveAggregation"));
-        assertEquals("Total frames should be sum", 10, status.get("totalLostFrames")); // 5+3+2
-        assertEquals("Total duration should be sum", 175, status.get("totalLostFramesDuration")); // 100+50+25
-        assertEquals("Event count should be 3", 3, status.get("eventCount"));
-
-        Map<String, Object> lastTrack = tracker.getLastTrackData();
-        assertEquals("Last event count should be latest", 2, lastTrack.get("lastFrameDropCount"));
-        assertEquals("Last event duration should be latest", 25, lastTrack.get("lastFrameDropDuration"));
-        assertEquals("Aggregated total should be maintained", 10, lastTrack.get("currentTotalFrames"));
+        Map<String, Object> attrs = tracker.getLastEventAttributes();
+        assertEquals("lostFrames should be sum of all callbacks", 10, attrs.get("lostFrames"));
+        assertEquals("lostFramesDuration should be sum of all elapsed windows", 175, attrs.get("lostFramesDuration"));
+        assertEquals("eventCount should be 3", 3, attrs.get("eventCount"));
     }
 
     @Test
-    public void testAggregationWindowExpiry() throws InterruptedException {
-        tracker.sendDroppedFrame(5, 100);
-        tracker.simulateTimeExpiry();
-        tracker.sendDroppedFrame(3, 50);
-
-        Map<String, Object> status = tracker.getCurrentAggregationStatus();
-        assertEquals("Should start new aggregation window", 3, status.get("totalLostFrames"));
-        assertEquals("Event count should reset to 1", 1, status.get("eventCount"));
-
-        assertTrue("Should have sent aggregated event", tracker.wasEventSent());
-        assertEquals("Should send content dropped frames event", "CONTENT_DROPPED_FRAMES", tracker.getLastEventType());
-
-        Map<String, Object> eventAttrs = tracker.getLastEventAttributes();
-        assertEquals("Event should contain aggregated frames", 5, eventAttrs.get("lostFrames"));
-        assertEquals("Event should contain aggregated duration", 100, eventAttrs.get("lostFramesDuration"));
-        assertEquals("Event should contain event count", 1, eventAttrs.get("eventCount"));
-    }
-
-    @Test
-    public void testMaxEventsFlushTrigger() {
-        for (int i = 0; i < 50; i++) { // MAX_EVENTS_PER_AGGREGATE = 50
-            tracker.sendDroppedFrame(1, 10);
-        }
-
-        assertTrue("Should flush when max events reached", tracker.wasEventSent());
-
-        tracker.clearEvents();
-        tracker.sendDroppedFrame(2, 20);
-
-        Map<String, Object> status = tracker.getCurrentAggregationStatus();
-        assertEquals("Should start new window", 2, status.get("totalLostFrames"));
-        assertEquals("Event count should reset", 1, status.get("eventCount"));
-        assertFalse("Should not send immediate event in aggregation mode", tracker.wasEventSent());
-    }
-
-    @Test
-    public void testLastTrackAlwaysAccessible() {
-        tracker.sendDroppedFrame(10, 200);
-
-        Map<String, Object> data1 = tracker.getLastTrackData();
-        assertNotNull("Data should never be null", data1);
-        assertEquals("Should contain latest frame drop count", 10, data1.get("lastFrameDropCount"));
-
-        tracker.sendDroppedFrame(5, 100);
-
-        Map<String, Object> data2 = tracker.getLastTrackData();
-        assertEquals("Should update to latest frame drop", 5, data2.get("lastFrameDropCount"));
-        assertEquals("Should maintain aggregated total", 15, data2.get("currentTotalFrames"));
-        assertSame("Should return same underlying map instance", data1, data2);
-    }
-
-    @Test
-    public void testDataPreservationAcrossStates() {
-        tracker.sendDroppedFrame(7, 140);
-
-        Map<String, Object> beforeDisable = tracker.getLastTrackData();
-        assertEquals("Should have data before disable", 7, beforeDisable.get("lastFrameDropCount"));
-
-        tracker.setDroppedFrameAggregationEnabled(false);
-
-        Map<String, Object> afterDisable = tracker.getLastTrackData();
-        assertNotNull("Data should be preserved after disable", afterDisable);
-        assertEquals("Frame drop count should be preserved", 7, afterDisable.get("lastFrameDropCount"));
-
-        tracker.setDroppedFrameAggregationEnabled(true);
-
-        Map<String, Object> afterEnable = tracker.getLastTrackData();
-        assertEquals("Data should persist after re-enable", 7, afterEnable.get("lastFrameDropCount"));
-    }
-
-    @Test
-    public void testAggregationToggle() {
-        assertTrue("Aggregation should be enabled by default", tracker.isDroppedFrameAggregationEnabled());
-
-        tracker.sendDroppedFrame(5, 100);
-        tracker.setDroppedFrameAggregationEnabled(false);
-
-        assertTrue("Should flush pending events when disabled", tracker.wasEventSent());
-
-        tracker.clearEvents();
-        tracker.sendDroppedFrame(3, 50);
-
-        assertTrue("Should send immediate event when disabled", tracker.wasEventSent());
-
-        Map<String, Object> eventAttrs = tracker.getLastEventAttributes();
-        assertEquals("Should send individual frame count", 3, eventAttrs.get("lostFrames"));
-        assertEquals("Should send individual duration", 50, eventAttrs.get("lostFramesDuration"));
-        assertNull("Should not have eventCount in immediate mode", eventAttrs.get("eventCount"));
-    }
-
-    @Test
-    public void testAggregationReEnable() {
-        tracker.setDroppedFrameAggregationEnabled(false);
-        tracker.sendDroppedFrame(2, 40); // Immediate mode
-
-        tracker.clearEvents();
-        tracker.setDroppedFrameAggregationEnabled(true);
-
-        tracker.sendDroppedFrame(4, 80);
-        tracker.sendDroppedFrame(3, 60);
-
-        Map<String, Object> status = tracker.getCurrentAggregationStatus();
-        assertEquals("Should aggregate after re-enable", 7, status.get("totalLostFrames"));
-        assertEquals("Should count events after re-enable", 2, status.get("eventCount"));
-    }
-
-    @Test
-    public void testEventAttributesCompleteness() {
+    public void multipleEvents_timingFieldsPresent() {
         tracker.sendDroppedFrame(8, 160);
         tracker.sendDroppedFrame(4, 80);
         tracker.simulateFlush();
 
         Map<String, Object> attrs = tracker.getLastEventAttributes();
-
-        assertEquals("Should contain total lost frames", 12, attrs.get("lostFrames"));
-        assertEquals("Should contain total duration", 240, attrs.get("lostFramesDuration"));
-        assertEquals("Should contain event count", 2, attrs.get("eventCount"));
-        assertNotNull("Should contain aggregation window", attrs.get("aggregationWindowMs"));
-        assertNotNull("Should contain first drop timestamp", attrs.get("firstDropTimestamp"));
-        assertNotNull("Should contain last drop timestamp", attrs.get("lastDropTimestamp"));
-        assertNotNull("Should contain actual duration", attrs.get("actualAggregationDurationMs"));
+        assertNotNull("firstDropTimestamp must be present when eventCount > 1", attrs.get("firstDropTimestamp"));
+        assertNotNull("lastDropTimestamp must be present when eventCount > 1", attrs.get("lastDropTimestamp"));
+        assertNotNull("actualAggregationDurationMs must be present when eventCount > 1", attrs.get("actualAggregationDurationMs"));
     }
 
     @Test
-    public void testStateReset() {
-        tracker.sendDroppedFrame(10, 200);
-        tracker.sendDroppedFrame(5, 100);
-
-        Map<String, Object> status = tracker.getCurrentAggregationStatus();
-        assertEquals("Should have active aggregation", true, status.get("hasActiveAggregation"));
-        assertEquals("Should have aggregated frames", 15, status.get("totalLostFrames"));
-
-        tracker.resetAggregationState();
-
-        status = tracker.getCurrentAggregationStatus();
-        assertEquals("Should clear active aggregation", false, status.get("hasActiveAggregation"));
-        assertEquals("Should reset total frames", 0, status.get("totalLostFrames"));
-        assertEquals("Should reset event count", 0, status.get("eventCount"));
-        assertEquals("Should reset timestamps", 0L, status.get("firstDropTimestamp"));
-
-        Map<String, Object> lastTrack = tracker.getLastTrackData();
-        assertEquals("Should preserve last frame drop count", 5, lastTrack.get("lastFrameDropCount"));
-    }
-
-    @Test
-    public void testBasicConcurrentAccess() {
-        tracker.sendDroppedFrame(5, 100);
-
-        Map<String, Object> data = tracker.getLastTrackData();
-        assertNotNull("Data should always be accessible", data);
-
-        Map<String, Object> status = tracker.getCurrentAggregationStatus();
-        assertNotNull("Status should always be accessible", status);
-
-        assertEquals("Should maintain data consistency", 5, data.get("lastFrameDropCount"));
-        assertEquals("Should maintain status consistency", 5, status.get("totalLostFrames"));
-    }
-
-    @Test
-    public void testDataConsistency() {
+    public void multipleEvents_actualAggregationDurationMsIsNonNegative() {
         tracker.sendDroppedFrame(8, 160);
-        tracker.sendDroppedFrame(3, 60);
+        tracker.sendDroppedFrame(4, 80);
+        tracker.simulateFlush();
 
-        Map<String, Object> status = tracker.getCurrentAggregationStatus();
-        Map<String, Object> lastTrack = tracker.getLastTrackData();
-
-        assertEquals("Status should show total frames", 11, status.get("totalLostFrames"));
-        assertEquals("Last track should show current total", 11, lastTrack.get("currentTotalFrames"));
-        assertEquals("Last track should show latest individual event", 3, lastTrack.get("lastFrameDropCount"));
+        long duration = (long) tracker.getLastEventAttributes().get("actualAggregationDurationMs");
+        assertTrue("actualAggregationDurationMs must be >= 0", duration >= 0);
     }
 
+    @Test
+    public void multipleEvents_aggregationWindowMsStillAbsent() {
+        tracker.sendDroppedFrame(8, 160);
+        tracker.sendDroppedFrame(4, 80);
+        tracker.simulateFlush();
+
+        assertNull("aggregationWindowMs must never appear in the event",
+                tracker.getLastEventAttributes().get("aggregationWindowMs"));
+    }
+
+    // -------------------------------------------------------------------------
+    // Flush triggers
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void maxEventsThreshold_triggersFlushAtFiftyCallbacks() {
+        // Production checks isMaxEventsReached() before processing each call.
+        // 50 calls accumulate eventCount=50; the 51st call sees count>=50 and flushes.
+        for (int i = 0; i < 51; i++) {
+            tracker.sendDroppedFrame(1, 10);
+        }
+
+        assertTrue("Reaching MAX_EVENTS_PER_AGGREGATE should trigger an automatic flush",
+                tracker.wasEventSent());
+        assertEquals("CONTENT_DROPPED_FRAMES", tracker.getLastEventType());
+    }
+
+    @Test
+    public void afterMaxEventsFlush_nextCallbackStartsFreshWindow() {
+        for (int i = 0; i < 50; i++) {
+            tracker.sendDroppedFrame(1, 10);
+        }
+        tracker.clearEvents();
+
+        tracker.sendDroppedFrame(7, 70);
+        tracker.simulateFlush();
+
+        Map<String, Object> attrs = tracker.getLastEventAttributes();
+        assertEquals("New window should start fresh after flush", 7, attrs.get("lostFrames"));
+        assertEquals("eventCount should reset to 1", 1, attrs.get("eventCount"));
+    }
+
+    @Test
+    public void explicitFlush_emitsEventAndResetState() {
+        tracker.sendDroppedFrame(5, 100);
+        tracker.simulateFlush();
+
+        assertTrue(tracker.wasEventSent());
+        assertEquals("CONTENT_DROPPED_FRAMES", tracker.getLastEventType());
+
+        tracker.clearEvents();
+        tracker.simulateFlush();
+        assertFalse("Flush on empty window should not emit an event", tracker.wasEventSent());
+    }
+
+    // -------------------------------------------------------------------------
+    // Aggregation toggle
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void aggregationEnabled_byDefault() {
+        assertTrue(tracker.isDroppedFrameAggregationEnabled());
+    }
+
+    @Test
+    public void disablingAggregation_flushesPendingEvents() {
+        tracker.sendDroppedFrame(5, 100);
+        tracker.setDroppedFrameAggregationEnabled(false);
+
+        assertTrue("Disabling aggregation should flush pending events", tracker.wasEventSent());
+    }
+
+    @Test
+    public void immediateMode_sendsEventPerCallback() {
+        tracker.setDroppedFrameAggregationEnabled(false);
+        tracker.sendDroppedFrame(3, 50);
+
+        assertTrue(tracker.wasEventSent());
+        Map<String, Object> attrs = tracker.getLastEventAttributes();
+        assertEquals(3, attrs.get("lostFrames"));
+        assertEquals(50, attrs.get("lostFramesDuration"));
+        assertNull("eventCount must be absent in immediate mode", attrs.get("eventCount"));
+    }
+
+    @Test
+    public void reEnablingAggregation_aggregatesSubsequentEvents() {
+        tracker.setDroppedFrameAggregationEnabled(false);
+        tracker.sendDroppedFrame(2, 40);
+        tracker.clearEvents();
+
+        tracker.setDroppedFrameAggregationEnabled(true);
+        tracker.sendDroppedFrame(4, 80);
+        tracker.sendDroppedFrame(3, 60);
+        tracker.simulateFlush();
+
+        Map<String, Object> attrs = tracker.getLastEventAttributes();
+        assertEquals("Frames should be aggregated after re-enable", 7, attrs.get("lostFrames"));
+        assertEquals("eventCount should reflect two callbacks", 2, attrs.get("eventCount"));
+    }
 }

--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/tracker/NRTracker.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/tracker/NRTracker.java
@@ -183,7 +183,8 @@ public class NRTracker {
                 it.remove();
             }
         }
-        NRLog.d("SEND EVENT " + action + " , attr = " + attributes);
+        final Map<String, Object> finalAttrs = attributes;
+        NRLog.d(() -> "SEND EVENT " + action + " , attr = " + finalAttrs);
         if (preSend(action, attributes)) {
             attributes.put("actionName", action);
             NRVideo.recordEvent(eventType, attributes);

--- a/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/utils/NRLog.java
+++ b/NewRelicVideoCore/src/main/java/com/newrelic/videoagent/core/utils/NRLog.java
@@ -1,6 +1,7 @@
 package com.newrelic.videoagent.core.utils;
 
 import android.util.Log;
+import java.util.function.Supplier;
 
 /**
  * `NRLog` contains methods for logging.
@@ -17,6 +18,18 @@ public class NRLog {
     public static void d(String s) {
         if (logging) {
             Log.d(TAG, s);
+        }
+    }
+
+    /**
+     * Print debug message using a supplier — the string is only built if logging is enabled.
+     * Use this instead of d(String) when building the message is expensive (e.g. Map.toString()).
+     *
+     * @param supplier Message supplier.
+     */
+    public static void d(Supplier<String> supplier) {
+        if (logging) {
+            Log.d(TAG, supplier.get());
         }
     }
 

--- a/NewRelicVideoCore/src/test/java/com/newrelic/videoagent/core/utils/NRLogTest.java
+++ b/NewRelicVideoCore/src/test/java/com/newrelic/videoagent/core/utils/NRLogTest.java
@@ -154,7 +154,7 @@ public class NRLogTest {
     @Test
     public void testLogWithNullMessage() {
         NRLog.enable();
-        NRLog.d(null);
+        NRLog.d((String) null);
 
         assertEquals(1, ShadowLog.getLogs().size());
         assertNull(ShadowLog.getLogs().get(0).msg);

--- a/README.md
+++ b/README.md
@@ -459,13 +459,15 @@ NRVideo.recordCustomEvent(attrs, trackerId);
 ### `NRTrackerExoPlayer` (ExoPlayer Tracker)
 
 #### `tracker.setDroppedFrameAggregationEnabled(enabled)`
-Enable or disable dropped frame aggregation (5-second window, max 50 events).
+Enable or disable dropped frame aggregation (5-second sliding window, max 50 ExoPlayer callbacks per window). Enabled by default.
 
 ```java
 NRTrackerExoPlayer tracker =
         (NRTrackerExoPlayer) NewRelicVideoAgent.getInstance().getContentTracker(trackerId);
 tracker.setDroppedFrameAggregationEnabled(true);
 ```
+
+For a full description of `CONTENT_DROPPED_FRAMES` event fields and their semantics, see [DATAMODEL.md](DATAMODEL.md#content_dropped_frames-and-ad_dropped_frames-attributes).
 
 ### Example: Complete Integration
 
@@ -495,11 +497,6 @@ NRVideoPlayerConfiguration playerConfig =
         new NRVideoPlayerConfiguration("main-player", player, false, customAttrs);
 
 Integer trackerId = NRVideo.addPlayer(playerConfig);
-
-// Enable dropped frame tracking
-NRTrackerExoPlayer tracker =
-        (NRTrackerExoPlayer) NewRelicVideoAgent.getInstance().getContentTracker(trackerId);
-tracker.setDroppedFrameAggregationEnabled(true);
 
 // Cleanup
 @Override


### PR DESCRIPTION
## Summary

Fixes the `CONTENT_DROPPED_FRAMES` / `AD_DROPPED_FRAMES` field bugs and the underlying ANR reported against agent v3.0.2 ([issue #44](https://github.com/newrelic/video-agent-android/issues/44)). Full investigation and rationale: [CONTENT_DROPPED_FRAMES — Investigation & Fix Proposal](https://newrelic.atlassian.net/wiki/spaces/VERTSOL/pages/5879202043).

The 5-second aggregation window from PR #51 stays — it works and reduces event volume ~90% under sustained drops. This PR fixes what was wrong with it.

## What's fixed

- **`actualAggregationDurationMs` always `0`** for the common case (`eventCount=1`) — was reporting `firstDropTimestamp == lastDropTimestamp` as if meaningful. `firstDropTimestamp`/`lastDropTimestamp`/`actualAggregationDurationMs` are now only emitted when `eventCount > 1`.
- **`aggregationWindowMs` removed** — it was a hardcoded constant (`5000`) on every event, carrying zero per-session information.
- **ANR root cause fixed** — `NRTracker.sendEvent()` built a debug log string (`Map#toString()` on the full attributes map) on the main thread on *every* event, unconditionally, even with logging disabled. Now guarded via a lazy `NRLog.d(Supplier<String>)` overload — the string is only built if logging is actually on. This benefits all event types, not just dropped frames.
- **Dead code removed** — `lastTrackData` map and `getLastTrackData()`/`getCurrentAggregationStatus()` in `NRTrackerExoPlayer` were written on every callback but never read by any real caller.
- **Tests fixed** — `MockNRTrackerExoPlayer` previously reimplemented the aggregation logic from scratch, so tests validated the mock, not production code (this is how the `actualAggregationDurationMs=0` bug shipped unnoticed). It now delegates to the real `flushCurrentAggregation()`.
- **Docs added** — `DATAMODEL.md` now documents every `CONTENT_DROPPED_FRAMES`/`AD_DROPPED_FRAMES` field, including the eventCount-gated ones and the drop-rate formula; README trimmed to point there instead of duplicating.

## Files changed

| File | Change |
|---|---|
| `NRTrackerExoPlayer.java` | Remove dead `lastTrackData` tracking; gate timing fields on `eventCount > 1`; drop `aggregationWindowMs` |
| `MockNRTrackerExoPlayer.java` | Delegate to real aggregation logic instead of reimplementing it |
| `NRTrackerExoPlayerFrameDropAggregationTest.java` | Rewritten to match new payload shape, run against real production code |
| `NRTracker.java` | Lazy-build debug log string via `Supplier` |
| `NRLog.java` | Add `d(Supplier<String>)` overload |
| `NRLogTest.java` | Mechanical fix for now-ambiguous `d(null)` call |
| `DATAMODEL.md` | New `CONTENT_DROPPED_FRAMES`/`AD_DROPPED_FRAMES` field reference |
| `README.md` | Trim duplicated docs, point to `DATAMODEL.md` |

## Not changing

Aggregation window/flush logic, `eventCount`, `setDroppedFrameAggregationEnabled()` public API, event names — all kept as-is.

## Test plan

- [ ] `NRTrackerExoPlayerFrameDropAggregationTest` passes (`./gradlew :NRExoPlayerTracker:testDebugUnitTest`)
- [ ] `NRLogTest` passes (`./gradlew :NewRelicVideoCore:testDebugUnitTest`)
- [ ] Manual: single burst → `eventCount=1`, no timing fields, no `aggregationWindowMs`; two bursts within 5s → `eventCount=2`, timing fields present and non-zero
- [ ] Confirm no jank/ANR when firing events rapidly with logging disabled
