### PR TITLE
docs: add harvest cycle configuration documentation

### DIFF
--- a/DATAMODEL.md
+++ b/DATAMODEL.md
@@ -285,8 +285,6 @@ AND eventCount > 1 SINCE 1 day ago
 
 ### QOE_AGGREGATE
 
-> **Note:** QoE aggregate events are opt-in and must be explicitly enabled. Reporting frequency is configurable per integration.
-
 Quality of Experience aggregate attributes sent with `CONTENT_END` events.
 
 | Attribute | Type | Description |

--- a/DATAMODEL.md
+++ b/DATAMODEL.md
@@ -64,7 +64,7 @@ An Attribute is a piece of data associated with an event. Attributes provide add
 | contentFps               | Current FPS (Frames per second).                                                                                                                   |
 | isBackgroundEvent        | If the player is hidden by another window.                                                                                                         |
 | totalAdPlaytime          | Total time ad is played for this video session.                                                                                                    |
-| elapsedTime              | Time that has passed since the last event.                                                                                                         |
+| elapsedTime              | Active content watched between two consecutive heartbeats, in milliseconds.                                                                                                         |
 | bufferType               | When buffer starts, i.e., initial, seek, pause & connection.                                                                                       |
 | asn                      | Autonomous System Number: a unique number identifying a group of IP networks that serves the content to the end user.                              |
 | asnLatitude              | The latitude of the geographic center of the postal code where the Autonomous System Network is registered. This is not the end user's latitude.   |
@@ -74,6 +74,18 @@ An Attribute is a piece of data associated with an event. Attributes provide add
 | instrumentation.provider | Player/agent name.                                                                                                                                 |
 | instrumentation.name     | Name of the instrumentation collecting the data.                                                                                                   |
 | instrumentation.version  | Agent’s version.                                                                                                                                   |
+
+| timeSinceRequested       | Time (in milliseconds) since the video was requested.                                                                                              |
+| timeSinceStarted         | Time (in milliseconds) since the video started playing.                                                                                            |
+| timeSinceTrackerReady    | Time (in milliseconds) since the tracker was initialized (PLAYER_READY).                                                                           |
+| timeSinceLastHeartbeat   | Time (in milliseconds) since the last heartbeat event.                                                                                             |
+| timeSinceBufferBegin     | Time (in milliseconds) since the last buffer event began.                                                                                          |
+| timeSincePaused          | Time (in milliseconds) since the video was last paused.                                                                                            |
+| timeSinceLastError       | Time (in milliseconds) since the last content error occurred. Only included after an error has occurred.                                            |
+| numberOfVideos           | Number of videos played in this session.                                                                                                           |
+| numberOfErrors           | Number of errors occurred in this session.                                                                                                         |
+| trackerName              | Name of the tracker/agent.                                                                                                                         |
+| trackerVersion           | Version of the tracker/agent.                                                                                                                      |
 
 #### List of possible Video Actions
 
@@ -144,7 +156,7 @@ An Attribute is a piece of data associated with an event. Attributes provide add
 | asnLongitude             | The longitude of the geographic center of the postal code where the Autonomous System Network is registered. This is not the end user's longitude. |
 | asnOrganization          | The organization that owns the Autonomous System Number. Often an ISP, sometimes a private company or institution.                                 |
 | timestamp                | The time (date, hour, minute, second) at which the interaction occurred.                                                                           |
-| elapsedTime              | Time that has passed since the last event.                                                                                                         |
+| elapsedTime              | Active content watched between two consecutive heartbeats, in milliseconds.                                                                                                         |
 | instrumentation.provider | Player/agent name.                                                                                                                                 |
 | instrumentation.name     | Name of the instrumentation collecting the data.                                                                                                   |
 | instrumentation.version  | Agent’s version.                                                                                                                                   |
@@ -247,9 +259,8 @@ AND eventCount > 1 SINCE 1 day ago
 | viewId                   | Trackers will generate unique IDs for every new video iteration.                                                                                   |
 | contentId                | The ID of the video.                                                                                                                               |
 | contentTitle             | The title of the video.                                                                                                                            |
-| errorName                | Name of the error.                                                                                                                                 |
+| errorName                | Name of the error. *(verify — not confirmed across all platforms)*                                                                                                                                 |
 | errorCode                | Error code if it's known.                                                                                                                          |
-| backTrace                | Stack trace of the error.                                                                                                                          |
 | isBackgroundEvent        | If the player is hidden by another window.                                                                                                         |
 | contentSrc               | Content source URL.                                                                                                                                |
 | contentCdn               | Content CDN URL.                                                                                                                                   |
