### PR TITLE
chore: align release notes and changelog format with docs template

### DIFF
--- a/.github/workflows/release-notes-docs-pr.yml
+++ b/.github/workflows/release-notes-docs-pr.yml
@@ -92,7 +92,11 @@ jobs:
           tag="${{ steps.release.outputs.tag }}"
           version="${tag#v}"
           releaseDate="${{ steps.release.outputs.releaseDate }}"
-          fileDate=$(date -u "+%y-%m-%d")
+          if [[ -n "${releaseDate}" ]]; then
+            fileDate="${releaseDate:2}"
+          else
+            fileDate=$(date -u "+%y-%m-%d")
+          fi
           releaseFile="${{ env.DOCS_FOLDER }}/${{ env.AGENT_FILE_PREFIX }}-${fileDate}.mdx"
           echo "version=${version}" >> "$GITHUB_OUTPUT"
           echo "releaseFile=${releaseFile}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release-notes-docs-pr.yml
+++ b/.github/workflows/release-notes-docs-pr.yml
@@ -31,6 +31,9 @@ jobs:
     name: Update public docs
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
       - name: Generate GitHub App token
         id: app-token
         uses: actions/create-github-app-token@v1
@@ -42,20 +45,24 @@ jobs:
 
       - name: Resolve release tag and body
         id: release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             tag="${{ github.event.inputs.tag }}"
           else
             tag="${{ github.event.release.tag_name }}"
           fi
-          body=$(gh release view "${tag}" --repo ${{ env.AGENT_REPO }} --json body --jq '.body')
           version="${tag#v}"
-          releaseDate=$(gh api "repos/${{ env.AGENT_REPO }}/contents/CHANGELOG.md" --jq '.content' | \
-            base64 -d | \
-            grep -m1 "^## \[${version}\]" | \
+          releaseDate=$(grep -m1 "^## \[${version}\]" CHANGELOG.md | \
             grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}')
+          body=$(awk -v ver="${version}" '
+            found && /^## +\[|^# / { exit }
+            found { print }
+            $0 ~ ("^## +\\[" ver "\\]") { found=1 }
+          ' CHANGELOG.md | sed -E 's/ *\(\[[0-9a-f]{6,40}\]\([^)]*\)\) *$//')
+          body=$(printf '%s' "${body}" | sed '/[^[:space:]]/,$!d' | sed -e :a -e '/^[[:space:]]*$/{$d;N;ba}')
+          if [[ -z "${body}" ]]; then
+            body="_No new features, improvements, or bug fixes for this release._"
+          fi
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
           echo "releaseDate=${releaseDate}" >> "$GITHUB_OUTPUT"
           echo "body<<RELEASE_BODY_EOF" >> "$GITHUB_OUTPUT"
@@ -97,11 +104,6 @@ jobs:
         env:
           RELEASE_BODY: ${{ steps.release.outputs.body }}
         run: |
-          processed=$(printf '%s\n' "${RELEASE_BODY}" | \
-            tr -d '\r' | \
-            awk 'BEGIN{s=1} /^## /{s=0} !s{print}' | \
-            sed "s/## What's Changed/## What's changed/g; s/## Full Changelog/## Full changelog/g" | \
-            awk '/^## Full changelog/{fc=1;next} fc && /^https?:\/\//{printf "[Full changelog](%s)\n\n",$0;fc=0;next} fc && NF==0{next} {fc=0;print}')
           echo "=== DRY RUN: MDX file that would be created ==="
           echo "File: ${{ steps.mdx.outputs.releaseFile }}"
           echo ""
@@ -114,7 +116,7 @@ jobs:
           printf '%s\n' 'category: ${{ env.AGENT_NAME }}'
           printf '%s\n' '---'
           printf '\n'
-          printf '%s\n' "${processed}"
+          printf '%s\n' "${RELEASE_BODY}"
 
       - name: Write release notes and open PR
         if: ${{ github.event.inputs.dry_run != 'true' }}
@@ -135,12 +137,6 @@ jobs:
             exit 0
           fi
 
-          processed=$(printf '%s\n' "${RELEASE_BODY}" | \
-            tr -d '\r' | \
-            awk 'BEGIN{s=1} /^## /{s=0} !s{print}' | \
-            sed "s/## What's Changed/## What's changed/g; s/## Full Changelog/## Full changelog/g" | \
-            awk '/^## Full changelog/{fc=1;next} fc && /^https?:\/\//{printf "[Full changelog](%s)\n\n",$0;fc=0;next} fc && NF==0{next} {fc=0;print}')
-
           {
             printf '%s\n' '---'
             printf '%s\n' 'subject: ${{ env.AGENT_SUBJECT }}'
@@ -151,7 +147,7 @@ jobs:
             printf '%s\n' 'category: ${{ env.AGENT_NAME }}'
             printf '%s\n' '---'
             printf '\n'
-            printf '%s\n' "${processed}"
+            printf '%s\n' "${RELEASE_BODY}"
           } > "${releaseFile}"
 
           git checkout -b "${branchName}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 ## [4.4.0](https://github.com/newrelic/video-agent-android/compare/v4.3.1...v4.4.0) (2026-08-04)
 
-### Features
+### New features
 
 * add JP region support ([e97c6ca](https://github.com/newrelic/video-agent-android/commit/e97c6caaac5ba1b261f8fa9812c8a262d49f09a4))
 
-### Bug Fixes
+### Bug fixes
 
 * Align totalPauseTime with iOS clock model; stop emitting totalTimeSwitchedDown ([924c7b9](https://github.com/newrelic/video-agent-android/commit/924c7b9ffcb5b65b5023bd7b41cf4515f964686b))
 * classify startup vs playback error by content-started (iOS parity) ([a6b3288](https://github.com/newrelic/video-agent-android/commit/a6b3288932f0ae60513ff58ca0214ae61b9432f2))


### PR DESCRIPTION
## Summary
- `release-notes-docs-pr.yml`: extracts a version's notes directly from `CHANGELOG.md` (stripping commit-hash links) instead of `gh release view`/`gh api` calls against GitHub's auto-generated release, with a fallback message when a version isn't found.
- Renames the v4.4.0 `CHANGELOG.md` entry's headings to the docs-template names (`Features`→`New features`, `Bug Fixes`→`Bug fixes`); bullet content unchanged.

This repo already sources its GitHub Release / release-PR notes from `CHANGELOG.md` directly (in `release.yml`/`publish.yml`/`beta-release.yml`/`beta-publish.yml`), so it doesn't need the `--generate-notes`→`CHANGELOG.md` change that the streaming-browser-agent repos needed (e.g. newrelic/video-html5-js#69). The section-heading generation there goes through a direct `conventional-changelog-cli` call that bypasses `.releaserc.json`, which is out of scope for this PR (flagged separately, not changed here).

## Test plan
- [ ] Run `release-notes-docs-pr.yml` with `dry_run: true` and confirm the printed MDX matches the CHANGELOG.md v4.4.0 entry