@@ -257,7 +268,7 @@ AND eventCount > 1 SINCE 1 day ago
 | asnLatitude              | The latitude of the geographic center of the postal code where the Autonomous System Network is registered. This is not the end user's latitude.   |
 | asnLongitude             | The longitude of the geographic center of the postal code where the Autonomous System Network is registered. This is not the end user's longitude. |
 | asnOrganization          | The organization that owns the Autonomous System Number. Often an ISP, sometimes a private company or institution.                                 |
-| elapsedTime              | Time that has passed since the last event.                                                                                                         |
+| elapsedTime              | Active content watched between two consecutive heartbeats, in milliseconds.                                                                                                         |
 | timestamp                | The time (date, hour, minute, second) at which the interaction occurred.                                                                           |
 | instrumentation.provider | Player/agent name.                                                                                                                                 |
 | instrumentation.name     | Name of the instrumentation collecting the data.                                                                                                   |
@@ -273,6 +284,8 @@ AND eventCount > 1 SINCE 1 day ago
 | CONTENT_ERROR | Content video error. |
 
 ### QOE_AGGREGATE
+
+> **Note:** QoE aggregate events are opt-in and must be explicitly enabled. Reporting frequency is configurable per integration.
 
 Quality of Experience aggregate attributes sent with `CONTENT_END` events.
 

--- a/DATAMODEL.md
+++ b/DATAMODEL.md
@@ -77,7 +77,7 @@ An Attribute is a piece of data associated with an event. Attributes provide add
 
 | timeSinceRequested       | Time (in milliseconds) since the video was requested.                                                                                              |
 | timeSinceStarted         | Time (in milliseconds) since the video started playing.                                                                                            |
-| timeSinceTrackerReady    | Time (in milliseconds) since the tracker was initialized (PLAYER_READY).                                                                           |
+| timeSinceTrackerReady    | Time (in milliseconds) since the tracker was initialized (TRACKER_READY).                                                                           |
 | timeSinceLastHeartbeat   | Time (in milliseconds) since the last heartbeat event.                                                                                             |
 | timeSinceBufferBegin     | Time (in milliseconds) since the last buffer event began.                                                                                          |
 | timeSincePaused          | Time (in milliseconds) since the video was last paused.                                                                                            |

--- a/DATAMODEL.md
+++ b/DATAMODEL.md
@@ -259,7 +259,7 @@ AND eventCount > 1 SINCE 1 day ago
 | viewId                   | Trackers will generate unique IDs for every new video iteration.                                                                                   |
 | contentId                | The ID of the video.                                                                                                                               |
 | contentTitle             | The title of the video.                                                                                                                            |
-| errorName                | Name of the error. *(verify — not confirmed across all platforms)*                                                                                                                                 |
+| errorMessage                | Message describing the error.                                                                                                                                                                               |
 | errorCode                | Error code if it's known.                                                                                                                          |
 | isBackgroundEvent        | If the player is hidden by another window.                                                                                                         |
 | contentSrc               | Content source URL.                                                                                                                                |

--- a/README.md
+++ b/README.md
@@ -395,7 +395,22 @@ Limits for custom attributes added to default mobile events:
 
 ### Live Stream Configuration
 
-For live streams, the agent automatically uses a shorter harvest cycle (30–60 seconds) for near-real-time data transmission. The `liveHarvestCycleSeconds` is configured internally based on content type.
+The agent uses a separate harvest interval for VOD and LIVE content:
+
+| Content Type | Default Interval | Range | Builder Method |
+| --- | --- | --- | --- |
+| VOD | 300s (Mobile) / 180s (TV) | 5–300s | `.withHarvestCycle(seconds)` |
+| LIVE | 30s (Mobile) / 10s (TV) | 1–60s | `.withLiveHarvestCycle(seconds)` |
+
+```java
+// Live stream — flush every 10 seconds on TV, 30s on Mobile (or override)
+NewRelicVideoAgent tracker = new NewRelicVideoAgent.Builder()
+    .withHarvestCycle(300)
+    .withLiveHarvestCycle(10)
+    .build();
+```
+
+> **Note:** Harvest intervals are immutable after `.build()`.
 
 ## API Reference
 


### PR DESCRIPTION
Adds `### Live Stream Configuration` section to README.md.

Part of [PRD: Harvest Cycle Configuration Documentation](https://newrelic.atlassian.net/wiki/spaces/VERTSOL/pages/5952111079/PRD+Harvest+Cycle+Configuration+Documentation).